### PR TITLE
Fix scrollbar hide/show behavior

### DIFF
--- a/src/app/workspace/screen/tabs.less
+++ b/src/app/workspace/screen/tabs.less
@@ -244,11 +244,15 @@
         display: flex;
         flex-direction: row;
         align-items: center;
-        overflow-x: hidden;
+        overflow-x: scroll;
 
-        &:hover,
-        &:focus {
-            overflow-x: overlay;
+        &::-webkit-scrollbar-thumb,
+        &::-webkit-scrollbar-track {
+            display: none;
+        }
+
+        &:hover::-webkit-scrollbar-thumb {
+            display: block;
         }
 
         .screen-tab {
@@ -321,6 +325,7 @@
         cursor: pointer;
         display: flex;
         align-items: center;
+        height: 37px;
 
         .icon {
             height: 2rem;


### PR DESCRIPTION
Previously, hovering over the tabs caused the scrollbar to appear, pushing the screen view down. This update includes style changes to prevent this behavior, ensuring a more consistent and stable user interface experience.