### PR TITLE
Fixed open ai renderer not scrolling correctly

### DIFF
--- a/src/plugins/openai/openai.less
+++ b/src/plugins/openai/openai.less
@@ -10,6 +10,7 @@
             color: @term-bright-green;
             font-weight: bold;
             width: 100px;
+            flex-shrink: 0;
         }
 
         .openai-role.openai-role-assistant {

--- a/src/plugins/openai/openai.less
+++ b/src/plugins/openai/openai.less
@@ -33,4 +33,6 @@
             color: @term-bright-red;
         }
     }
+
+    overflow-y: auto;
 }

--- a/src/plugins/openai/openai.tsx
+++ b/src/plugins/openai/openai.tsx
@@ -196,7 +196,6 @@ class OpenAIRenderer extends React.Component<{ model: OpenAIRendererModel }> {
         }
         let message = output.message;
         let opts = model.opts;
-        let maxWidth = opts.maxSize.width;
         let minWidth = opts.maxSize.width;
         if (minWidth > 1000) {
             minWidth = 1000;
@@ -209,9 +208,6 @@ class OpenAIRenderer extends React.Component<{ model: OpenAIRendererModel }> {
                         className="scroller"
                         style={{
                             maxHeight: opts.maxSize.height,
-                            minWidth: minWidth,
-                            width: "min-content",
-                            maxWidth: maxWidth,
                         }}
                     >
                         <Markdown text={message} style={{ maxHeight: opts.maxSize.height }} />
@@ -240,7 +236,14 @@ class OpenAIRenderer extends React.Component<{ model: OpenAIRendererModel }> {
         let cmd = model.rawCmd;
         let styleVal: Record<string, any> = null;
         if (model.loading.get() && model.savedHeight >= 0 && model.isDone) {
-            styleVal = { height: model.savedHeight };
+            let maxWidth = model.opts.maxSize.width
+            if(maxWidth > 1000) {
+                maxWidth = 1000
+            }
+            styleVal = { 
+                height: model.savedHeight,
+                maxWidth: maxWidth,
+            };
         }
         let version = model.version.get();
         let loadError = model.loadError.get();

--- a/src/plugins/openai/openai.tsx
+++ b/src/plugins/openai/openai.tsx
@@ -205,9 +205,9 @@ class OpenAIRenderer extends React.Component<{ model: OpenAIRendererModel }> {
                 <div className="openai-role openai-role-assistant">[assistant]</div>
                 <div className="openai-content-assistant">
                     <div
-                        className="scroller"
                         style={{
                             maxHeight: opts.maxSize.height,
+                            paddingRight: 5
                         }}
                     >
                         <Markdown text={message} style={{ maxHeight: opts.maxSize.height }} />
@@ -236,13 +236,18 @@ class OpenAIRenderer extends React.Component<{ model: OpenAIRendererModel }> {
         let cmd = model.rawCmd;
         let styleVal: Record<string, any> = null;
         if (model.loading.get() && model.savedHeight >= 0 && model.isDone) {
+            styleVal = { 
+                height: model.savedHeight,
+                maxHeight: model.opts.maxSize.height
+            };
+        } else {
             let maxWidth = model.opts.maxSize.width
             if(maxWidth > 1000) {
                 maxWidth = 1000
             }
             styleVal = { 
-                height: model.savedHeight,
                 maxWidth: maxWidth,
+                maxHeight: model.opts.maxSize.height
             };
         }
         let version = model.version.get();


### PR DESCRIPTION
Added `overflow-y:auto` to css for open ai renderer, allowing it to scroll and not cut off output