### PR TITLE
Packetparser Ignore Spurious Invalid Input at Beginning of Stream

### DIFF
--- a/waveshell/main-waveshell.go
+++ b/waveshell/main-waveshell.go
@@ -156,7 +156,7 @@ func readFullRunPacket(packetParser *packet.PacketParser) (*packet.RunPacketType
 }
 
 func handleSingle(fromServer bool) {
-	packetParser := packet.MakePacketParser(os.Stdin, false)
+	packetParser := packet.MakePacketParser(os.Stdin, nil)
 	sender := packet.MakePacketSender(os.Stdout, nil)
 	defer func() {
 		sender.Close()

--- a/waveshell/pkg/server/server.go
+++ b/waveshell/pkg/server/server.go
@@ -717,7 +717,7 @@ func RunServer() (int, error) {
 	if debug {
 		packet.GlobalDebug = true
 	}
-	server.MainInput = packet.MakePacketParser(os.Stdin, false)
+	server.MainInput = packet.MakePacketParser(os.Stdin, nil)
 	server.Sender = packet.MakePacketSender(os.Stdout, server.packetSenderErrorHandler)
 	defer server.Close()
 	var err error

--- a/waveshell/pkg/shexec/client.go
+++ b/waveshell/pkg/shexec/client.go
@@ -50,8 +50,8 @@ func MakeClientProc(ctx context.Context, ecmd *exec.Cmd) (*ClientProc, *packet.I
 		return nil, nil, fmt.Errorf("running local client: %w", err)
 	}
 	sender := packet.MakePacketSender(inputWriter, nil)
-	stdoutPacketParser := packet.MakePacketParser(stdoutReader, false)
-	stderrPacketParser := packet.MakePacketParser(stderrReader, false)
+	stdoutPacketParser := packet.MakePacketParser(stdoutReader, &packet.PacketParserOpts{IgnoreUntilValid: true})
+	stderrPacketParser := packet.MakePacketParser(stderrReader, nil)
 	packetParser := packet.CombinePacketParsers(stdoutPacketParser, stderrPacketParser, true)
 	cproc := &ClientProc{
 		Cmd:          ecmd,

--- a/waveshell/pkg/shexec/shexec.go
+++ b/waveshell/pkg/shexec/shexec.go
@@ -740,7 +740,7 @@ func RunInstallFromCmd(ctx context.Context, ecmd *exec.Cmd, tryDetect bool, mshe
 	if mshellStream != nil {
 		sendMShellBinary(inputWriter, mshellStream)
 	}
-	packetParser := packet.MakePacketParser(stdoutReader, false)
+	packetParser := packet.MakePacketParser(stdoutReader, nil)
 	err = ecmd.Start()
 	if err != nil {
 		return fmt.Errorf("running ssh command: %w", err)
@@ -873,8 +873,8 @@ func RunClientSSHCommandAndWait(runPacket *packet.RunPacketType, fdContext FdCon
 		return nil, fmt.Errorf("running ssh command: %w", err)
 	}
 	defer cmd.Close()
-	stdoutPacketParser := packet.MakePacketParser(stdoutReader, false)
-	stderrPacketParser := packet.MakePacketParser(stderrReader, false)
+	stdoutPacketParser := packet.MakePacketParser(stdoutReader, nil)
+	stderrPacketParser := packet.MakePacketParser(stderrReader, nil)
 	packetParser := packet.CombinePacketParsers(stdoutPacketParser, stderrPacketParser, false)
 	sender := packet.MakePacketSender(inputWriter, nil)
 	versionOk := false

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -43,6 +43,11 @@ const RemoteTermCols = 80
 const PtyReadBufSize = 100
 const RemoteConnectTimeout = 15 * time.Second
 
+// we add this ping packet to the MShellServer Commands in order to deal with spurious SSH output
+// basically we guarantee the parser will see a valid packet (either an init error or a ping)
+// so we can pass ignoreUntilValid to PacketParser
+const PrintPingPacket = `printf "\n##N{\"type\": \"ping\"}\n"`
+
 const MShellServerCommandFmt = `
 PATH=$PATH:~/.mshell;
 which mshell-[%VERSION%] > /dev/null;
@@ -50,6 +55,7 @@ if [[ "$?" -ne 0 ]]
 then
   printf "\n##N{\"type\": \"init\", \"notfound\": true, \"uname\": \"%s | %s\"}\n" "$(uname -s)" "$(uname -m)"
 else
+  [%PINGPACKET%]
   mshell-[%VERSION%] --server
 fi
 `
@@ -60,14 +66,16 @@ func MakeLocalMShellCommandStr(isSudo bool) (string, error) {
 		return "", err
 	}
 	if isSudo {
-		return fmt.Sprintf("sudo %s --server", mshellPath), nil
+		return fmt.Sprintf(`%s; sudo %s --server`, PrintPingPacket, mshellPath), nil
 	} else {
-		return fmt.Sprintf("%s --server", mshellPath), nil
+		return fmt.Sprintf(`%s; %s --server`, PrintPingPacket, mshellPath), nil
 	}
 }
 
 func MakeServerCommandStr() string {
-	return strings.ReplaceAll(MShellServerCommandFmt, "[%VERSION%]", semver.MajorMinor(scbase.MShellVersion))
+	rtn := strings.ReplaceAll(MShellServerCommandFmt, "[%VERSION%]", semver.MajorMinor(scbase.MShellVersion))
+	rtn = strings.ReplaceAll(rtn, "[%PINGPACKET%]", PrintPingPacket)
+	return rtn
 }
 
 const (


### PR DESCRIPTION
Possible fix for #99.  Add a flag to have the parser ignore spurious input that happens before seeing a real packet.  Normally that spurious input is converted in a RawPacket.  Those RawPackets cause connection errors (since the code on the other side is waiting for an InitPacket).  This flag will let the parser ignore input until it sees a valid packet.

We also need to force all of the paths that use this new flow to output a valid packet.  That's why I added the "ping" packets in the mshell commands.