### PR TITLE
On MacOS allow UserShell to override /bin/bash

### DIFF
--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -547,7 +547,7 @@ function runWaveSrv() {
         envCopy[WaveDevVarName] = "1";
     }
     console.log("trying to run local server", getWaveSrvPath());
-    let proc = child_process.spawn("/bin/bash", ["-c", getWaveSrvCmd()], {
+    let proc = child_process.spawn("bash", ["-c", getWaveSrvCmd()], {
         cwd: getWaveSrvCwd(),
         env: envCopy,
     });

--- a/waveshell/pkg/server/server.go
+++ b/waveshell/pkg/server/server.go
@@ -150,7 +150,7 @@ func runSingleCompGen(cwd string, compType string, prefix string) ([]string, boo
 		return nil, false, fmt.Errorf("invalid compgen type '%s'", compType)
 	}
 	compGenCmdStr := fmt.Sprintf("cd %s; compgen -A %s -- %s | sort | uniq | head -n %d", shellescape.Quote(cwd), shellescape.Quote(compType), shellescape.Quote(prefix), packet.MaxCompGenValues+1)
-	ecmd := exec.Command("bash", "-c", compGenCmdStr)
+	ecmd := exec.Command(shexec.GetLocalBashPath(), "-c", compGenCmdStr)
 	outputBytes, err := ecmd.Output()
 	if err != nil {
 		return nil, false, fmt.Errorf("compgen error: %w", err)

--- a/wavesrv/pkg/scbase/scbase.go
+++ b/wavesrv/pkg/scbase/scbase.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"os/user"
 	"path"
 	"regexp"
 	"runtime"
@@ -39,7 +38,6 @@ const WaveAppPathVarName = "WAVETERM_APP_PATH"
 const WaveVersion = "v0.5.1"
 const WaveAuthKeyFileName = "waveterm.authkey"
 const MShellVersion = "v0.3.0"
-const DefaultMacOSShell = "/bin/bash"
 
 var SessionDirCache = make(map[string]string)
 var ScreenDirCache = make(map[string]string)
@@ -378,31 +376,4 @@ func MacOSRelease() string {
 		osRelease = macOSRelease()
 	})
 	return osRelease
-}
-
-var userShellRegexp = regexp.MustCompile(`^UserShell: (.*)$`)
-
-// dscl . -read /User/[username] UserShell
-// defaults to /bin/bash
-func MacUserShell() string {
-	osUser, err := user.Current()
-	if err != nil {
-		log.Printf("error getting current user: %v\n", err)
-		return DefaultMacOSShell
-	}
-	ctx, cancelFn := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancelFn()
-	userStr := "/Users/" + osUser.Name
-	out, err := exec.CommandContext(ctx, "dscl", ".", "-read", userStr, "UserShell").CombinedOutput()
-	if err != nil {
-		log.Printf("error executing macos user shell lookup: %v %q\n", err, string(out))
-		return DefaultMacOSShell
-	}
-	outStr := strings.TrimSpace(string(out))
-	m := userShellRegexp.FindStringSubmatch(outStr)
-	if m == nil {
-		log.Printf("error in format of dscl output: %q\n", outStr)
-		return DefaultMacOSShell
-	}
-	return m[1]
 }


### PR DESCRIPTION
Fix for issue #132.  If the user overrides their login shell using chsh, Wave should respect that.  Currently that new shell must be a "bash" shell (we check that it contains the substr "bash").  But now when starting Wave, if you shell has been changed, e.g. /opt/homebrew/bin/bash, that will be respected locally.

Note that any shell changes will only be picked up after restarting Wave (as we cache the output of "dscl" command).