### PR TITLE
Allow user to specify openAI baseURL

### DIFF
--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -3639,8 +3639,21 @@ func ClientSetCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (ss
 			return nil, fmt.Errorf("error updating client openai maxchoices: %v", err)
 		}
 	}
+	if aiBaseURL, found := pk.Kwargs["openaibaseurl"]; found {
+		aiOpts := clientData.OpenAIOpts
+		if aiOpts == nil {
+			aiOpts = &sstore.OpenAIOptsType{}
+			clientData.OpenAIOpts = aiOpts
+		}
+		aiOpts.BaseURL = aiBaseURL
+		varsUpdated = append(varsUpdated, "openaibaseurl")
+		err = sstore.UpdateClientOpenAIOpts(ctx, *aiOpts)
+		if err != nil {
+			return nil, fmt.Errorf("error updating client openai base url: %v", err)
+		}
+	}
 	if len(varsUpdated) == 0 {
-		return nil, fmt.Errorf("/client:set requires a value to set: %s", formatStrs([]string{"termfontsize", "openaiapitoken", "openaimodel", "openaimaxtokens", "openaimaxchoices"}, "or", false))
+		return nil, fmt.Errorf("/client:set requires a value to set: %s", formatStrs([]string{"termfontsize", "openaiapitoken", "openaimodel", "openaibaseurl", "openaimaxtokens", "openaimaxchoices"}, "or", false))
 	}
 	clientData, err = sstore.EnsureClientData(ctx)
 	if err != nil {

--- a/wavesrv/pkg/remote/openai/openai.go
+++ b/wavesrv/pkg/remote/openai/openai.go
@@ -49,7 +49,11 @@ func RunCompletion(ctx context.Context, opts *sstore.OpenAIOptsType, prompt []ss
 	if opts.APIToken == "" {
 		return nil, fmt.Errorf("no api token")
 	}
-	client := openaiapi.NewClient(opts.APIToken)
+	clientConfig := openaiapi.DefaultConfig(opts.APIToken)
+	if opts.BaseURL != "" {
+		clientConfig.BaseURL = opts.BaseURL
+	}
+	client := openaiapi.NewClientWithConfig(clientConfig)
 	req := openaiapi.ChatCompletionRequest{
 		Model:     opts.Model,
 		Messages:  convertPrompt(prompt),
@@ -78,7 +82,11 @@ func RunCompletionStream(ctx context.Context, opts *sstore.OpenAIOptsType, promp
 	if opts.APIToken == "" {
 		return nil, fmt.Errorf("no api token")
 	}
-	client := openaiapi.NewClient(opts.APIToken)
+	clientConfig := openaiapi.DefaultConfig(opts.APIToken)
+	if opts.BaseURL != "" {
+		clientConfig.BaseURL = opts.BaseURL
+	}
+	client := openaiapi.NewClientWithConfig(clientConfig)
 	req := openaiapi.ChatCompletionRequest{
 		Model:     opts.Model,
 		Messages:  convertPrompt(prompt),

--- a/wavesrv/pkg/sstore/sstore.go
+++ b/wavesrv/pkg/sstore/sstore.go
@@ -433,7 +433,7 @@ func (h *HistoryItemType) FromMap(m map[string]interface{}) bool {
 
 type ScreenOptsType struct {
 	TabColor string `json:"tabcolor,omitempty"`
-	TabIcon string `json:"tabicon,omitempty"`
+	TabIcon  string `json:"tabicon,omitempty"`
 	PTerm    string `json:"pterm,omitempty"`
 }
 
@@ -924,6 +924,7 @@ type RemoteOptsType struct {
 type OpenAIOptsType struct {
 	Model      string `json:"model"`
 	APIToken   string `json:"apitoken"`
+	BaseURL    string `json:"baseurl,omitempty"`
 	MaxTokens  int    `json:"maxtokens,omitempty"`
 	MaxChoices int    `json:"maxchoices,omitempty"`
 }


### PR DESCRIPTION
PR for https://github.com/wavetermdev/waveterm/issues/133

Exposes open ai BaseURL in client:set command

User can set BaseURL with `/client:set openaibaseurl=<BASEURL>`

--TESTING--
I couldn't find any other hosted open ai models to test this with, but I was able to confirm with logs that the baseURL is correctly plumbed through the client data opts and it appears correctly when used by the chat command. I was also able to set the base url to the default open ai base url and verify that the chat command still worked, as well as verify that the chat command stopped working when given a bogus base url 

<img width="895" alt="Screen Shot 2023-12-12 at 5 15 13 PM" src="https://github.com/wavetermdev/waveterm/assets/42708380/e0c3fd4f-5a75-46e2-82a7-86e47ad776b9">

--CONSIDERATIONS--
Something to consider about this pr: The go openai library that we use has a special Azure type. if azure baseUrl is specified, and APITypeAzure is not specified, client.fullURL is not going to work correctly. This shouldn't be a big deal, we don't currently use client.fullURL(), but it's something to note if we need it in the future. 

Also authenticating with Azure API Keys is currently not supported, must authenticate with Microsoft Entra authentication, which works exactly the same as Open AI token authentication.

