### PR TITLE
Fixing linting errors in unused keygen function

### DIFF
--- a/wavesrv/pkg/keygen/keygen.go
+++ b/wavesrv/pkg/keygen/keygen.go
@@ -35,7 +35,7 @@ func CreateKeyPair(keyFileName string, certFileName string, id string) error {
 }
 
 // Creates a private key at keyFileName (ECDSA, secp384r1 (P-384)), PEM format
-func CreatePrivateKey() (*ecdsa.PrivateKey, error) {
+func CreatePrivateKey(keyFileName string) (*ecdsa.PrivateKey, error) {
 	curve := elliptic.P384() // secp384r1
 	privateKey, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {

--- a/wavesrv/pkg/keygen/keygen.go
+++ b/wavesrv/pkg/keygen/keygen.go
@@ -39,7 +39,7 @@ func CreatePrivateKey(keyFileName string) (*ecdsa.PrivateKey, error) {
 	curve := elliptic.P384() // secp384r1
 	privateKey, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("Error generating P-384 key err:%w", err)
+		return nil, fmt.Errorf("error generating P-384 key err:%w", err)
 	}
 	keyFile, err := os.Create(keyFileName)
 	if err != nil {
@@ -48,11 +48,11 @@ func CreatePrivateKey(keyFileName string) (*ecdsa.PrivateKey, error) {
 	defer keyFile.Close()
 	pkBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
 	if err != nil {
-		return nil, fmt.Errorf("Error MarshalPKCS8PrivateKey err:%w", err)
+		return nil, fmt.Errorf("error MarshalPKCS8PrivateKey err:%w", err)
 	}
 	paramsBytes, err := base64.StdEncoding.DecodeString(p384Params)
 	if err != nil {
-		return nil, fmt.Errorf("Error decoding bytes for P-384 EC PARAMETERS err:%w", err)
+		return nil, fmt.Errorf("error decoding bytes for P-384 EC PARAMETERS err:%w", err)
 	}
 	var pemParamsBlock = &pem.Block{
 		Type:  "EC PARAMETERS",
@@ -60,7 +60,7 @@ func CreatePrivateKey(keyFileName string) (*ecdsa.PrivateKey, error) {
 	}
 	err = pem.Encode(keyFile, pemParamsBlock)
 	if err != nil {
-		return nil, fmt.Errorf("Error writing EC PARAMETERS pem block err:%w", err)
+		return nil, fmt.Errorf("error writing EC PARAMETERS pem block err:%w", err)
 	}
 	var pemPrivateBlock = &pem.Block{
 		Type:  "EC PRIVATE KEY",

--- a/wavesrv/pkg/keygen/keygen.go
+++ b/wavesrv/pkg/keygen/keygen.go
@@ -68,7 +68,7 @@ func CreatePrivateKey(keyFileName string) (*ecdsa.PrivateKey, error) {
 	}
 	err = pem.Encode(keyFile, pemPrivateBlock)
 	if err != nil {
-		return nil, fmt.Errorf("Error writing EC PRIVATE KEY pem block err:%w", err)
+		return nil, fmt.Errorf("error writing EC PRIVATE KEY pem block err:%w", err)
 	}
 	return privateKey, nil
 }
@@ -77,15 +77,15 @@ func CreatePrivateKey(keyFileName string) (*ecdsa.PrivateKey, error) {
 func CreateCertificate(certFileName string, privateKey *ecdsa.PrivateKey, id string) error {
 	serialNumber, err := rand.Int(rand.Reader, big.NewInt(1000000000000))
 	if err != nil {
-		return fmt.Errorf("Cannot generate serial number err:%w", err)
+		return fmt.Errorf("cannot generate serial number err:%w", err)
 	}
 	notBefore, err := time.Parse("Jan 2 15:04:05 2006", "Jan 1 00:00:00 2020")
 	if err != nil {
-		return fmt.Errorf("Cannot Parse Date err:%w", err)
+		return fmt.Errorf("cannot Parse Date err:%w", err)
 	}
 	notAfter, err := time.Parse("Jan 2 15:04:05 2006", "Jan 1 00:00:00 2030")
 	if err != nil {
-		return fmt.Errorf("Cannot Parse Date err:%w", err)
+		return fmt.Errorf("cannot Parse Date err:%w", err)
 	}
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
@@ -100,16 +100,16 @@ func CreateCertificate(certFileName string, privateKey *ecdsa.PrivateKey, id str
 	}
 	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 	if err != nil {
-		return fmt.Errorf("Error running x509.CreateCertificate err:%v\n", err)
+		return fmt.Errorf("error running x509.CreateCertificate err:%v", err)
 	}
 	certFile, err := os.Create(certFileName)
 	if err != nil {
-		return fmt.Errorf("Error opening file:%s err:%w", certFileName, err)
+		return fmt.Errorf("error opening file:%s err:%w", certFileName, err)
 	}
 	defer certFile.Close()
 	err = pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
 	if err != nil {
-		return fmt.Errorf("Error writing CERTIFICATE pem block err:%w", err)
+		return fmt.Errorf("error writing CERTIFICATE pem block err:%w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
This is a typo fix for an unused function that was showing a linting error due to a missing parameter. It also fixes some warnings about error message formatting, such as no capitalized error messages and no trailing punctuation or whitespace.