### PR TITLE
Fix Centering of TOS Text

### DIFF
--- a/src/app/common/modals/modals.less
+++ b/src/app/common/modals/modals.less
@@ -235,6 +235,11 @@
         }
 
         footer {
+            margin-top: 32px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+
             .button-wrapper {
                 display: flex;
                 flex-direction: row;


### PR DESCRIPTION
Fixes the TOS modal to center the text referring to the terms of service.  This is a partial fix to #121.