### PR TITLE
big update to screen/session delete, and clear

### DIFF
--- a/src/app/common/modals/settings.tsx
+++ b/src/app/common/modals/settings.tsx
@@ -39,13 +39,13 @@ const BUILD = __WAVETERM_BUILD__;
 const ScreenDeleteMessage = `
 Are you sure you want to delete this tab?
 
-All commands and output will be deleted, and removed from history.  To hide the tab, and retain the commands in history, use 'archive'.
+All commands and output will be deleted.  To hide the tab, and retain the commands and output, use 'archive'.
 `.trim();
 
 const SessionDeleteMessage = `
 Are you sure you want to delete this workspace?
 
-All commands and output will be deleted, and removed from history.  To hide the workspace, and retain the commands in history, use 'archive'.
+All commands and output will be deleted.  To hide the workspace, and retain the commands and output, use 'archive'.
 `.trim();
 
 const WebShareConfirmMarkdown = `
@@ -219,7 +219,7 @@ class ScreenSettingsModal extends React.Component<{}, {}> {
             return;
         }
         if (this.screen.getScreenLines().lines.length == 0) {
-            GlobalCommandRunner.screenPurge(this.screenId);
+            GlobalCommandRunner.screenDelete(this.screenId);
             GlobalModel.modalsModel.popModal();
             return;
         }
@@ -229,7 +229,7 @@ class ScreenSettingsModal extends React.Component<{}, {}> {
             if (!result) {
                 return;
             }
-            let prtn = GlobalCommandRunner.screenPurge(this.screenId);
+            let prtn = GlobalCommandRunner.screenDelete(this.screenId);
             commandRtnHandler(prtn, this.errorMessage);
             GlobalModel.modalsModel.popModal();
         });
@@ -439,7 +439,7 @@ class SessionSettingsModal extends React.Component<{}, {}> {
             if (!result) {
                 return;
             }
-            let prtn = GlobalCommandRunner.sessionPurge(this.sessionId);
+            let prtn = GlobalCommandRunner.sessionDelete(this.sessionId);
             commandRtnHandler(prtn, this.errorMessage, () => GlobalModel.modalsModel.popModal());
         });
     }

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -4339,8 +4339,8 @@ class CommandRunner {
         );
     }
 
-    screenPurge(screenId: string): Promise<CommandRtnType> {
-        return GlobalModel.submitCommand("screen", "purge", [screenId], { nohist: "1" }, false);
+    screenDelete(screenId: string): Promise<CommandRtnType> {
+        return GlobalModel.submitCommand("screen", "delete", [screenId], { nohist: "1" }, false);
     }
 
     screenWebShare(screenId: string, shouldShare: boolean): Promise<CommandRtnType> {
@@ -4469,8 +4469,8 @@ class CommandRunner {
         );
     }
 
-    sessionPurge(sessionId: string): Promise<CommandRtnType> {
-        return GlobalModel.submitCommand("session", "purge", [sessionId], { nohist: "1" }, false);
+    sessionDelete(sessionId: string): Promise<CommandRtnType> {
+        return GlobalModel.submitCommand("session", "delete", [sessionId], { nohist: "1" }, false);
     }
 
     sessionSetSettings(sessionId: string, settings: { name?: string }, interactive: boolean): Promise<CommandRtnType> {

--- a/wavesrv/db/migrations/000027_historyupdates.down.sql
+++ b/wavesrv/db/migrations/000027_historyupdates.down.sql
@@ -1,2 +1,6 @@
 ALTER TABLE history ADD COLUMN incognito boolean NOT NULL DEFAULT false;
-
+ALTER TABLE history DROP COLUMN exitcode;
+ALTER TABLE history DROP COLUMN durationms;
+ALTER TABLE history DROP COLUMN festate;
+ALTER TABLE history DROP COLUMN tags;
+ALTER TABLE history DROP COLUMN status;

--- a/wavesrv/db/migrations/000027_historyupdates.down.sql
+++ b/wavesrv/db/migrations/000027_historyupdates.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE history ADD COLUMN incognito boolean NOT NULL DEFAULT false;
+

--- a/wavesrv/db/migrations/000027_historyupdates.down.sql
+++ b/wavesrv/db/migrations/000027_historyupdates.down.sql
@@ -4,3 +4,7 @@ ALTER TABLE history DROP COLUMN durationms;
 ALTER TABLE history DROP COLUMN festate;
 ALTER TABLE history DROP COLUMN tags;
 ALTER TABLE history DROP COLUMN status;
+
+DROP TABLE session_tombstone;
+DROP TABLE screen_tombstone;
+

--- a/wavesrv/db/migrations/000027_historyupdates.up.sql
+++ b/wavesrv/db/migrations/000027_historyupdates.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE history DROP COLUMN incognito;
+

--- a/wavesrv/db/migrations/000027_historyupdates.up.sql
+++ b/wavesrv/db/migrations/000027_historyupdates.up.sql
@@ -22,4 +22,18 @@ UPDATE history
 SET status = 'done'
 WHERE lineid = '';
 
+CREATE TABLE session_tombstone (
+    sessionid varchar(36) PRIMARY KEY,
+    deletedts bigint NOT NULL,
+    name varchar(50) NOT NULL
+);
+
+CREATE TABLE screen_tombstone (
+    screenid varchar(36) PRIMARY KEY,
+    sessionid varchar(36) NOT NULL,
+    deletedts bigint NOT NULL,
+    screenopts json NOT NULL,
+    name varchar(50) NOT NULL
+);
+
 

--- a/wavesrv/db/migrations/000027_historyupdates.up.sql
+++ b/wavesrv/db/migrations/000027_historyupdates.up.sql
@@ -1,2 +1,25 @@
 ALTER TABLE history DROP COLUMN incognito;
+ALTER TABLE history ADD COLUMN exitcode int NULL DEFAULT NULL;
+ALTER TABLE history ADD COLUMN durationms int NULL DEFAULT NULL;
+ALTER TABLE history ADD COLUMN festate json NOT NULL DEFAULT '{}';
+ALTER TABLE history ADD COLUMN tags json NOT NULL DEFAULT '{}';
+ALTER TABLE history ADD COLUMN status varchar(10) NOT NULL DEFAULT 'unknown';
+
+UPDATE cmd
+SET festate = json_remove(festate, "$.PROMPTVAR_GITBRANCH")
+WHERE festate->>'PROMPTVAR_GITBRANCH' = '';
+
+UPDATE history
+SET exitcode = cmd.exitcode,
+    durationms = cmd.durationms,
+    festate = cmd.festate,
+    status = cmd.status
+FROM cmd
+WHERE history.screenid = cmd.screenid
+  AND history.lineid = cmd.lineid;
+
+UPDATE history
+SET status = 'done'
+WHERE lineid = '';
+
 

--- a/wavesrv/db/schema.sql
+++ b/wavesrv/db/schema.sql
@@ -56,7 +56,7 @@ CREATE TABLE remote (
     local boolean NOT NULL,
     archived boolean NOT NULL,
     remoteidx int NOT NULL
-, statevars json NOT NULL DEFAULT '{}', openaiopts json NOT NULL DEFAULT '{}');
+, statevars json NOT NULL DEFAULT '{}', openaiopts json NOT NULL DEFAULT '{}', sshconfigsrc varchar(36) NOT NULL DEFAULT 'waveterm-manual');
 CREATE TABLE history (
     historyid varchar(36) PRIMARY KEY,
     ts bigint NOT NULL,
@@ -70,8 +70,7 @@ CREATE TABLE history (
     haderror boolean NOT NULL,
     cmdstr text NOT NULL,
     ismetacmd boolean,
-    incognito boolean
-, linenum int NOT NULL DEFAULT 0);
+    linenum int NOT NULL DEFAULT 0, exitcode int NULL DEFAULT NULL, durationms int NULL DEFAULT NULL, festate json NOT NULL DEFAULT '{}', tags json NOT NULL DEFAULT '{}', status varchar(10) NOT NULL DEFAULT 'unknown');
 CREATE TABLE activity (
     day varchar(20) PRIMARY KEY,
     uploaded boolean NOT NULL,
@@ -210,4 +209,16 @@ CREATE TABLE cmd_migrate20 (
     lineid varchar(36) NOT NULL,
     cmdid varchar(36) NOT NULL,
     PRIMARY KEY (screenid, lineid)
+);
+CREATE TABLE session_tombstone (
+    sessionid varchar(36) PRIMARY KEY,
+    deletedts bigint NOT NULL,
+    name varchar(50) NOT NULL
+);
+CREATE TABLE screen_tombstone (
+    screenid varchar(36) PRIMARY KEY,
+    sessionid varchar(36) NOT NULL,
+    deletedts bigint NOT NULL,
+    screenopts json NOT NULL,
+    name varchar(50) NOT NULL
 );

--- a/wavesrv/db/schema.sql
+++ b/wavesrv/db/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE client (
     userpublickeybytes blob NOT NULL,
     userprivatekeybytes blob NOT NULL,
     winsize json NOT NULL
-, clientopts json NOT NULL DEFAULT '', feopts json NOT NULL DEFAULT '{}', cmdstoretype varchar(20) DEFAULT 'session', openaiopts json NOT NULL DEFAULT '{}');
+, clientopts json NOT NULL DEFAULT '', feopts json NOT NULL DEFAULT '{}', cmdstoretype varchar(20) DEFAULT 'session', openaiopts json NOT NULL DEFAULT '{}', releaseinfo json NOT NULL DEFAULT '{}');
 CREATE TABLE session (
     sessionid varchar(36) PRIMARY KEY,
     name varchar(50) NOT NULL,
@@ -146,7 +146,7 @@ CREATE TABLE IF NOT EXISTS "screen" (
     anchor json NOT NULL,
     focustype varchar(12) NOT NULL,
     archived boolean NOT NULL,
-    archivedts bigint NOT NULL, webshareopts json NOT NULL DEFAULT 'null',
+    archivedts bigint NOT NULL, webshareopts json NOT NULL DEFAULT 'null', screenviewopts json DEFAULT '{}',
     PRIMARY KEY (screenid)
 );
 CREATE TABLE IF NOT EXISTS "line" (
@@ -180,12 +180,6 @@ CREATE TABLE webptypos (
     PRIMARY KEY (screenid, lineid)
 );
 CREATE INDEX idx_screenupdate_ids ON screenupdate (screenid, lineid);
-CREATE TABLE cmd_migration (
-    screenid varchar(36) NOT NULL,
-    lineid varchar(36) NOT NULL,
-    cmdid varchar(36) NOT NULL,
-    PRIMARY KEY (screenid, lineid)
-);
 CREATE TABLE IF NOT EXISTS "cmd" (
     screenid varchar(36) NOT NULL,
     lineid varchar(36) NOT NULL,

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -163,7 +163,7 @@ func init() {
 	registerCmdFn("session:open", SessionOpenCommand)
 	registerCmdAlias("session:new", SessionOpenCommand)
 	registerCmdFn("session:set", SessionSetCommand)
-	registerCmdAlias("session:delete", SessionDeleteCommand)
+	registerCmdFn("session:delete", SessionDeleteCommand)
 	registerCmdFn("session:archive", SessionArchiveCommand)
 	registerCmdFn("session:showall", SessionShowAllCommand)
 	registerCmdFn("session:show", SessionShowCommand)

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -164,7 +164,6 @@ func init() {
 	registerCmdAlias("session:new", SessionOpenCommand)
 	registerCmdFn("session:set", SessionSetCommand)
 	registerCmdAlias("session:delete", SessionDeleteCommand)
-	registerCmdFn("session:purge", SessionDeleteCommand)
 	registerCmdFn("session:archive", SessionArchiveCommand)
 	registerCmdFn("session:showall", SessionShowAllCommand)
 	registerCmdFn("session:show", SessionShowCommand)
@@ -172,7 +171,7 @@ func init() {
 
 	registerCmdFn("screen", ScreenCommand)
 	registerCmdFn("screen:archive", ScreenArchiveCommand)
-	registerCmdFn("screen:purge", ScreenPurgeCommand)
+	registerCmdFn("screen:delete", ScreenDeleteCommand)
 	registerCmdFn("screen:open", ScreenOpenCommand)
 	registerCmdAlias("screen:new", ScreenOpenCommand)
 	registerCmdFn("screen:set", ScreenSetCommand)
@@ -201,7 +200,7 @@ func init() {
 	registerCmdFn("line:bookmark", LineBookmarkCommand)
 	registerCmdFn("line:pin", LinePinCommand)
 	registerCmdFn("line:archive", LineArchiveCommand)
-	registerCmdFn("line:purge", LinePurgeCommand)
+	registerCmdFn("line:delete", LineDeleteCommand)
 	registerCmdFn("line:setheight", LineSetHeightCommand)
 	registerCmdFn("line:view", LineViewCommand)
 	registerCmdFn("line:set", LineSetCommand)
@@ -640,6 +639,13 @@ func addToHistory(ctx context.Context, pk *scpacket.FeCommandPacketType, history
 		FeState:   historyContext.FeState,
 		Status:    historyContext.InitialStatus,
 	}
+	if hitem.Status == "" {
+		if hadError {
+			hitem.Status = sstore.CmdStatusError
+		} else {
+			hitem.Status = "done"
+		}
+	}
 	if !isMetaCmd && historyContext.RemotePtr != nil {
 		hitem.Remote = *historyContext.RemotePtr
 	}
@@ -753,23 +759,23 @@ func ScreenArchiveCommand(ctx context.Context, pk *scpacket.FeCommandPacketType)
 	}
 }
 
-func ScreenPurgeCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (sstore.UpdatePacket, error) {
+func ScreenDeleteCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (sstore.UpdatePacket, error) {
 	ids, err := resolveUiIds(ctx, pk, R_Session) // don't force R_Screen
 	if err != nil {
-		return nil, fmt.Errorf("/screen:purge cannot purge screen: %w", err)
+		return nil, fmt.Errorf("/screen:delete cannot delete screen: %w", err)
 	}
 	screenId := ids.ScreenId
 	if len(pk.Args) > 0 {
 		ri, err := resolveSessionScreen(ctx, ids.SessionId, pk.Args[0], ids.ScreenId)
 		if err != nil {
-			return nil, fmt.Errorf("/screen:purge cannot resolve screen arg: %v", err)
+			return nil, fmt.Errorf("/screen:delete cannot resolve screen arg: %v", err)
 		}
 		screenId = ri.Id
 	}
 	if screenId == "" {
-		return nil, fmt.Errorf("/screen:purge no active screen or screen arg passed")
+		return nil, fmt.Errorf("/screen:delete no active screen or screen arg passed")
 	}
-	update, err := sstore.PurgeScreen(ctx, screenId, false)
+	update, err := sstore.DeleteScreen(ctx, screenId, false)
 	if err != nil {
 		return nil, err
 	}
@@ -2309,19 +2315,19 @@ func SessionDeleteCommand(ctx context.Context, pk *scpacket.FeCommandPacketType)
 	if len(pk.Args) >= 1 {
 		ritem, err := resolveSession(ctx, pk.Args[0], ids.SessionId)
 		if err != nil {
-			return nil, fmt.Errorf("/session:purge error resolving session %q: %w", pk.Args[0], err)
+			return nil, fmt.Errorf("/session:delete error resolving session %q: %w", pk.Args[0], err)
 		}
 		if ritem == nil {
-			return nil, fmt.Errorf("/session:purge session %q not found", pk.Args[0])
+			return nil, fmt.Errorf("/session:delete session %q not found", pk.Args[0])
 		}
 		sessionId = ritem.Id
 	} else {
 		sessionId = ids.SessionId
 	}
 	if sessionId == "" {
-		return nil, fmt.Errorf("/session:purge no sessionid found")
+		return nil, fmt.Errorf("/session:delete no sessionid found")
 	}
-	update, err := sstore.PurgeSession(ctx, sessionId)
+	update, err := sstore.DeleteSession(ctx, sessionId)
 	if err != nil {
 		return nil, fmt.Errorf("cannot delete session: %v", err)
 	}
@@ -2545,18 +2551,18 @@ func ClearCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (sstore
 	if err != nil {
 		return nil, err
 	}
-	if resolveBool(pk.Kwargs["purge"], false) {
-		update, err := sstore.PurgeScreenLines(ctx, ids.ScreenId)
+	if resolveBool(pk.Kwargs["archive"], false) {
+		update, err := sstore.ArchiveScreenLines(ctx, ids.ScreenId)
 		if err != nil {
-			return nil, fmt.Errorf("clearing screen: %v", err)
+			return nil, fmt.Errorf("clearing screen (archiving): %v", err)
 		}
 		update.Info = &sstore.InfoMsgType{
-			InfoMsg:   fmt.Sprintf("screen cleared (all lines purged)"),
+			InfoMsg:   fmt.Sprintf("screen cleared (all lines archived)"),
 			TimeoutMs: 2000,
 		}
 		return update, nil
 	} else {
-		update, err := sstore.ArchiveScreenLines(ctx, ids.ScreenId)
+		update, err := sstore.DeleteScreenLines(ctx, ids.ScreenId)
 		if err != nil {
 			return nil, fmt.Errorf("clearing screen: %v", err)
 		}
@@ -2581,23 +2587,11 @@ func HistoryPurgeCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) 
 		}
 		historyIds = append(historyIds, historyArg)
 	}
-	historyItemsRemoved, err := sstore.PurgeHistoryByIds(ctx, historyIds)
+	err := sstore.PurgeHistoryByIds(ctx, historyIds)
 	if err != nil {
 		return nil, fmt.Errorf("/history:purge error purging items: %v", err)
 	}
-	update := &sstore.ModelUpdate{}
-	for _, historyItem := range historyItemsRemoved {
-		if historyItem.LineId == "" {
-			continue
-		}
-		lineObj := &sstore.LineType{
-			ScreenId: historyItem.ScreenId,
-			LineId:   historyItem.LineId,
-			Remove:   true,
-		}
-		update.Lines = append(update.Lines, lineObj)
-	}
-	return update, nil
+	return sstore.InfoMsgUpdate("removed history items"), nil
 }
 
 const HistoryViewPageSize = 50
@@ -2819,7 +2813,7 @@ func ScreenResizeCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) 
 }
 
 func LineCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (sstore.UpdatePacket, error) {
-	return nil, fmt.Errorf("/line requires a subcommand: %s", formatStrs([]string{"show", "star", "hide", "purge", "setheight", "set"}, "or", false))
+	return nil, fmt.Errorf("/line requires a subcommand: %s", formatStrs([]string{"show", "star", "hide", "delete", "setheight", "set"}, "or", false))
 }
 
 func LineSetHeightCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (sstore.UpdatePacket, error) {
@@ -3181,13 +3175,13 @@ func LineArchiveCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (
 	return &sstore.ModelUpdate{Line: lineObj}, nil
 }
 
-func LinePurgeCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (sstore.UpdatePacket, error) {
+func LineDeleteCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (sstore.UpdatePacket, error) {
 	ids, err := resolveUiIds(ctx, pk, R_Session|R_Screen)
 	if err != nil {
 		return nil, err
 	}
 	if len(pk.Args) == 0 {
-		return nil, fmt.Errorf("/line:purge requires at least one argument (line number or id)")
+		return nil, fmt.Errorf("/line:delete requires at least one argument (line number or id)")
 	}
 	var lineIds []string
 	for _, lineArg := range pk.Args {
@@ -3200,9 +3194,9 @@ func LinePurgeCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (ss
 		}
 		lineIds = append(lineIds, lineId)
 	}
-	err = sstore.PurgeLinesByIds(ctx, ids.ScreenId, lineIds)
+	err = sstore.DeleteLinesByIds(ctx, ids.ScreenId, lineIds)
 	if err != nil {
-		return nil, fmt.Errorf("/line:purge error purging lines: %v", err)
+		return nil, fmt.Errorf("/line:delete error purging lines: %v", err)
 	}
 	update := &sstore.ModelUpdate{}
 	for _, lineId := range lineIds {

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -624,10 +624,6 @@ func addToHistory(ctx context.Context, pk *scpacket.FeCommandPacketType, history
 	if err != nil {
 		return err
 	}
-	isIncognito, err := sstore.IsIncognitoScreen(ctx, ids.SessionId, ids.ScreenId)
-	if err != nil {
-		return fmt.Errorf("cannot add to history, error looking up incognito status of screen: %v", err)
-	}
 	hitem := &sstore.HistoryItemType{
 		HistoryId: scbase.GenWaveUUID(),
 		Ts:        time.Now().UnixMilli(),
@@ -639,7 +635,6 @@ func addToHistory(ctx context.Context, pk *scpacket.FeCommandPacketType, history
 		HadError:  hadError,
 		CmdStr:    cmdStr,
 		IsMetaCmd: isMetaCmd,
-		Incognito: isIncognito,
 	}
 	if !isMetaCmd && historyContext.RemotePtr != nil {
 		hitem.Remote = *historyContext.RemotePtr

--- a/wavesrv/pkg/dbutil/dbutil.go
+++ b/wavesrv/pkg/dbutil/dbutil.go
@@ -45,9 +45,29 @@ func QuickSetInt(ival *int, m map[string]interface{}, name string) {
 	}
 }
 
+func QuickSetNullableInt64(ival **int64, m map[string]any, name string) {
+	v, ok := m[name]
+	if !ok {
+		// set to nil
+		return
+	}
+	sqlInt64, ok := v.(int64)
+	if ok {
+		*ival = &sqlInt64
+		return
+	}
+	sqlInt, ok := v.(int)
+	if ok {
+		sqlInt64 = int64(sqlInt)
+		*ival = &sqlInt64
+		return
+	}
+}
+
 func QuickSetInt64(ival *int64, m map[string]interface{}, name string) {
 	v, ok := m[name]
 	if !ok {
+		// leave as zero
 		return
 	}
 	sqlInt64, ok := v.(int64)

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -2043,7 +2043,12 @@ func evalPromptEsc(escCode string, vars map[string]string, state *packet.ShellSt
 		if err != nil {
 			return escCode
 		}
-		return string([]byte{byte(ival)})
+		if ival >= 0 && ival <= 255 {
+			return string([]byte{byte(ival)})
+		} else {
+			// if it was out of range just return the string (invalid escape)
+			return escCode
+		}
 	}
 	if escCode == "e" {
 		return "\033"

--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -23,7 +23,7 @@ import (
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/scbase"
 )
 
-const HistoryCols = "h.historyid, h.ts, h.userid, h.sessionid, h.screenid, h.lineid, h.haderror, h.cmdstr, h.remoteownerid, h.remoteid, h.remotename, h.ismetacmd, h.incognito, h.linenum"
+const HistoryCols = "h.historyid, h.ts, h.userid, h.sessionid, h.screenid, h.lineid, h.haderror, h.cmdstr, h.remoteownerid, h.remoteid, h.remotename, h.ismetacmd, h.linenum"
 const DefaultMaxHistoryItems = 1000
 
 var updateWriterCVar = sync.NewCond(&sync.Mutex{})
@@ -220,16 +220,12 @@ func InsertHistoryItem(ctx context.Context, hitem *HistoryItemType) error {
 	}
 	txErr := WithTx(ctx, func(tx *TxWrap) error {
 		query := `INSERT INTO history 
