### PR TITLE
Add support for proxying open AI chat completion through cloud

### DIFF
--- a/scripthaus.md
+++ b/scripthaus.md
@@ -27,7 +27,7 @@ node_modules/.bin/electron-rebuild
 ```bash
 # @scripthaus command electron
 # @scripthaus cd :playbook
-WAVETERM_DEV=1 PCLOUD_ENDPOINT="https://ot2e112zx5.execute-api.us-west-2.amazonaws.com/dev" node_modules/.bin/electron dist-dev/emain.js
+WAVETERM_DEV=1 PCLOUD_ENDPOINT="https://ot2e112zx5.execute-api.us-west-2.amazonaws.com/dev" PCLOUD_WS_ENDPOINT="wss://5lfzlg5crl.execute-api.us-west-2.amazonaws.com/dev/" node_modules/.bin/electron dist-dev/emain.js
 ```
 
 ```bash

--- a/src/app/line/linecomps.tsx
+++ b/src/app/line/linecomps.tsx
@@ -76,11 +76,14 @@ class SmallLineAvatar extends React.Component<{ line: LineType; cmd: Cmd; onRigh
                 iconTitle = "success";
             } else {
                 icon = <XmarkIcon className="fail" />;
-                iconTitle = "fail";
+                iconTitle = "exitcode " + exitcode;
             }
-        } else if (status == "hangup" || status == "error") {
+        } else if (status == "hangup") {
             icon = <WarningIcon className="warning" />;
             iconTitle = status;
+        } else if (status == "error") {
+            icon = <XmarkIcon className="fail" />;
+            iconTitle = "error";
         } else if (status == "running" || "detached") {
             icon = <RotateIcon className="warning spin" />;
             iconTitle = "running";

--- a/waveshell/pkg/packet/packet.go
+++ b/waveshell/pkg/packet/packet.go
@@ -65,6 +65,8 @@ const (
 
 const PacketSenderQueueSize = 20
 
+const PacketEOFStr = "EOF"
+
 var TypeStrToFactory map[string]reflect.Type
 
 func init() {

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -22,6 +22,7 @@ import (
 	"unicode"
 
 	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
 	"github.com/wavetermdev/waveterm/waveshell/pkg/base"
 	"github.com/wavetermdev/waveterm/waveshell/pkg/packet"
 	"github.com/wavetermdev/waveterm/waveshell/pkg/shexec"
@@ -1550,7 +1551,9 @@ func doOpenAIStreamCompletion(cmd *sstore.CmdType, opts *sstore.OpenAIOptsType, 
 			writeErrorToPty(cmd, fmt.Sprintf("In order to protect against abuse, you must have telemetry turned on in order to use Wave's free AI features.  If you do not want to turn telemetry on, you can still use Wave's AI features by adding your own OpenAI key in Settings.  Note that when you use your own key, requests are not proxied through Wave's servers and will be sent directly to the OpenAI API."), outputPos)
 			return
 		}
-		ch, err = openai.RunCloudCompletionStream(ctx, opts, prompt)
+		var conn *websocket.Conn
+		ch, conn, err = openai.RunCloudCompletionStream(ctx, opts, prompt)
+		defer conn.Close()
 	} else {
 		ch, err = openai.RunCompletionStream(ctx, opts, prompt)
 	}

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1561,7 +1561,7 @@ func doOpenAIStreamCompletion(cmd *sstore.CmdType, opts *sstore.OpenAIOptsType, 
 		select {
 		case <-time.After(OpenAIPacketTimeout):
 			// timeout reading from channel
-			timeoutPk := openai.CreateErrorPacket(fmt.Sprintf("Server timed out waiting for packets"))
+			timeoutPk := openai.CreateTextPacket(fmt.Sprintf("... (timed out waiting for server response)"))
 			err = writePacketToPty(ctx, cmd, timeoutPk, &outputPos)
 			if err != nil {
 				log.Printf("error writing response to ptybuffer: %v", err)

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1547,7 +1547,7 @@ func doOpenAIStreamCompletion(cmd *sstore.CmdType, opts *sstore.OpenAIOptsType, 
 			return
 		}
 		if clientData.ClientOpts.NoTelemetry {
-			writeErrorToPty(cmd, fmt.Sprintf("Error: must have telemetry enabled to use wave cloud"), outputPos)
+			writeErrorToPty(cmd, fmt.Sprintf("In order to protect against abuse, you must have telemetry turned on in order to use Wave's free AI features.  If you do not want to turn telemetry on, you can still use Wave's AI features by adding your own OpenAI key in Settings.  Note that when you use your own key, requests are not proxied through Wave's servers and will be sent directly to the OpenAI API."), outputPos)
 			return
 		}
 		ch, err = openai.RunCloudCompletionStream(ctx, opts, prompt)

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -69,6 +69,8 @@ const TsFormatStr = "2006-01-02 15:04:05"
 
 const OpenAIPacketTimeout = 10 * time.Second
 
+const OpenAICloudCompletionTelemetryOffErrorMsg = "In order to protect against abuse, you must have telemetry turned on in order to use Wave's free AI features.  If you do not want to turn telemetry on, you can still use Wave's AI features by adding your own OpenAI key in Settings.  Note that when you use your own key, requests are not proxied through Wave's servers and will be sent directly to the OpenAI API."
+
 const (
 	KwArgRenderer = "renderer"
 	KwArgView     = "view"
@@ -1548,7 +1550,7 @@ func doOpenAIStreamCompletion(cmd *sstore.CmdType, opts *sstore.OpenAIOptsType, 
 			return
 		}
 		if clientData.ClientOpts.NoTelemetry {
-			writeErrorToPty(cmd, fmt.Sprintf("In order to protect against abuse, you must have telemetry turned on in order to use Wave's free AI features.  If you do not want to turn telemetry on, you can still use Wave's AI features by adding your own OpenAI key in Settings.  Note that when you use your own key, requests are not proxied through Wave's servers and will be sent directly to the OpenAI API."), outputPos)
+			writeErrorToPty(cmd, fmt.Sprintf(OpenAICloudCompletionTelemetryOffErrorMsg), outputPos)
 			return
 		}
 		var conn *websocket.Conn

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1564,7 +1564,7 @@ func doOpenAIStreamCompletion(cmd *sstore.CmdType, opts *sstore.OpenAIOptsType, 
 			timeoutPk := openai.CreateErrorPacket(fmt.Sprintf("Server timed out waiting for packets"))
 			err = writePacketToPty(ctx, cmd, timeoutPk, &outputPos)
 			if err != nil {
-				writeErrorToPty(cmd, fmt.Sprintf("error writing response to ptybuffer: %v", err), outputPos)
+				log.Printf("error writing response to ptybuffer: %v", err)
 				return
 			}
 			doneWaitingForPackets = true
@@ -1574,7 +1574,7 @@ func doOpenAIStreamCompletion(cmd *sstore.CmdType, opts *sstore.OpenAIOptsType, 
 				// got a packet
 				err = writePacketToPty(ctx, cmd, pk, &outputPos)
 				if err != nil {
-					writeErrorToPty(cmd, fmt.Sprintf("error writing response to ptybuffer: %v", err), outputPos)
+					log.Printf("error writing response to ptybuffer: %v", err)
 					return
 				}
 			} else {

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1484,7 +1484,16 @@ func doOpenAICompletion(cmd *sstore.CmdType, opts *sstore.OpenAIOptsType, prompt
 		}
 		sstore.MainBus.SendScreenUpdate(cmd.ScreenId, update)
 	}()
-	respPks, err := openai.RunCompletion(ctx, opts, prompt)
+	var respPks []*packet.OpenAIPacketType
+	var err error
+	log.Printf("TODO: fix this condition - short circuited to access cloud code path\n")
+	if true || opts.APIToken == "" {
+		// run open ai completion in the cloud
+		respPks, err = openai.RunCloudCompletion(ctx, opts, prompt)
+	} else {
+		// run open ai completion locally
+		respPks, err = openai.RunCompletion(ctx, opts, prompt)
+	}
 	if err != nil {
 		writeErrorToPty(cmd, fmt.Sprintf("error calling OpenAI API: %v", err), outputPos)
 		return
@@ -1533,7 +1542,16 @@ func doOpenAIStreamCompletion(cmd *sstore.CmdType, opts *sstore.OpenAIOptsType, 
 		}
 		sstore.MainBus.SendScreenUpdate(cmd.ScreenId, update)
 	}()
-	ch, err := openai.RunCompletionStream(ctx, opts, prompt)
+	var ch chan *packet.OpenAIPacketType
+	var err error
+	log.Printf("TODO: fix this condition - short circuited to access cloud code path\n")
+	if true || opts.APIToken == "" {
+		// run open ai completion in the cloud
+		ch, err = openai.RunCloudCompletionStream(ctx, opts, prompt)
+	} else {
+		// run open ai completion locally
+		ch, err = openai.RunCompletionStream(ctx, opts, prompt)
+	}
 	if err != nil {
 		writeErrorToPty(cmd, fmt.Sprintf("error calling OpenAI API: %v", err), outputPos)
 		return

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -68,7 +68,7 @@ const TermFontSizeMax = 24
 const TsFormatStr = "2006-01-02 15:04:05"
 
 const OpenAIPacketTimeout = 10 * time.Second
-const OpenAIStreamTimeout = 60 * time.Second
+const OpenAIStreamTimeout = 5 * time.Minute
 
 const OpenAICloudCompletionTelemetryOffErrorMsg = "In order to protect against abuse, you must have telemetry turned on in order to use Wave's free AI features.  If you do not want to turn telemetry on, you can still use Wave's AI features by adding your own OpenAI key in Settings.  Note that when you use your own key, requests are not proxied through Wave's servers and will be sent directly to the OpenAI API."
 

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1557,7 +1557,7 @@ func doOpenAIStreamCompletion(cmd *sstore.CmdType, opts *sstore.OpenAIOptsType, 
 		return
 	}
 	doneWaitingForPackets := false
-	for doneWaitingForPackets == false {
+	for !doneWaitingForPackets {
 		select {
 		case <-time.After(OpenAIPacketTimeout):
 			// timeout reading from channel

--- a/wavesrv/pkg/pcloud/pcloud.go
+++ b/wavesrv/pkg/pcloud/pcloud.go
@@ -24,7 +24,7 @@ import (
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/sstore"
 )
 
-const PCloudEndpoint = "https://api.getprompt.dev/central"
+const PCloudEndpoint = "https://api.waveterm.dev/central"
 const PCloudEndpointVarName = "PCLOUD_ENDPOINT"
 const APIVersion = 1
 const MaxPtyUpdateSize = (128 * 1024)
@@ -33,6 +33,9 @@ const MaxUpdatesToDeDup = 1000
 const MaxUpdateWriterErrors = 3
 const PCloudDefaultTimeout = 5 * time.Second
 const PCloudWebShareUpdateTimeout = 15 * time.Second
+
+const PCloudWSEndpoint = "wss://wsapi.waveterm.dev/"
+const PCloudWSEndpointVarName = "PCLOUD_WS_ENDPOINT"
 
 // setting to 1M to be safe (max is 6M for API-GW + Lambda, but there is base64 encoding and upload time)
 // we allow one extra update past this estimated size
@@ -61,6 +64,18 @@ func GetEndpoint() string {
 		panic("Invalid PCloud dev endpoint, PCLOUD_ENDPOINT not set or invalid")
 	}
 	return endpoint
+}
+
+func GetWSEndpoint() string {
+	if !scbase.IsDevMode() {
+		return PCloudWSEndpoint
+	} else {
+		endpoint := os.Getenv(PCloudWSEndpointVarName)
+		if endpoint == "" {
+			panic("Invalid PCloud ws dev endpoint, PCLOUD_WS_ENDPOINT not set or invalid")
+		}
+		return endpoint
+	}
 }
 
 func makeAuthPostReq(ctx context.Context, apiUrl string, authInfo AuthInfo, data interface{}) (*http.Request, error) {

--- a/wavesrv/pkg/remote/openai/openai.go
+++ b/wavesrv/pkg/remote/openai/openai.go
@@ -124,7 +124,7 @@ func RunCloudCompletionStream(ctx context.Context, opts *sstore.OpenAIOptsType, 
 				break
 			} else if streamResp.Error != "" {
 				// use error from server directly
-				errPk := CreateErrorPacket(fmt.Sprintf(err.Error()))
+				errPk := CreateErrorPacket(streamResp.Error)
 				rtn <- errPk
 				break
 			}

--- a/wavesrv/pkg/remote/openai/openai.go
+++ b/wavesrv/pkg/remote/openai/openai.go
@@ -4,9 +4,15 @@
 package openai
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
 
 	openaiapi "github.com/sashabaranov/go-openai"
 	"github.com/wavetermdev/waveterm/waveshell/pkg/packet"
@@ -30,7 +36,7 @@ func convertUsage(resp openaiapi.ChatCompletionResponse) *packet.OpenAIUsageType
 	}
 }
 
-func convertPrompt(prompt []sstore.OpenAIPromptMessageType) []openaiapi.ChatCompletionMessage {
+func ConvertPrompt(prompt []sstore.OpenAIPromptMessageType) []openaiapi.ChatCompletionMessage {
 	var rtn []openaiapi.ChatCompletionMessage
 	for _, p := range prompt {
 		msg := openaiapi.ChatCompletionMessage{Role: p.Role, Content: p.Content, Name: p.Name}
@@ -56,7 +62,7 @@ func RunCompletion(ctx context.Context, opts *sstore.OpenAIOptsType, prompt []ss
 	client := openaiapi.NewClientWithConfig(clientConfig)
 	req := openaiapi.ChatCompletionRequest{
 		Model:     opts.Model,
-		Messages:  convertPrompt(prompt),
+		Messages:  ConvertPrompt(prompt),
 		MaxTokens: opts.MaxTokens,
 	}
 	if opts.MaxChoices > 1 {
@@ -70,6 +76,96 @@ func RunCompletion(ctx context.Context, opts *sstore.OpenAIOptsType, prompt []ss
 		return nil, fmt.Errorf("no response received")
 	}
 	return marshalResponse(apiResp), nil
+}
+
+func RunCloudCompletion(ctx context.Context, opts *sstore.OpenAIOptsType, prompt []sstore.OpenAIPromptMessageType) ([]*packet.OpenAIPacketType, error) {
+	if opts == nil {
+		return nil, fmt.Errorf("no openai opts found")
+	}
+	if opts.Model == "" {
+		return nil, fmt.Errorf("no openai model specified")
+	}
+	cloudCompletionRequestConfig := sstore.OpenAICloudCompletionRequest{
+		Model:      opts.Model,
+		Prompt:     prompt,
+		MaxTokens:  opts.MaxTokens,
+		MaxChoices: opts.MaxChoices,
+	}
+	const cloudTestAddr = "http://127.0.0.1:7999/api/chat-completion"
+	payloadBuf := new(bytes.Buffer)
+	json.NewEncoder(payloadBuf).Encode(cloudCompletionRequestConfig)
+	httpreq, err := http.NewRequest("POST", cloudTestAddr, payloadBuf)
+	if err != nil {
+		return nil, fmt.Errorf("request create err: %v", err)
+	}
+	httpresp, err := http.DefaultClient.Do(httpreq)
+	if err != nil {
+		return nil, fmt.Errorf("request err: %v", err)
+	}
+	defer httpresp.Body.Close()
+	body, err := io.ReadAll(httpresp.Body)
+	var apiResp openaiapi.ChatCompletionResponse
+	type jsonResponse struct {
+		Data openaiapi.ChatCompletionResponse
+	}
+	var httpjsonresp jsonResponse
+	err = json.Unmarshal(body, &httpjsonresp)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding json output %v", err)
+	}
+	apiResp = httpjsonresp.Data
+	return marshalResponse(apiResp), nil
+}
+
+func RunCloudCompletionStream(ctx context.Context, opts *sstore.OpenAIOptsType, prompt []sstore.OpenAIPromptMessageType) (chan *packet.OpenAIPacketType, error) {
+	const AWSLambdaCentralWSAddr = "wss://5lfzlg5crl.execute-api.us-west-2.amazonaws.com/dev/"
+	if opts == nil {
+		return nil, fmt.Errorf("no openai opts found")
+	}
+	if opts.Model == "" {
+		return nil, fmt.Errorf("no openai model specified")
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(AWSLambdaCentralWSAddr, nil)
+	if err != nil {
+		log.Printf("Websocket error: %v", err)
+		return nil, fmt.Errorf("Websocket error: %v", err)
+	}
+	cloudCompletionRequestConfig := sstore.OpenAICloudCompletionRequest{
+		Model:      opts.Model,
+		Prompt:     prompt,
+		MaxTokens:  opts.MaxTokens,
+		MaxChoices: opts.MaxChoices,
+	}
+	configMessageBuf := new(bytes.Buffer)
+	json.NewEncoder(configMessageBuf).Encode(cloudCompletionRequestConfig)
+	err = conn.WriteMessage(websocket.TextMessage, configMessageBuf.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("Websocker write config error: %v", err)
+	}
+	rtn := make(chan *packet.OpenAIPacketType, DefaultStreamChanSize)
+	go func() {
+		defer close(rtn)
+		for {
+			_, socketMessage, err := conn.ReadMessage()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				errPk := CreateErrorPacket(fmt.Sprintf("Websocket error: %v", err))
+				rtn <- errPk
+				break
+			}
+			decoder := json.NewDecoder(bytes.NewReader(socketMessage))
+			var streamResp *packet.OpenAIPacketType
+			err = decoder.Decode(&streamResp)
+			if err != nil {
+				errPk := CreateErrorPacket(fmt.Sprintf("Websocket response json decode error: %v", err))
+				rtn <- errPk
+			}
+			rtn <- streamResp
+		}
+	}()
+	return rtn, err
 }
 
 func RunCompletionStream(ctx context.Context, opts *sstore.OpenAIOptsType, prompt []sstore.OpenAIPromptMessageType) (chan *packet.OpenAIPacketType, error) {
@@ -89,7 +185,7 @@ func RunCompletionStream(ctx context.Context, opts *sstore.OpenAIOptsType, promp
 	client := openaiapi.NewClientWithConfig(clientConfig)
 	req := openaiapi.ChatCompletionRequest{
 		Model:     opts.Model,
-		Messages:  convertPrompt(prompt),
+		Messages:  ConvertPrompt(prompt),
 		MaxTokens: opts.MaxTokens,
 		Stream:    true,
 	}

--- a/wavesrv/pkg/remote/openai/openai.go
+++ b/wavesrv/pkg/remote/openai/openai.go
@@ -218,3 +218,9 @@ func CreateErrorPacket(errStr string) *packet.OpenAIPacketType {
 	errPk.Error = errStr
 	return errPk
 }
+
+func CreateTextPacket(text string) *packet.OpenAIPacketType {
+	pk := packet.MakeOpenAIPacket()
+	pk.Text = text
+	return pk
+}

--- a/wavesrv/pkg/remote/openai/openai.go
+++ b/wavesrv/pkg/remote/openai/openai.go
@@ -8,13 +8,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"time"
 
 	"github.com/gorilla/websocket"
 
 	openaiapi "github.com/sashabaranov/go-openai"
 	"github.com/wavetermdev/waveterm/waveshell/pkg/packet"
+	"github.com/wavetermdev/waveterm/wavesrv/pkg/pcloud"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/sstore"
 )
 
@@ -80,14 +80,12 @@ func RunCompletion(ctx context.Context, opts *sstore.OpenAIOptsType, prompt []ss
 }
 
 func RunCloudCompletionStream(ctx context.Context, opts *sstore.OpenAIOptsType, prompt []sstore.OpenAIPromptMessageType) (chan *packet.OpenAIPacketType, *websocket.Conn, error) {
-	const AWSLambdaCentralWSAddr = "wss://5lfzlg5crl.execute-api.us-west-2.amazonaws.com/dev/"
 	if opts == nil {
 		return nil, nil, fmt.Errorf("no openai opts found")
 	}
 	websocketContext, _ := context.WithTimeout(context.Background(), CloudWebsocketConnectTimeout)
-	conn, _, err := websocket.DefaultDialer.DialContext(websocketContext, AWSLambdaCentralWSAddr, nil)
+	conn, _, err := websocket.DefaultDialer.DialContext(websocketContext, pcloud.GetWSEndpoint(), nil)
 	if err != nil {
-		log.Printf("Websocket error: %v", err)
 		return nil, nil, fmt.Errorf("Websocket error: %v", err)
 	}
 	cloudCompletionRequestConfig := sstore.OpenAICloudCompletionRequest{

--- a/wavesrv/pkg/remote/openai/openai.go
+++ b/wavesrv/pkg/remote/openai/openai.go
@@ -84,9 +84,6 @@ func RunCloudCompletionStream(ctx context.Context, opts *sstore.OpenAIOptsType, 
 	if opts == nil {
 		return nil, fmt.Errorf("no openai opts found")
 	}
-	if opts.Model == "" {
-		return nil, fmt.Errorf("no openai model specified")
-	}
 	websocketContext, _ := context.WithTimeout(context.Background(), CloudWebsocketConnectTimeout)
 	conn, _, err := websocket.DefaultDialer.DialContext(websocketContext, AWSLambdaCentralWSAddr, nil)
 	if err != nil {

--- a/wavesrv/pkg/sstore/sstore.go
+++ b/wavesrv/pkg/sstore/sstore.go
@@ -778,6 +778,13 @@ type OpenAIPromptMessageType struct {
 	Name    string `json:"name,omitempty"`
 }
 
+type OpenAICloudCompletionRequest struct {
+	Model      string                    `json:"model"`
+	Prompt     []OpenAIPromptMessageType `json:"prompt"`
+	MaxTokens  int                       `json:"maxtokens,omitempty"`
+	MaxChoices int                       `json:"maxchoices,omitempty"`
+}
+
 type PlaybookType struct {
 	PlaybookId   string   `json:"playbookid"`
 	PlaybookName string   `json:"playbookname"`

--- a/wavesrv/pkg/sstore/sstore.go
+++ b/wavesrv/pkg/sstore/sstore.go
@@ -779,7 +779,6 @@ type OpenAIPromptMessageType struct {
 }
 
 type OpenAICloudCompletionRequest struct {
-	Model      string                    `json:"model"`
 	Prompt     []OpenAIPromptMessageType `json:"prompt"`
 	MaxTokens  int                       `json:"maxtokens,omitempty"`
 	MaxChoices int                       `json:"maxchoices,omitempty"`


### PR DESCRIPTION
<img width="1119" alt="Screen Shot 2023-12-14 at 8 02 52 PM" src="https://github.com/wavetermdev/waveterm/assets/42708380/60f9c331-ee3c-4e2b-934a-581f98ec3b3f">
Added support for proxying open ai chat completion through cloud, this allows users to not have to specify their own openai token

If token is not set, chat completion will now be proxied through the cloud. You can unset your token through the UI. 
the cloud uses the default model, currently "gpt-3.5-turbo".
It allows you to set max tokens and max choices parameter

If you don't have telemetry set to on, you cannot use this feature 

-- CONSIDERATIONS --
For now, this is set to only hit our dev lambda server. When we deploy the completion code to our prod lambda server, we should add a check for is dev or prod


-- TESTING --
I tested with telemetry on and off, and confirmed that the correct error shows. I have tested the channel timeout and confirm that if the socket hangs, the channel will timeout and send an error, and then the terminal can continue as normal.

I have tested all of the standard code paths, confirmed that when token is set we will still do completion locally, and when token is not set we will do cloud completion. I confirmed that token can now be set to empty string, and it looks good in the ui (it goes back to "not set"). I have also checked socket failed to connect error.

There are some more unlikely error paths that I haven't checked because I didn't reproduce that error, like json decode, etc etc. I also haven't tested socket connect timeout error, but I expect these paths to work as described because the behavior is fairly standard

What do we think about the way I do testing? I can write unit tests in the future 