### PR TITLE
Modify "Check for Updates" setting name

### DIFF
--- a/src/app/common/modals/modals.less
+++ b/src/app/common/modals/modals.less
@@ -745,7 +745,7 @@
 .client-settings-modal {
     .settings-field {
         .settings-label {
-            width: 150px;
+            width: 157px;
         }
         .dropdown-menu {
             min-width: 7.25em;

--- a/src/app/common/modals/settings.tsx
+++ b/src/app/common/modals/settings.tsx
@@ -781,7 +781,7 @@ class ClientSettingsModal extends React.Component<{}, {}> {
                         </div>
                     </div>
                     <div className="settings-field">
-                        <div className="settings-label">Check for Updates Automatically</div>
+                        <div className="settings-label">Check for Updates</div>
                         <div className="settings-input">
                             <Toggle checked={!cdata.clientopts.noreleasecheck} onChange={this.handleChangeReleaseCheck} />
                         </div>


### PR DESCRIPTION
Changes the setting toggle for the NoReleaseCheck setting from "Check for Updates Automatically" to "Check for Updates" and makes the settings label slightly wider.

<img width="654" alt="image" src="https://github.com/wavetermdev/waveterm/assets/16651283/ecfe68f5-bf43-4884-a23a-33d90bd898a1">
