### PR TITLE
allow @ symbol in user for ssh connections

### DIFF
--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -103,8 +103,8 @@ var SetVarScopes = []SetVarScope{
 	{ScopeName: "remote", VarNames: []string{}},
 }
 
-var hostNameRe = regexp.MustCompile("^[a-z][a-z0-9.-]*$")
-var userHostRe = regexp.MustCompile("^(sudo@)?([a-z][a-z0-9._-]*)@([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$")
+var hostNameRe = regexp.MustCompile("^[a-z][a-z0-9-._@]*$")
+var userHostRe = regexp.MustCompile("^(sudo@)?([a-z][a-z0-9-._@]*)@([a-z0-9][a-z0-9-.]*)(?::([0-9]+))?$")
 var remoteAliasRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_-]*$")
 var genericNameRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_ .()<>,/\"'\\[\\]{}=+$@!*-]*$")
 var rendererRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_.:-]*$")

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -103,8 +103,7 @@ var SetVarScopes = []SetVarScope{
 	{ScopeName: "remote", VarNames: []string{}},
 }
 
-var hostNameRe = regexp.MustCompile("^[a-z][a-z0-9-._@]*$")
-var userHostRe = regexp.MustCompile("^(sudo@)?([a-z][a-z0-9-._@]*)@([a-z0-9][a-z0-9-.]*)(?::([0-9]+))?$")
+var userHostRe = regexp.MustCompile("^(sudo@)?([a-z][a-z0-9._@-]*)@([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$")
 var remoteAliasRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_-]*$")
 var genericNameRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_ .()<>,/\"'\\[\\]{}=+$@!*-]*$")
 var rendererRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_.:-]*$")


### PR DESCRIPTION
Issue #127 raised the issue that user in (user@host) was previously not allowed to contain @ symbols.  This change modifies the regex to allow it.

Note that this does not interfere with the previous sudo@ prefix since this can still be parsed separately.  As host is not allowed to contain an @ symbol, we allow any number of @ symbols as part of the user.
