### PR TITLE
fix ability to log into ssh with key and password

### DIFF
--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -986,7 +986,6 @@ func (msh *MShellProc) WaitAndSendPassword(pw string) {
 				isWaiting = msh.isWaitingForPassword_nolock()
 			}
 			isConnecting = msh.Status == StatusConnecting
-			fmt.Printf("\nstuck with status \"%s\"", msh.Status)
 		})
 		if !isConnecting {
 			break


### PR DESCRIPTION
Issue #128 centers around the ssh system being broken with the key+password option. This was introduce by a previous refactor to the password system. With this change, key+password is handled as a special case allowing both to work independently.