### PR TITLE
Add Waveterm Icon to Linux

### DIFF
--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -250,6 +250,7 @@ function createMainWindow(clientData) {
         minWidth: 800,
         minHeight: 600,
         transparent: true,
+        icon: "public/logos/wave-logo-dark.png",
         webPreferences: {
             preload: path.join(getAppBasePath(), DistDir, "preload.js"),
         },

--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -250,7 +250,7 @@ function createMainWindow(clientData) {
         minWidth: 800,
         minHeight: 600,
         transparent: true,
-        icon: "public/logos/wave-logo-dark.png",
+        icon: (unamePlatform == "linux") ? "public/logos/wave-logo-dark.png" : undefined,
         webPreferences: {
             preload: path.join(getAppBasePath(), DistDir, "preload.js"),
         },


### PR DESCRIPTION
Issue #97 brought up that the icon does not appear on linux.  This change provides the wave-logo-dark.png to the Electron Browser Window to fix that.