### PR TITLE
Fix Commands that Require Quoted Paths

### DIFF
--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -546,12 +546,11 @@ function runWaveSrv() {
     if (isDev) {
         envCopy[WaveDevVarName] = "1";
     }
-    let wavePath = `"${getWaveSrvPath()}"`;
-    console.log("trying to run local server", wavePath);
-    let proc = child_process.spawn("bash", ["-c", wavePath], {
+    let waveSrvCmd = getWaveSrvCmd();
+    console.log("trying to run local server", waveSrvCmd);
+    let proc = child_process.spawn("bash", ["-c", waveSrvCmd], {
         cwd: getWaveSrvCwd(),
         env: envCopy,
-        windowsVerbatimArguments: true,
     });
     proc.on("exit", (e) => {
         console.log("wavesrv exit", e);

--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -556,7 +556,7 @@ function runWaveSrv() {
         console.log("wavesrv exit", e);
         waveSrvProc = null;
         sendWSSC();
-        pReject(new Error(sprintf("failed to start local server (%s)", wavePath)));
+        pReject(new Error(sprintf("failed to start local server (%s)", waveSrvCmd)));
         if (waveSrvShouldRestart) {
             waveSrvShouldRestart = false;
             this.runWaveSrv();

--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -140,7 +140,7 @@ function getWaveSrvCmd() {
     let waveSrvPath = getWaveSrvPath();
     let waveHome = getWaveHomeDir();
     let logFile = path.join(waveHome, "wavesrv.log");
-    return `${waveSrvPath} >> "${logFile}" 2>&1`;
+    return `"${waveSrvPath}" >> "${logFile}" 2>&1`;
 }
 
 function getWaveSrvCwd() {
@@ -535,8 +535,8 @@ function sendWSSC() {
 }
 
 function runWaveSrv() {
-    let pResolve = null;
-    let pReject = null;
+    let pResolve: (value: unknown) => void;
+    let pReject: (reason?: any) => void;
     let rtnPromise = new Promise((argResolve, argReject) => {
         pResolve = argResolve;
         pReject = argReject;
@@ -546,16 +546,18 @@ function runWaveSrv() {
     if (isDev) {
         envCopy[WaveDevVarName] = "1";
     }
-    console.log("trying to run local server", getWaveSrvPath());
-    let proc = child_process.spawn("bash", ["-c", getWaveSrvCmd()], {
+    let wavePath = `"${getWaveSrvPath()}"`;
+    console.log("trying to run local server", wavePath);
+    let proc = child_process.spawn("bash", ["-c", wavePath], {
         cwd: getWaveSrvCwd(),
         env: envCopy,
+        windowsVerbatimArguments: true,
     });
     proc.on("exit", (e) => {
         console.log("wavesrv exit", e);
         waveSrvProc = null;
         sendWSSC();
-        pReject(new Error(sprintf("failed to start local server (%s)", getWaveSrvPath())));
+        pReject(new Error(sprintf("failed to start local server (%s)", wavePath)));
         if (waveSrvShouldRestart) {
             waveSrvShouldRestart = false;
             this.runWaveSrv();

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/alessio/shellescape"
 	"github.com/armon/circbuf"
 	"github.com/creack/pty"
 	"github.com/google/uuid"
@@ -66,9 +67,9 @@ func MakeLocalMShellCommandStr(isSudo bool) (string, error) {
 		return "", err
 	}
 	if isSudo {
-		return fmt.Sprintf(`%s; sudo %s --server`, PrintPingPacket, mshellPath), nil
+		return fmt.Sprintf(`%s; sudo %s --server`, PrintPingPacket, shellescape.Quote(mshellPath)), nil
 	} else {
-		return fmt.Sprintf(`%s; %s --server`, PrintPingPacket, mshellPath), nil
+		return fmt.Sprintf(`%s; %s --server`, PrintPingPacket, shellescape.Quote(mshellPath)), nil
 	}
 }
 


### PR DESCRIPTION
Several commands did not wrap the path in quotes which caused problems when attempting to store the waveterm installation in a place that had a space in the path. This corrects this in the particular case where the username does not have spaces but the path to the executable does.

Note: the case of a user name having spaces has not been tested but likely does not work.