-                  ( historyid, ts, userid, sessionid, screenid, lineid, haderror, cmdstr, remoteownerid, remoteid, remotename, ismetacmd, incognito, linenum) VALUES
-                  (:historyid,:ts,:userid,:sessionid,:screenid,:lineid,:haderror,:cmdstr,:remoteownerid,:remoteid,:remotename,:ismetacmd,:incognito,:linenum)`
+                  ( historyid, ts, userid, sessionid, screenid, lineid, haderror, cmdstr, remoteownerid, remoteid, remotename, ismetacmd, linenum) VALUES
+                  (:historyid,:ts,:userid,:sessionid,:screenid,:lineid,:haderror,:cmdstr,:remoteownerid,:remoteid,:remotename,:ismetacmd,:linenum)`
 		tx.NamedExec(query, hitem.ToMap())
 		return nil
 	})
 	return txErr
-}
-
-func IsIncognitoScreen(ctx context.Context, sessionId string, screenId string) (bool, error) {
-	return false, nil
 }
 
 const HistoryQueryChunkSize = 1000

--- a/wavesrv/pkg/sstore/migrate.go
+++ b/wavesrv/pkg/sstore/migrate.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 )
 
-const MaxMigration = 26
+const MaxMigration = 27
 const MigratePrimaryScreenVersion = 9
 const CmdScreenSpecialMigration = 13
 const CmdLineSpecialMigration = 20

