### PR TITLE
Run release check in the background when toggling the setting

### DIFF
--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -4106,10 +4106,14 @@ func ReleaseCheckOnCommand(ctx context.Context, pk *scpacket.FeCommandPacketType
 		return nil, err
 	}
 
-	err = runReleaseCheck(ctx, true)
-	if err != nil {
-		log.Printf("error checking for new release after enabling auto release check: %v\n", err)
-	}
+	go func() {
+		updateCtx, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelFn()
+		err = runReleaseCheck(updateCtx, true)
+		if err != nil {
+			log.Printf("error checking for new release after enabling auto release check: %v\n", err)
+		}
+	}()
 
 	clientData, err = sstore.EnsureClientData(ctx)
 	if err != nil {

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -4109,9 +4109,9 @@ func ReleaseCheckOnCommand(ctx context.Context, pk *scpacket.FeCommandPacketType
 	go func() {
 		releaseCheckCtx, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancelFn()
-		err = runReleaseCheck(releaseCheckCtx, true)
-		if err != nil {
-			log.Printf("error checking for new release after enabling auto release check: %v\n", err)
+		releaseCheckErr := runReleaseCheck(releaseCheckCtx, true)
+		if releaseCheckErr != nil {
+			log.Printf("error checking for new release after enabling auto release check: %v\n", releaseCheckErr)
 		}
 	}()
 

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -4107,9 +4107,9 @@ func ReleaseCheckOnCommand(ctx context.Context, pk *scpacket.FeCommandPacketType
 	}
 
 	go func() {
-		updateCtx, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
+		releaseCheckCtx, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancelFn()
-		err = runReleaseCheck(updateCtx, true)
+		err = runReleaseCheck(releaseCheckCtx, true)
 		if err != nil {
 			log.Printf("error checking for new release after enabling auto release check: %v\n", err)
 		}


### PR DESCRIPTION
Before, we ran release check in the same context as the setting toggle operation, meaning the setting slider wouldn't update until the check completed. This caused a delayed response on slow connections.

Now, we will queue a background task to run the release check so that we don't block the setting toggle.