### PR TITLE
cmdinput: Fix crtl typo

### DIFF
--- a/src/app/workspace/cmdinput/cmdinput.tsx
+++ b/src/app/workspace/cmdinput/cmdinput.tsx
@@ -168,7 +168,7 @@ class CmdInput extends React.Component<{}, {}> {
                         )}
                         {focusVal && (
                             <div onMouseDown={this.clickHistoryHint} className="cmd-btn hoverEffect">
-                                {historyShow ? "close (esc)" : "history (crtl-r)"}
+                                {historyShow ? "close (esc)" : "history (ctrl-r)"}
                             </div>
                         )}
                         <ExecIcon


### PR DESCRIPTION
The keycap for the Control key typically reads Ctrl.