### PR TITLE
Adjust the username regex - '_' character

### DIFF
--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -101,7 +101,7 @@ var SetVarScopes = []SetVarScope{
 }
 
 var hostNameRe = regexp.MustCompile("^[a-z][a-z0-9.-]*$")
-var userHostRe = regexp.MustCompile("^(sudo@)?([a-z][a-z0-9-]*)@([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$")
+var userHostRe = regexp.MustCompile("^(sudo@)?([a-z][a-z0-9-_]*)@([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$")
 var remoteAliasRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_-]*$")
 var genericNameRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_ .()<>,/\"'\\[\\]{}=+$@!*-]*$")
 var rendererRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_.:-]*$")


### PR DESCRIPTION
'_' character can appear in username - ex. in OS Login name assignment in GCP. Adjusted regex so that this is covered and such connections can be added.