### PR TITLE
Small tweak to the checkbox toggle slider

### DIFF
--- a/src/app/common/common.less
+++ b/src/app/common/common.less
@@ -134,7 +134,7 @@
     position: relative;
     display: inline-block;
     width: 40px;
-    height: 23px;
+    height: 22px;
 
     input {
         opacity: 0;
@@ -160,8 +160,8 @@
         content: "";
         height: 18px;
         width: 18px;
-        left: 3px;
-        bottom: 3px;
+        left: 2px;
+        bottom: 2px;
         background-color: @term-white;
         transition: 0.5s;
         border-radius: 50%;


### PR DESCRIPTION
This fixes a very small UI bug in the checkbox toggle element. The slider was offset by a pixel from where it should be due to the odd number of pixels in the height of the whole checkbox vs. the even height of pixels in the animated slider. This could be fixed by using fractions of pixels for the offset, but these won't display well on all displays. Instead, I made the whole element one pixel shorter and made the offset each 1 pixel less. This makes the whole slider line up better with the sides of the toggle too.

Old:
<img width="520" alt="image" src="https://github.com/wavetermdev/waveterm/assets/16651283/653a2a37-9bcc-4e0b-be8f-bdfe5c251c98">

New:
<img width="520" alt="image" src="https://github.com/wavetermdev/waveterm/assets/16651283/c4611173-c40e-46c8-8192-6c5bd1f0e899">

