### PR TITLE
Fix "wterm" flexrows option

### DIFF
--- a/waveshell/pkg/packet/packet.go
+++ b/waveshell/pkg/packet/packet.go
@@ -676,6 +676,7 @@ type TermOpts struct {
 	Cols       int    `json:"cols"`
 	Term       string `json:"term"`
 	MaxPtySize int64  `json:"maxptysize,omitempty"`
+	FlexRows   bool   `json:"flexrows,omitempty"`
 }
 
 type RemoteFd struct {

--- a/wavesrv/pkg/cmdrunner/termopts.go
+++ b/wavesrv/pkg/cmdrunner/termopts.go
@@ -110,6 +110,7 @@ func GetUITermOpts(winSize *packet.WinSize, ptermStr string) (*packet.TermOpts, 
 	termOpts.MaxPtySize = base.BoundInt64(termOpts.MaxPtySize, shexec.MinMaxPtySize, shexec.MaxMaxPtySize)
 	termOpts.Cols = base.BoundInt(termOpts.Cols, shexec.MinTermCols, shexec.MaxTermCols)
 	termOpts.Rows = base.BoundInt(termOpts.Rows, shexec.MinTermRows, shexec.MaxTermRows)
+	termOpts.FlexRows = opts.RowsFlex
 	return termOpts, nil
 }
 
@@ -117,7 +118,7 @@ func convertTermOpts(pkto *packet.TermOpts) *sstore.TermOpts {
 	return &sstore.TermOpts{
 		Rows:       int64(pkto.Rows),
 		Cols:       int64(pkto.Cols),
-		FlexRows:   true,
+		FlexRows:   pkto.FlexRows,
 		MaxPtySize: pkto.MaxPtySize,
 	}
 }

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -1394,7 +1394,7 @@ func (msh *MShellProc) SendFileData(dataPk *packet.FileDataPacketType) error {
 }
 
 func makeTermOpts(runPk *packet.RunPacketType) sstore.TermOpts {
-	return sstore.TermOpts{Rows: int64(runPk.TermOpts.Rows), Cols: int64(runPk.TermOpts.Cols), FlexRows: true, MaxPtySize: DefaultMaxPtySize}
+	return sstore.TermOpts{Rows: int64(runPk.TermOpts.Rows), Cols: int64(runPk.TermOpts.Cols), FlexRows: runPk.TermOpts.FlexRows, MaxPtySize: DefaultMaxPtySize}
 }
 
 // returns (ok, currentPSC)


### PR DESCRIPTION
pass flexrows through to packet.TermOpts so it gets back to the FE correctly.  this fixes wterm overrides and github issue #116