### PR TITLE
Update `clear` so it no longer archives Running Commands

### DIFF
--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -1401,7 +1401,10 @@ func ArchiveScreenLines(ctx context.Context, screenId string) (*ModelUpdate, err
 			count := tx.GetInt(query, screenId)
 			fmt.Printf("** archive-screen-lines: wrote into screenupdate: %d\n", count)
 		}
-		query = `UPDATE line SET archived = 1 WHERE screenid = ? AND archived = 0`
+		query = `UPDATE line SET archived = 1
+		         WHERE line.archived = 0 AND line.screenid = ? AND NOT EXISTS (SELECT * FROM cmd c
+				 WHERE line.screenid = c.screenid AND line.lineid = c.lineid AND c.status IN ('running', 'detached')
+				 )`
 		tx.Exec(query, screenId)
 		return nil
 	})
@@ -1709,7 +1712,7 @@ const (
 	ScreenField_SelectedLine = "selectedline" // int
 	ScreenField_Focus        = "focustype"    // string
 	ScreenField_TabColor     = "tabcolor"     // string
-	ScreenField_TabIcon      = "tabicon"     // string
+	ScreenField_TabIcon      = "tabicon"      // string
 	ScreenField_PTerm        = "pterm"        // string
 	ScreenField_Name         = "name"         // string
 	ScreenField_ShareName    = "sharename"    // string

--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -1391,15 +1391,6 @@ func ArchiveScreenLines(ctx context.Context, screenId string) (*ModelUpdate, err
 		if !tx.Exists(query, screenId) {
 			return fmt.Errorf("screen does not exist")
 		}
-		if isWebShare(tx, screenId) {
-			query = `INSERT INTO screenupdate (screenid, lineid, updatetype, updatets)
-                     SELECT screenid, lineid, ?, ? FROM line WHERE screenid = ? AND archived = 0`
-			tx.Exec(query, UpdateType_LineDel, time.Now().UnixMilli(), screenId)
-			NotifyUpdateWriter()
-			query = `SELECT count(*) FROM line WHERE screenid = ? AND archived = 0`
-			count := tx.GetInt(query, screenId)
-			fmt.Printf("** archive-screen-lines: wrote into screenupdate: %d\n", count)
-		}
 		query = `UPDATE line SET archived = 1
 		         WHERE line.archived = 0 AND line.screenid = ? AND NOT EXISTS (SELECT * FROM cmd c
 				 WHERE line.screenid = c.screenid AND line.lineid = c.lineid AND c.status IN ('running', 'detached')

--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -1393,8 +1393,7 @@ func ArchiveScreenLines(ctx context.Context, screenId string) (*ModelUpdate, err
 		}
 		query = `UPDATE line SET archived = 1
 		         WHERE line.archived = 0 AND line.screenid = ? AND NOT EXISTS (SELECT * FROM cmd c
-				 WHERE line.screenid = c.screenid AND line.lineid = c.lineid AND c.status IN ('running', 'detached')
-				 )`
+				 WHERE line.screenid = c.screenid AND line.lineid = c.lineid AND c.status IN ('running', 'detached'))`
 		tx.Exec(query, screenId)
 		return nil
 	})

--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -1391,7 +1391,6 @@ func ArchiveScreenLines(ctx context.Context, screenId string) (*ModelUpdate, err
 		if !tx.Exists(query, screenId) {
 			return fmt.Errorf("screen does not exist")
 		}
-		fmt.Printf("** archive-screen-lines: %s\n", screenId)
 		if isWebShare(tx, screenId) {
 			query = `INSERT INTO screenupdate (screenid, lineid, updatetype, updatets)
                      SELECT screenid, lineid, ?, ? FROM line WHERE screenid = ? AND archived = 0`


### PR DESCRIPTION
As mentioned in issue #104, the `clear` command previously cleared all lines in the current tab regardless of if they are currently running.  This fixes that behavior by no longer allowing `clear` to archive commands that have a status of 'running' or 'detached'.

Note that this does not completely resolve #104 as there are a few remaining changes to be made:
- This fix does not fix the problem of archiving tabs with running commands
- This fix does not introduce the filter commands mentioned in that discussion