### PR TITLE
Clean up cirfile and cirfile_tests, ensure we are using contexts with cancellation signals

### DIFF
--- a/waveshell/pkg/cirfile/cirfile.go
+++ b/waveshell/pkg/cirfile/cirfile.go
@@ -128,18 +128,6 @@ func OpenCirFile(fileName string) (*File, error) {
 		return nil, err
 	}
 
-	if !cfRegex.MatchString(fileName) {
-		return nil, fmt.Errorf("invalid cirfile path[%s]", fileName)
-	}
-
-	// Check that the file is in the wavehomedir or tempdir, these are the only places we allow cirfiles to be created
-	absPath, err := filepath.Abs(fileName)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get absolute path for file[%s]: %w", fileName, err)
-	}
-	if !strings.HasPrefix(absPath, waveHomeDir) && !strings.HasPrefix(absPath, tempDir) {
-		return nil, fmt.Errorf("invalid cirfile path[%s], must be in wavehomedir[%s] or tempdir[%s]", fileName, waveHomeDir, tempDir)
-	}
 	fd, err := os.OpenFile(fileName, os.O_RDWR, 0777)
 	if err != nil {
 		return nil, err

--- a/waveshell/pkg/cirfile/cirfile.go
+++ b/waveshell/pkg/cirfile/cirfile.go
@@ -98,7 +98,7 @@ func (f *File) unflock() {
 }
 
 // cirfile path must not be in the root directory and must not contain more than one period (.) in the filename
-var cfRegex = regexp.MustCompile(`([^.\v]+[\\|\/])+([^.\v]+.cf)`)
+var cfRegex = regexp.MustCompile(`([^.\n\v]+[\\|\/])+(([^.\n\v]+.){1,2}cf)`)
 var tempDir = os.TempDir()
 var waveHomeDir = scbase.GetWaveHomeDir()
 

--- a/waveshell/pkg/cirfile/cirfile.go
+++ b/waveshell/pkg/cirfile/cirfile.go
@@ -97,7 +97,7 @@ func (f *File) unflock() {
 	}
 }
 
-// cf path must not be in the root directory and must not contain more than one period (.) in the filename
+// cirfile path must not be in the root directory and must not contain more than one period (.) in the filename
 var cfRegex = regexp.MustCompile(`([^.\v]+[\\|\/])+([^.\v]+.cf)`)
 var tempDir = os.TempDir()
 var waveHomeDir = scbase.GetWaveHomeDir()

--- a/waveshell/pkg/cirfile/cirfile.go
+++ b/waveshell/pkg/cirfile/cirfile.go
@@ -150,9 +150,7 @@ func CreateCirFile(fileName string, maxSize int64) (*File, error) {
 		return nil, err
 	}
 	rtn := &File{OSFile: fd, Version: CurrentVersion, MaxSize: maxSize, StartPos: FilePosEmpty}
-	timeoutContext, cancelFn := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancelFn()
-	err = rtn.flock(timeoutContext, syscall.LOCK_EX)
+	err = rtn.flock(nil, syscall.LOCK_EX) // pass nil context here for a fast fail if someone else is also creating the same file
 	if err != nil {
 		return nil, fmt.Errorf("cannot lock file: %w", err)
 	}

--- a/waveshell/pkg/cirfile/cirfile.go
+++ b/waveshell/pkg/cirfile/cirfile.go
@@ -95,16 +95,19 @@ func (f *File) unflock() {
 	}
 }
 
+// cf path must not be in the root directory and must not contain more than one period (.) in the filename
 var cfRegex = regexp.MustCompile(`([^.\v]+[\\|\/])+([^.\v]+.cf)`)
