### PR TITLE
Tabs freeze fix

### DIFF
--- a/src/app/workspace/screen/tabs.tsx
+++ b/src/app/workspace/screen/tabs.tsx
@@ -28,6 +28,7 @@ class ScreenTabs extends React.Component<
     scrollIntoViewTimeoutId = null;
     deltaYHistory = [];
     disposeScreensReaction = null;
+    debouncedHandleWheel: Function;
 
     constructor(props: any) {
         super(props);
@@ -58,8 +59,8 @@ class ScreenTabs extends React.Component<
 
         // Add the wheel event listener to the tabsRef
         if (this.tabsRef.current) {
-            let handleWheel = debounce(300, this.handleWheel);
-            this.tabsRef.current.addEventListener("wheel", handleWheel, { passive: false });
+            this.debouncedHandleWheel = debounce(300, this.handleWheel);
+            this.tabsRef.current.addEventListener("wheel", this.debouncedHandleWheel, { passive: false });
         }
     }
 
@@ -70,6 +71,10 @@ class ScreenTabs extends React.Component<
 
         if (this.disposeScreensReaction) {
             this.disposeScreensReaction(); // Clean up the reaction
+        }
+
+        if (this.tabsRef.current && this.debouncedHandleWheel) {
+            this.tabsRef.current.removeEventListener("wheel", this.debouncedHandleWheel);
         }
     }
 

--- a/src/app/workspace/screen/tabs.tsx
+++ b/src/app/workspace/screen/tabs.tsx
@@ -12,6 +12,7 @@ import { ReactComponent as AddIcon } from "../../assets/icons/add.svg";
 import * as constants from "../../appconst";
 import { Reorder } from "framer-motion";
 import { ScreenTab } from "./tab";
+import { debounce } from "throttle-debounce";
 
 import "./tabs.less";
 
@@ -57,7 +58,8 @@ class ScreenTabs extends React.Component<
 
         // Add the wheel event listener to the tabsRef
         if (this.tabsRef.current) {
-            this.tabsRef.current.addEventListener("wheel", this.handleWheel, { passive: false });
+            let handleWheel = debounce(300, this.handleWheel);
+            this.tabsRef.current.addEventListener("wheel", handleWheel, { passive: false });
         }
     }
 
@@ -152,11 +154,11 @@ class ScreenTabs extends React.Component<
 
         // Add the current deltaY to the history
         this.deltaYHistory.push(Math.abs(event.deltaY));
-        if (this.deltaYHistory.length > 5) {
+        if (this.deltaYHistory.length > 2) {
             this.deltaYHistory.shift(); // Keep only the last 5 entries
         }
 
-        // Check if any of the last 5 deltaY values are greater than a threshold
+        // Check if any of the last 2 deltaY values are greater than a threshold
         let isMouseWheel = this.deltaYHistory.some((deltaY) => deltaY > 0);
 
         if (isMouseWheel) {


### PR DESCRIPTION
Previously, when swiping rapidly through over a hundred tabs, ScreenTabs would freeze and become unusable. This patch fixes that issue.