--- a/wavesrv/pkg/sstore/sstore.go
+++ b/wavesrv/pkg/sstore/sstore.go
@@ -414,7 +414,6 @@ func (h *HistoryItemType) ToMap() map[string]interface{} {
 	rtn["remoteid"] = h.Remote.RemoteId
 	rtn["remotename"] = h.Remote.Name
 	rtn["ismetacmd"] = h.IsMetaCmd
-	rtn["incognito"] = h.Incognito
 	return rtn
 }
 
@@ -433,7 +432,6 @@ func (h *HistoryItemType) FromMap(m map[string]interface{}) bool {
 	quickSetBool(&h.IsMetaCmd, m, "ismetacmd")
 	quickSetStr(&h.HistoryNum, m, "historynum")
 	quickSetInt64(&h.LineNum, m, "linenum")
-	quickSetBool(&h.Incognito, m, "incognito")
 	return true
 }
 
@@ -588,7 +586,6 @@ type HistoryItemType struct {
 	CmdStr    string        `json:"cmdstr"`
 	Remote    RemotePtrType `json:"remote"`
 	IsMetaCmd bool          `json:"ismetacmd"`
-	Incognito bool          `json:"incognito,omitempty"`
 
 	// only for updates
 	Remove bool `json:"remove"`
@@ -709,7 +706,7 @@ func FeStateFromShellState(state *packet.ShellState) map[string]string {
 		rtn["VIRTUAL_ENV"] = envMap["VIRTUAL_ENV"]
 	}
 	for key, val := range envMap {
-		if strings.HasPrefix(key, "PROMPTVAR_") {
+		if strings.HasPrefix(key, "PROMPTVAR_") && rtn[key] != "" {
 			rtn[key] = val
 		}
 	}

--- a/wavesrv/pkg/sstore/sstore.go
+++ b/wavesrv/pkg/sstore/sstore.go
@@ -73,6 +73,7 @@ const (
 	CmdStatusError    = "error"
 	CmdStatusDone     = "done"
 	CmdStatusHangup   = "hangup"
+	CmdStatusUnknown  = "unknown" // used for history items where we don't have a status
 )
 
 const (
@@ -414,6 +415,11 @@ func (h *HistoryItemType) ToMap() map[string]interface{} {
 	rtn["remoteid"] = h.Remote.RemoteId
 	rtn["remotename"] = h.Remote.Name
 	rtn["ismetacmd"] = h.IsMetaCmd
+	rtn["exitcode"] = h.ExitCode
+	rtn["durationms"] = h.DurationMs
+	rtn["festate"] = quickJson(h.FeState)
+	rtn["tags"] = quickJson(h.Tags)
+	rtn["status"] = h.Status
 	return rtn
 }
 
@@ -432,6 +438,11 @@ func (h *HistoryItemType) FromMap(m map[string]interface{}) bool {
 	quickSetBool(&h.IsMetaCmd, m, "ismetacmd")
 	quickSetStr(&h.HistoryNum, m, "historynum")
 	quickSetInt64(&h.LineNum, m, "linenum")
+	dbutil.QuickSetNullableInt64(&h.ExitCode, m, "exitcode")
+	dbutil.QuickSetNullableInt64(&h.DurationMs, m, "durationms")
+	quickSetJson(&h.FeState, m, "festate")
+	quickSetJson(&h.Tags, m, "tags")
+	quickSetStr(&h.Status, m, "status")
 	return true
 }
 
@@ -576,23 +587,28 @@ type ScreenAnchorType struct {
 }
 
 type HistoryItemType struct {
-	HistoryId string        `json:"historyid"`
-	Ts        int64         `json:"ts"`
-	UserId    string        `json:"userid"`
-	SessionId string        `json:"sessionid"`
-	ScreenId  string        `json:"screenid"`
-	LineId    string        `json:"lineid"`
-	HadError  bool          `json:"haderror"`
-	CmdStr    string        `json:"cmdstr"`
-	Remote    RemotePtrType `json:"remote"`
-	IsMetaCmd bool          `json:"ismetacmd"`
+	HistoryId  string          `json:"historyid"`
+	Ts         int64           `json:"ts"`
+	UserId     string          `json:"userid"`
+	SessionId  string          `json:"sessionid"`
+	ScreenId   string          `json:"screenid"`
+	LineId     string          `json:"lineid"`
+	HadError   bool            `json:"haderror"`
+	CmdStr     string          `json:"cmdstr"`
+	Remote     RemotePtrType   `json:"remote"`
+	IsMetaCmd  bool            `json:"ismetacmd"`
+	ExitCode   *int64          `json:"exitcode,omitempty"`
+	DurationMs *int64          `json:"durationms,omitempty"`
+	FeState    FeStateType     `json:"festate,omitempty"`
+	Tags       map[string]bool `json:"tags,omitempty"`
+	LineNum    int64           `json:"linenum" dbmap:"-"`
+	Status     string          `json:"status"`
 
 	// only for updates
-	Remove bool `json:"remove"`
+	Remove bool `json:"remove" dbmap:"-"`
 
 	// transient (string because of different history orderings)
-	HistoryNum string `json:"historynum"`
-	LineNum    int64  `json:"linenum"`
+	HistoryNum string `json:"historynum" dbmap:"-"`
 }
 
 type HistoryQueryOpts struct {

--- a/wavesrv/pkg/sstore/sstore.go
+++ b/wavesrv/pkg/sstore/sstore.go
@@ -329,6 +329,14 @@ type SessionType struct {
 	Full   bool `json:"full,omitempty"`
 }
 
+type SessionTombstoneType struct {
+	SessionId string `json:"sessionid"`
+	Name      string `json:"name"`
+	DeletedTs int64  `json:"deletedts"`
+}
+
+func (SessionTombstoneType) UseDBMap() {}
+
 type SessionStatsType struct {
 	SessionId          string              `json:"sessionid"`
 	NumScreens         int                 `json:"numscreens"`
@@ -555,6 +563,16 @@ func (s *ScreenType) FromMap(m map[string]interface{}) bool {
 	quickSetInt64(&s.ArchivedTs, m, "archivedts")
 	return true
 }
+
+type ScreenTombstoneType struct {
+	ScreenId   string         `json:"screenid"`
+	SessionId  string         `json:"sessionid"`
+	Name       string         `json:"name"`
+	DeletedTs  int64          `json:"deletedts"`
+	ScreenOpts ScreenOptsType `json:"screenopts"`
+}
+
+func (ScreenTombstoneType) UseDBMap() {}
 
 const (
 	LayoutFull = "full"

--- a/wavesrv/pkg/sstore/updatebus.go
+++ b/wavesrv/pkg/sstore/updatebus.go
@@ -38,26 +38,28 @@ func (*PtyDataUpdate) UpdateType() string {
 func (pdu *PtyDataUpdate) Clean() {}
 
 type ModelUpdate struct {
-	Sessions         []*SessionType     `json:"sessions,omitempty"`
-	ActiveSessionId  string             `json:"activesessionid,omitempty"`
-	Screens          []*ScreenType      `json:"screens,omitempty"`
-	ScreenLines      *ScreenLinesType   `json:"screenlines,omitempty"`
-	Line             *LineType          `json:"line,omitempty"`
-	Lines            []*LineType        `json:"lines,omitempty"`
-	Cmd              *CmdType           `json:"cmd,omitempty"`
-	CmdLine          *utilfn.StrWithPos `json:"cmdline,omitempty"`
-	Info             *InfoMsgType       `json:"info,omitempty"`
-	ClearInfo        bool               `json:"clearinfo,omitempty"`
-	Remotes          []interface{}      `json:"remotes,omitempty"` // []*remote.RemoteState
-	History          *HistoryInfoType   `json:"history,omitempty"`
-	Interactive      bool               `json:"interactive"`
-	Connect          bool               `json:"connect,omitempty"`
-	MainView         string             `json:"mainview,omitempty"`
-	Bookmarks        []*BookmarkType    `json:"bookmarks,omitempty"`
-	SelectedBookmark string             `json:"selectedbookmark,omitempty"`
-	HistoryViewData  *HistoryViewData   `json:"historyviewdata,omitempty"`
-	ClientData       *ClientData        `json:"clientdata,omitempty"`
-	RemoteView       *RemoteViewType    `json:"remoteview,omitempty"`
+	Sessions          []*SessionType          `json:"sessions,omitempty"`
+	ActiveSessionId   string                  `json:"activesessionid,omitempty"`
+	Screens           []*ScreenType           `json:"screens,omitempty"`
+	ScreenLines       *ScreenLinesType        `json:"screenlines,omitempty"`
+	Line              *LineType               `json:"line,omitempty"`
+	Lines             []*LineType             `json:"lines,omitempty"`
+	Cmd               *CmdType                `json:"cmd,omitempty"`
+	CmdLine           *utilfn.StrWithPos      `json:"cmdline,omitempty"`
+	Info              *InfoMsgType            `json:"info,omitempty"`
+	ClearInfo         bool                    `json:"clearinfo,omitempty"`
+	Remotes           []interface{}           `json:"remotes,omitempty"` // []*remote.RemoteState
+	History           *HistoryInfoType        `json:"history,omitempty"`
+	Interactive       bool                    `json:"interactive"`
+	Connect           bool                    `json:"connect,omitempty"`
+	MainView          string                  `json:"mainview,omitempty"`
+	Bookmarks         []*BookmarkType         `json:"bookmarks,omitempty"`
+	SelectedBookmark  string                  `json:"selectedbookmark,omitempty"`
+	HistoryViewData   *HistoryViewData        `json:"historyviewdata,omitempty"`
+	ClientData        *ClientData             `json:"clientdata,omitempty"`
+	RemoteView        *RemoteViewType         `json:"remoteview,omitempty"`
+	ScreenTombstones  []*ScreenTombstoneType  `json:"screentombstones,omitempty"`
+	SessionTombstones []*SessionTombstoneType `json:"sessiontombstones,omitempty"`
 }
 
 func (*ModelUpdate) UpdateType() string {


### PR DESCRIPTION
* rename /session:purge and /screen:purge to /session:delete and /screen:delete
* clear and delete no longer removes history items
* enhance history table to store festate, exitcode, durationms, and status (as well as unused tags)
* create tombstone tables for session/screen
* history items are now standalone (they do not require a line to exist)
* removed unused "incognito" column from history
* by default "clear" now deletes lines (instead of archiving them), more in line with what people expect
* updated confirm messages for deletions