+var tempDir = os.TempDir()
+var waveHomeDir = scbase.GetWaveHomeDir()
 
 // does not read metadata because locking could block/fail.  we want to be able
 // to return a valid file struct without blocking.
 func OpenCirFile(fileName string) (*File, error) {
-	waveHomeDir := scbase.GetWaveHomeDir()
-	tempDir := os.TempDir()
 	if !cfRegex.MatchString(fileName) {
 		return nil, fmt.Errorf("invalid cirfile path[%s]", fileName)
 	}
+
+	// Check that the file is in the wavehomedir or tempdir, these are the only places we allow cirfiles to be created
 	absPath, err := filepath.Abs(fileName)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get absolute path for file[%s]: %w", fileName, err)

--- a/waveshell/pkg/cirfile/cirfile.go
+++ b/waveshell/pkg/cirfile/cirfile.go
@@ -125,16 +125,16 @@ func ValidateCirFilePath(fileName string) error {
 func OpenCirFile(fileName string) (*File, error) {
 	err := ValidateCirFilePath(fileName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to validate cirfile path[%s]: %w", fileName, err)
 	}
 
 	fd, err := os.OpenFile(fileName, os.O_RDWR, 0777)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot open file: %w", err)
 	}
 	finfo, err := fd.Stat()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot get file info: %w", err)
 	}
 	if finfo.Size() < HeaderLen {
 		return nil, fmt.Errorf("invalid cirfile, file length[%d] less than HeaderLen[%d]", finfo.Size(), HeaderLen)

--- a/waveshell/pkg/cirfile/cirfile.go
+++ b/waveshell/pkg/cirfile/cirfile.go
@@ -57,7 +57,9 @@ func (f *File) flock(ctx context.Context, lockType int) error {
 	if err != syscall.EWOULDBLOCK {
 		return err
 	}
-	if ctx == nil {
+
+	// Do not busy-wait unless we have a way to cancel the context
+	if ctx == nil || ctx.Done() == nil {
 		return syscall.EWOULDBLOCK
 	}
 	// busy-wait with context

--- a/waveshell/pkg/cirfile/cirfile_test.go
+++ b/waveshell/pkg/cirfile/cirfile_test.go
@@ -361,10 +361,14 @@ func TestValidateCirFilePath(t *testing.T) {
 	tempDir := t.TempDir()
 	testValidateCirFilePath(t, filepath.Join(tempDir, "no-such-file"), true)
 	testValidateCirFilePath(t, filepath.Join(tempDir, "should-succeed.cf"), false)
+	testValidateCirFilePath(t, filepath.Join(tempDir, "should-succeed.ptyout.cf"), false)
+	testValidateCirFilePath(t, filepath.Join(tempDir, "should-fail.x.ptyout.cf"), true)
 
 	waveHomeDir := getWaveHomeDir(t)
 	testValidateCirFilePath(t, filepath.Join(waveHomeDir, "no-such-file"), true)
 	testValidateCirFilePath(t, filepath.Join(waveHomeDir, "should-succeed.cf"), false)
+	testValidateCirFilePath(t, filepath.Join(tempDir, "should-succeed.ptyout.cf"), false)
+	testValidateCirFilePath(t, filepath.Join(tempDir, "should-fail.x.ptyout.cf"), true)
 
 }
 

--- a/waveshell/pkg/cirfile/cirfile_test.go
+++ b/waveshell/pkg/cirfile/cirfile_test.go
@@ -387,7 +387,9 @@ func TestOpenCirFile(t *testing.T) {
 	waveHomeDir := getWaveHomeDir(t)
 	waveHomeCirFileUuid := uuid.New().String()
 	waveHomeCirFilePath := path.Join(waveHomeDir, waveHomeCirFileUuid+".cf")
-	defer os.Remove(waveHomeCirFilePath)
+	t.Cleanup(func() {
+		os.Remove(waveHomeCirFilePath)
+	})
 	testOpenCirFile(t, waveHomeCirFilePath, true)
 	_, err = CreateCirFile(waveHomeCirFilePath, 100)
 	if err != nil {

--- a/waveshell/pkg/cirfile/cirfile_test.go
+++ b/waveshell/pkg/cirfile/cirfile_test.go
@@ -8,10 +8,14 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/wavetermdev/waveterm/wavesrv/pkg/scbase"
 )
 
 func validateFileSize(t *testing.T, name string, size int) {
@@ -53,25 +57,39 @@ func makeData(size int) string {
 	return rtn
 }
 
-func TestCreate(t *testing.T) {
+func testFilePath(t *testing.T, name string) string {
 	tempDir := t.TempDir()
-	f1Name := path.Join(tempDir, "f1.cf")
-	f, err := OpenCirFile(f1Name)
-	if err == nil || f != nil {
-		t.Fatalf("OpenCirFile f1.cf should fail (no file)")
-	}
-	f, err = CreateCirFile(f1Name, 100)
+	return path.Join(tempDir, name)
+}
+
+func createTestFile(t *testing.T, name string) (*File, string, error) {
+	fPath := testFilePath(t, name)
+	f, err := CreateCirFile(fPath, 100)
 	if err != nil {
-		t.Fatalf("CreateCirFile f1.cf failed: %v", err)
+		return nil, fPath, err
+	}
+	return f, fPath, nil
+}
+
+func TestCreate(t *testing.T) {
+	const fName = "f1.cf"
+	fPath := testFilePath(t, fName)
+	f, err := OpenCirFile(fPath)
+	if err == nil || f != nil {
+		t.Fatalf("OpenCirFile %s should fail (no file)", fPath)
+	}
+	f, err = CreateCirFile(fPath, 100)
+	if err != nil {
+		t.Fatalf("CreateCirFile %s failed: %v", fPath, err)
 	}
 	if f == nil {
-		t.Fatalf("CreateCirFile f1.cf returned nil")
+		t.Fatalf("CreateCirFile %s returned nil", fPath)
 	}
 	err = f.ReadMeta(context.Background())
 	if err != nil {
-		t.Fatalf("cannot readmeta from f1.cf: %v", err)
+		t.Fatalf("cannot readmeta from %s: %v", fPath, err)
 	}
-	validateFileSize(t, f1Name, 256)
+	validateFileSize(t, fPath, 256)
 	if f.Version != CurrentVersion || f.MaxSize != 100 || f.FileOffset != 0 || f.StartPos != FilePosEmpty || f.EndPos != 0 || f.FileDataSize != 0 || f.FlockStatus != 0 {
 		t.Fatalf("error with initial metadata #%v", f)
 	}
@@ -84,62 +102,65 @@ func TestCreate(t *testing.T) {
 	if realOffset != 0 || nr != 0 || err != nil {
 		t.Fatalf("error with empty read: real-offset[%d] nr[%d] err[%v]", realOffset, nr, err)
 	}
-	f2, err := CreateCirFile(f1Name, 100)
+	f2, err := CreateCirFile(fPath, 100)
 	if err == nil || f2 != nil {
 		t.Fatalf("should be an error to create duplicate CirFile")
 	}
 }
 
+const cannotAppendData = "cannot append data: %v"
+const cannotReadNext = "cannot readnext: %v"
+const cannotCreateCirFile = "cannot create cirfile [%s]: %v"
+
 func TestFile(t *testing.T) {
-	tempDir := t.TempDir()
-	f1Name := path.Join(tempDir, "f1.cf")
-	f, err := CreateCirFile(f1Name, 100)
+	const fName = "f1.cf"
+	f, fPath, err := createTestFile(t, fName)
 	if err != nil {
-		t.Fatalf("cannot create cirfile: %v", err)
+		t.Fatalf(cannotCreateCirFile, fPath, err)
 	}
 	err = f.AppendData(context.Background(), nil)
 	if err != nil {
-		t.Fatalf("cannot append data: %v", err)
+		t.Fatalf(cannotAppendData, err)
 	}
-	validateFileSize(t, f1Name, HeaderLen)
+	validateFileSize(t, fPath, HeaderLen)
 	validateMeta(t, "1", f, FilePosEmpty, 0, 0, 0)
 	err = f.AppendData(context.Background(), []byte("hello"))
 	if err != nil {
-		t.Fatalf("cannot append data: %v", err)
+		t.Fatalf(cannotAppendData, err)
 	}
-	validateFileSize(t, f1Name, HeaderLen+5)
+	validateFileSize(t, fPath, HeaderLen+5)
 	validateMeta(t, "2", f, 0, 4, 5, 0)
 	err = f.AppendData(context.Background(), []byte(" foo"))
 	if err != nil {
-		t.Fatalf("cannot append data: %v", err)
+		t.Fatalf(cannotAppendData, err)
 	}
-	validateFileSize(t, f1Name, HeaderLen+9)
+	validateFileSize(t, fPath, HeaderLen+9)
 	validateMeta(t, "3", f, 0, 8, 9, 0)
 	err = f.AppendData(context.Background(), []byte("\n"+makeData(20)))
 	if err != nil {
-		t.Fatalf("cannot append data: %v", err)
+		t.Fatalf(cannotAppendData, err)
 	}
-	validateFileSize(t, f1Name, HeaderLen+30)
+	validateFileSize(t, fPath, HeaderLen+30)
 	validateMeta(t, "4", f, 0, 29, 30, 0)
 
 	data120 := makeData(120)
 	err = f.AppendData(context.Background(), []byte(data120))
 	if err != nil {
-		t.Fatalf("cannot append data: %v", err)
+		t.Fatalf(cannotAppendData, err)
 	}
-	validateFileSize(t, f1Name, HeaderLen+100)
+	validateFileSize(t, fPath, HeaderLen+100)
 	validateMeta(t, "5", f, 0, 99, 100, 50)
 	err = f.AppendData(context.Background(), []byte("foo "))
 	if err != nil {
-		t.Fatalf("cannot append data: %v", err)
+		t.Fatalf(cannotAppendData, err)
 	}
-	validateFileSize(t, f1Name, HeaderLen+100)
+	validateFileSize(t, fPath, HeaderLen+100)
 	validateMeta(t, "6", f, 4, 3, 100, 54)
 
 	buf := make([]byte, 5)
 	realOffset, nr, err := f.ReadNext(context.Background(), buf, 0)
 	if err != nil {
-		t.Fatalf("cannot ReadNext: %v", err)
+		t.Fatalf(cannotReadNext, err)
 	}
 	if realOffset != 54 {
 		t.Fatalf("wrong realoffset got[%d] expected[%d]", realOffset, 54)
@@ -152,7 +173,7 @@ func TestFile(t *testing.T) {
 	}
 	realOffset, nr, err = f.ReadNext(context.Background(), buf, 60)
 	if err != nil {
-		t.Fatalf("cannot readnext: %v", err)
+		t.Fatalf(cannotReadNext, err)
 	}
 	if realOffset != 60 && nr != 5 {
 		t.Fatalf("invalid rtn realoffset[%d] nr[%d]", realOffset, nr)
@@ -171,13 +192,12 @@ func TestFile(t *testing.T) {
 }
 
 func TestFlock(t *testing.T) {
-	tempDir := t.TempDir()
-	f1Name := path.Join(tempDir, "f1.cf")
-	f, err := CreateCirFile(f1Name, 100)
+	const fName = "f1.cf"
+	f, fPath, err := createTestFile(t, fName)
 	if err != nil {
-		t.Fatalf("cannot create cirfile: %v", err)
+		t.Fatalf(cannotCreateCirFile, fPath, err)
 	}
-	fd2, err := os.OpenFile(f1Name, os.O_RDWR, 0777)
+	fd2, err := os.OpenFile(fPath, os.O_RDWR, 0777)
 	if err != nil {
 		t.Fatalf("cannot open file: %v", err)
 	}
@@ -195,7 +215,7 @@ func TestFlock(t *testing.T) {
 	if err != context.DeadlineExceeded {
 		t.Fatalf("readmeta should fail with context.DeadlineExceeded")
 	}
-	dur := time.Now().Sub(startTs)
+	dur := time.Since(startTs)
 	if dur < 20*time.Millisecond {
 		t.Fatalf("readmeta should take at least 20ms")
 	}
@@ -223,63 +243,103 @@ func TestFlock(t *testing.T) {
 	}
 }
 
+const writeAtError = "writeat error: %v"
+
 func TestWriteAt(t *testing.T) {
-	tempDir := t.TempDir()
-	f1Name := path.Join(tempDir, "f1.cf")
-	f, err := CreateCirFile(f1Name, 100)
+	const fName = "f1.cf"
+	f, fPath, err := createTestFile(t, fName)
 	if err != nil {
 		t.Fatalf("cannot create cirfile: %v", err)
 	}
-	err = f.WriteAt(nil, []byte("hello\nmike"), 4)
+	err = f.WriteAt(context.TODO(), []byte("hello\nmike"), 4)
 	if err != nil {
-		t.Fatalf("writeat error: %v", err)
+		t.Fatalf(writeAtError, err)
 	}
-	err = f.WriteAt(nil, []byte("t"), 2)
+	err = f.WriteAt(context.TODO(), []byte("t"), 2)
 	if err != nil {
-		t.Fatalf("writeat error: %v", err)
+		t.Fatalf(writeAtError, err)
 	}
-	err = f.WriteAt(nil, []byte("more"), 30)
+	err = f.WriteAt(context.TODO(), []byte("more"), 30)
 	if err != nil {
-		t.Fatalf("writeat error: %v", err)
+		t.Fatalf(writeAtError, err)
 	}
-	err = f.WriteAt(nil, []byte("\n"), 19)
+	err = f.WriteAt(context.TODO(), []byte("\n"), 19)
 	if err != nil {
-		t.Fatalf("writeat error: %v", err)
+		t.Fatalf(writeAtError, err)
 	}
-	dumpFile(f1Name)
-	err = f.WriteAt(nil, []byte("hello"), 200)
+	dumpFile(fPath)
+	err = f.WriteAt(context.TODO(), []byte("hello"), 200)
 	if err != nil {
-		t.Fatalf("writeat error: %v", err)
+		t.Fatalf(writeAtError, err)
 	}
 	buf := make([]byte, 10)
 	realOffset, nr, err := f.ReadNext(context.Background(), buf, 200)
 	if err != nil || realOffset != 200 || nr != 5 || string(buf[0:nr]) != "hello" {
 		t.Fatalf("invalid readnext: err[%v] realoffset[%d] nr[%d] buf[%s]", err, realOffset, nr, string(buf[0:nr]))
 	}
-	err = f.WriteAt(nil, []byte("0123456789\n"), 100)
+	err = f.WriteAt(context.TODO(), []byte("0123456789\n"), 100)
 	if err != nil {
-		t.Fatalf("writeat error: %v", err)
+		t.Fatalf(writeAtError, err)
 	}
-	dumpFile(f1Name)
+	dumpFile(fPath)
 	dataStr := makeData(200)
-	err = f.WriteAt(nil, []byte(dataStr), 50)
+	err = f.WriteAt(context.TODO(), []byte(dataStr), 50)
 	if err != nil {
-		t.Fatalf("writeat error: %v", err)
+		t.Fatalf(writeAtError, err)
 	}
-	dumpFile(f1Name)
+	dumpFile(fPath)
 
 	dataStr = makeData(1000)
-	err = f.WriteAt(nil, []byte(dataStr), 1002)
+	err = f.WriteAt(context.TODO(), []byte(dataStr), 1002)
 	if err != nil {
-		t.Fatalf("writeat error: %v", err)
+		t.Fatalf(writeAtError, err)
 	}
-	err = f.WriteAt(nil, []byte("hello\n"), 2010)
+	err = f.WriteAt(context.TODO(), []byte("hello\n"), 2010)
 	if err != nil {
-		t.Fatalf("writeat error: %v", err)
+		t.Fatalf(writeAtError, err)
 	}
-	err = f.AppendData(nil, []byte("foo\n"))
+	err = f.AppendData(context.TODO(), []byte("foo\n"))
 	if err != nil {
 		t.Fatalf("appenddata error: %v", err)
 	}
-	dumpFile(f1Name)
+	dumpFile(fPath)
+}
+
+func testOpenCirFile(t *testing.T, fileName string, shouldError bool) {
+	f, err := OpenCirFile(fileName)
+	if shouldError {
+		if err == nil {
+			t.Fatalf("should be an error opening file[%s]", fileName)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("error opening file[%s]: %v", fileName, err)
+	}
+	if f == nil {
+		t.Fatalf("nil file returned")
+	}
+}
+
+func TestOpenCirFile(t *testing.T) {
+	const noSuchFile = "no such file"
+	testOpenCirFile(t, noSuchFile, true)
+	testOpenCirFile(t, "testdata/empty.cf", true)
+	testOpenCirFile(t, "", true)
+	testOpenCirFile(t, filepath.Join(os.TempDir(), noSuchFile), true)
+	_, fPath, err := createTestFile(t, "f1.cf")
+	if err != nil {
+		t.Fatalf(cannotCreateCirFile, fPath, err)
+	}
+	testOpenCirFile(t, fPath, false)
+
+	waveHomeCirFileUuid := uuid.New().String()
+	waveHomeCirFilePath := path.Join(scbase.GetWaveHomeDir(), waveHomeCirFileUuid+".cf")
+	defer os.Remove(waveHomeCirFilePath)
+	testOpenCirFile(t, waveHomeCirFilePath, true)
+	_, err = CreateCirFile(waveHomeCirFilePath, 100)
+	if err != nil {
+		t.Fatalf(cannotCreateCirFile, waveHomeCirFilePath, err)
+	}
+	testOpenCirFile(t, waveHomeCirFilePath, false)
 }

--- a/waveshell/pkg/cirfile/cirfile_test.go
+++ b/waveshell/pkg/cirfile/cirfile_test.go
@@ -326,6 +326,8 @@ func TestOpenCirFile(t *testing.T) {
 	testOpenCirFile(t, noSuchFile, true)
 	testOpenCirFile(t, "testdata/empty.cf", true)
 	testOpenCirFile(t, "", true)
+
+	// Test whether we can open a file in the temp dir
 	testOpenCirFile(t, filepath.Join(os.TempDir(), noSuchFile), true)
 	_, fPath, err := createTestFile(t, "f1.cf")
 	if err != nil {
@@ -333,6 +335,17 @@ func TestOpenCirFile(t *testing.T) {
 	}
 	testOpenCirFile(t, fPath, false)
 
+	// Test whether we can open a file in the wave home dir
+	waveHomeDir := scbase.GetWaveHomeDir()
+	// this could happen on test agents
+	if waveHomeDir == "" {
+		userHomeDir, err := os.UserHomeDir()
+		if err != nil {
+			t.Fatalf("cannot get user home dir as fallback for missing waveHomeDir env var: %v", err)
+		}
+		os.Setenv(scbase.WaveHomeVarName, userHomeDir)
+		defer os.Unsetenv(scbase.WaveHomeVarName)
+	}
 	waveHomeCirFileUuid := uuid.New().String()
 	waveHomeCirFilePath := path.Join(scbase.GetWaveHomeDir(), waveHomeCirFileUuid+".cf")
 	defer os.Remove(waveHomeCirFilePath)

--- a/waveshell/pkg/cirfile/cirfile_test.go
+++ b/waveshell/pkg/cirfile/cirfile_test.go
@@ -205,11 +205,12 @@ func TestFlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot lock fd: %v", err)
 	}
-	err = f.AppendData(nil, []byte("hello"))
+	err = f.AppendData(context.TODO(), []byte("hello"))
 	if err != syscall.EWOULDBLOCK {
 		t.Fatalf("append should fail with EWOULDBLOCK")
 	}
-	timeoutCtx, _ := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelFn()
 	startTs := time.Now()
 	err = f.ReadMeta(timeoutCtx)
 	if err != context.DeadlineExceeded {
@@ -228,7 +229,7 @@ func TestFlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot flock: %v", err)
 	}
-	err = f.AppendData(nil, []byte("hello"))
+	err = f.AppendData(context.TODO(), []byte("hello"))
 	if err != syscall.EWOULDBLOCK {
 		t.Fatalf("append should fail with EWOULDBLOCK")
 	}
@@ -237,7 +238,7 @@ func TestFlock(t *testing.T) {
 		t.Fatalf("readmeta err (should work because LOCK_SH): %v", err)
 	}
 	fd2.Close()
-	err = f.AppendData(nil, []byte("hello"))
+	err = f.AppendData(context.TODO(), []byte("hello"))
 	if err != nil {
 		t.Fatalf("append error (should work fd2 was closed): %v", err)
 	}

--- a/waveshell/pkg/cirfile/cirfile_test.go
+++ b/waveshell/pkg/cirfile/cirfile_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -59,7 +58,7 @@ func makeData(size int) string {
 
 func testFilePath(t *testing.T, name string) string {
 	tempDir := t.TempDir()
-	return path.Join(tempDir, name)
+	return filepath.Join(tempDir, name)
 }
 
 func createTestFile(t *testing.T, name string) (*File, string, error) {
@@ -360,12 +359,12 @@ func TestValidateCirFilePath(t *testing.T) {
 	testValidateCirFilePath(t, "invalid.cf", true)
 
 	tempDir := t.TempDir()
-	testValidateCirFilePath(t, path.Join(tempDir, "no-such-file"), true)
-	testValidateCirFilePath(t, path.Join(tempDir, "should-succeed.cf"), false)
+	testValidateCirFilePath(t, filepath.Join(tempDir, "no-such-file"), true)
+	testValidateCirFilePath(t, filepath.Join(tempDir, "should-succeed.cf"), false)
 
 	waveHomeDir := getWaveHomeDir(t)
-	testValidateCirFilePath(t, path.Join(waveHomeDir, "no-such-file"), true)
-	testValidateCirFilePath(t, path.Join(waveHomeDir, "should-succeed.cf"), false)
+	testValidateCirFilePath(t, filepath.Join(waveHomeDir, "no-such-file"), true)
+	testValidateCirFilePath(t, filepath.Join(waveHomeDir, "should-succeed.cf"), false)
 
 }
 
@@ -387,7 +386,7 @@ func TestOpenCirFile(t *testing.T) {
 	// Test whether we can open a file in the wave home dir
 	waveHomeDir := getWaveHomeDir(t)
 	waveHomeCirFileUuid := uuid.New().String()
-	waveHomeCirFilePath := path.Join(waveHomeDir, waveHomeCirFileUuid+".cf")
+	waveHomeCirFilePath := filepath.Join(waveHomeDir, waveHomeCirFileUuid+".cf")
 	t.Cleanup(func() {
 		os.Remove(waveHomeCirFilePath)
 	})

--- a/waveshell/pkg/cirfile/cirfile_test.go
+++ b/waveshell/pkg/cirfile/cirfile_test.go
@@ -353,8 +353,8 @@ func getWaveHomeDir(t *testing.T) string {
 }
 
 func TestValidateCirFilePath(t *testing.T) {
-	testValidateCirFilePath(t, "testdata/empty.cf", true)
-	testValidateCirFilePath(t, "testdata/empty", true)
+	testValidateCirFilePath(t, "testdata/invalid.cf", true)
+	testValidateCirFilePath(t, "testdata/invalid", true)
 	testValidateCirFilePath(t, "", true)
 	testValidateCirFilePath(t, "invalid.cf", true)
 

--- a/waveshell/pkg/cirfile/cirfile_test.go
+++ b/waveshell/pkg/cirfile/cirfile_test.go
@@ -314,11 +314,58 @@ func testOpenCirFile(t *testing.T, fileName string, shouldError bool) {
 		return
 	}
 	if err != nil {
-		t.Fatalf("error opening file[%s]: %v", fileName, err)
+		t.Fatalf("unexpected error opening file[%s]: %v", fileName, err)
 	}
 	if f == nil {
 		t.Fatalf("nil file returned")
 	}
+}
+
+func testValidateCirFilePath(t *testing.T, fileName string, shouldError bool) {
+	err := ValidateCirFilePath(fileName)
+	if shouldError {
+		if err == nil {
+			t.Fatalf("should be an error validating cirfile path[%s]", fileName)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error validating cirfile path[%s]: %v", fileName, err)
+	}
+}
+
+// Get the wave home dir, creating the env var if necessary
+func getWaveHomeDir(t *testing.T) string {
+	// Test whether we can open a file in the wave home dir
+	waveHomeDir := scbase.GetWaveHomeDir()
+	// this could happen on test agents
+	if waveHomeDir == "" {
+		userHomeDir, err := os.UserHomeDir()
+		if err != nil {
+			t.Fatalf("cannot get user home dir as fallback for missing waveHomeDir env var: %v", err)
+		}
+		os.Setenv(scbase.WaveHomeVarName, userHomeDir)
+		t.Cleanup(func() {
+			os.Unsetenv(scbase.WaveHomeVarName)
+		})
+	}
+	return waveHomeDir
+}
+
+func TestValidateCirFilePath(t *testing.T) {
+	testValidateCirFilePath(t, "testdata/empty.cf", true)
+	testValidateCirFilePath(t, "testdata/empty", true)
+	testValidateCirFilePath(t, "", true)
+	testValidateCirFilePath(t, "invalid.cf", true)
+
+	tempDir := t.TempDir()
+	testValidateCirFilePath(t, path.Join(tempDir, "no-such-file"), true)
+	testValidateCirFilePath(t, path.Join(tempDir, "should-succeed.cf"), false)
+
+	waveHomeDir := getWaveHomeDir(t)
+	testValidateCirFilePath(t, path.Join(waveHomeDir, "no-such-file"), true)
+	testValidateCirFilePath(t, path.Join(waveHomeDir, "should-succeed.cf"), false)
+
 }
 
 func TestOpenCirFile(t *testing.T) {
@@ -326,6 +373,7 @@ func TestOpenCirFile(t *testing.T) {
 	testOpenCirFile(t, noSuchFile, true)
 	testOpenCirFile(t, "testdata/empty.cf", true)
 	testOpenCirFile(t, "", true)
+	testOpenCirFile(t, "invalid.cf", true)
 
 	// Test whether we can open a file in the temp dir
 	testOpenCirFile(t, filepath.Join(os.TempDir(), noSuchFile), true)
@@ -336,18 +384,9 @@ func TestOpenCirFile(t *testing.T) {
 	testOpenCirFile(t, fPath, false)
 
 	// Test whether we can open a file in the wave home dir
-	waveHomeDir := scbase.GetWaveHomeDir()
-	// this could happen on test agents
-	if waveHomeDir == "" {
-		userHomeDir, err := os.UserHomeDir()
-		if err != nil {
-			t.Fatalf("cannot get user home dir as fallback for missing waveHomeDir env var: %v", err)
-		}
-		os.Setenv(scbase.WaveHomeVarName, userHomeDir)
-		defer os.Unsetenv(scbase.WaveHomeVarName)
-	}
+	waveHomeDir := getWaveHomeDir(t)
 	waveHomeCirFileUuid := uuid.New().String()
-	waveHomeCirFilePath := path.Join(scbase.GetWaveHomeDir(), waveHomeCirFileUuid+".cf")
+	waveHomeCirFilePath := path.Join(waveHomeDir, waveHomeCirFileUuid+".cf")
 	defer os.Remove(waveHomeCirFilePath)
 	testOpenCirFile(t, waveHomeCirFilePath, true)
 	_, err = CreateCirFile(waveHomeCirFilePath, 100)


### PR DESCRIPTION
I've cleaned up some other linting warnings in `cirfile.go` and `cirfile_tests.go`, notably the use of nil contexts. I've worked to ensure that where file operations could indefinitely block a routine (such as not having a cancellation or timeout), we return EWOULDBLOCK.