### PR TITLE
Chat GPT Command Info Chat

### DIFF
--- a/src/app/common/common.less
+++ b/src/app/common/common.less
@@ -352,7 +352,7 @@
         background-color: @markdown-highlight;
         color: @term-white;
         font-family: @terminal-font;
-        display: inline-block;
+        border-radius: 4px;
     }
 
     code.inline {
@@ -403,6 +403,13 @@
         background-color: @markdown-highlight;
         margin: 4px 10px 4px 10px;
         padding: 6px 6px 6px 10px;
+        border-radius: 4px;
+    }
+    
+    pre.selected {
+        border-style: solid;
+        border-width:2px;
+        border-color: @term-green; 
     }
 
     .title.is-1 {

--- a/src/app/common/common.less
+++ b/src/app/common/common.less
@@ -408,7 +408,7 @@
     
     pre.selected {
         border-style: solid;
-        border-width:2px;
+        outline-width: 2px;
         border-color: @term-green; 
     }
 

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -11,6 +11,7 @@ import cn from "classnames";
 import { If } from "tsx-control-statements/components";
 import type { RemoteType } from "../../types/types";
 import ReactDOM from "react-dom";
+import { GlobalModel } from "../../model/model";
 
 import { ReactComponent as CheckIcon } from "../assets/icons/line/check.svg";
 import { ReactComponent as CopyIcon } from "../assets/icons/history/copy.svg";
@@ -823,14 +824,78 @@ function HeaderRenderer(props: any, hnum: number): any {
     return <div className={cn("title", "is-" + hnum)}>{props.children}</div>;
 }
 
-function CodeRenderer(props: any): any {
-    return <code className={cn({ inline: props.inline })}>{props.children}</code>;
-}
-
 @mobxReact.observer
-class Markdown extends React.Component<{ text: string; style?: any; extraClassName?: string }, {}> {
+class Markdown extends React.Component<{ text: string; style?: any; extraClassName?: string; codeSelect?: boolean}, {}> {
+    codeBlockList: Array<React.RefObject<HTMLElement>>    
+    codeSelectMarkdownID: number;
+
+    constructor(props: any) {
+        super(props);  
+        this.codeBlockList = [];
+        if(this.props.codeSelect) {
+            let model = GlobalModel;
+            let inputModel = model.inputModel; 
+            this.codeSelectMarkdownID = inputModel.registerCodeSelectMarkdown();   
+        }
+    }  
+
+   CodeRenderer(props: any, codeSelect: boolean): any { 
+        let codeText = props.children;
+        if(codeText) {
+            codeText = codeText.replace(/\n$/, "") // remove trailing newline        
+        }
+        let blockRef: React.RefObject<HTMLElement> = React.createRef();
+        let clickHandler: (e: React.MouseEvent<HTMLElement>, blockIndex: number) => void;
+        let curBlockIndex: number;
+        if(codeSelect) {
+            let model = GlobalModel;
+            let inputModel = model.inputModel;
+            curBlockIndex = inputModel.addCodeBlockToCodeSelect(blockRef, this.codeSelectMarkdownID);
+            clickHandler = (e: React.MouseEvent<HTMLElement>, blockIndex: number) => {
+                inputModel.setCodeSelectSelectedCodeBlock(blockIndex, this.codeSelectMarkdownID);
+            };
+        } else {
+            clickHandler = (e: React.MouseEvent<HTMLElement>, blockIndex: number) => {
+                navigator.clipboard.writeText(codeText);
+            };
+            curBlockIndex = this.addCodeBlockToList(blockRef);
+        }
+        return (
+            <code className={cn({ inline: props.inline})} ref={blockRef} onClick={(event) => clickHandler(event, curBlockIndex)}>{props.children}</code>
+        )
+    
+    }
+    
+    setSelectedCodeBlock(selectIndex: number) {
+        for(let index = 0; index < this.codeBlockList.length; index++) {
+            let curBlockRef = this.codeBlockList[index];
+            if(curBlockRef != null && curBlockRef.current != null) {
+                if(index == selectIndex) {
+                    curBlockRef.current.style.background = "yellow";
+                } else {
+                    curBlockRef.current.style.background = "";
+                }
+            }
+        }  
+    }
+     
+    getCodeBlockWithIndex(index: number): React.RefObject<HTMLElement> {
+        if(index >= 0 && index < this.codeBlockList.length) {
+            return this.codeBlockList[index];
+        }
+        return null;
+    }
+    
+    addCodeBlockToList(ref: React.RefObject<HTMLElement>): number {
+        let rtn = this.codeBlockList.length;
+        this.codeBlockList.push(ref)  
+        return rtn;
+    }
+
     render() {
         let text = this.props.text;
+        let codeSelect = this.props.codeSelect;
+        console.log("codeSelect value: ", codeSelect);
         let markdownComponents = {
             a: LinkRenderer,
             h1: (props) => HeaderRenderer(props, 1),
@@ -839,7 +904,7 @@ class Markdown extends React.Component<{ text: string; style?: any; extraClassNa
             h4: (props) => HeaderRenderer(props, 4),
             h5: (props) => HeaderRenderer(props, 5),
             h6: (props) => HeaderRenderer(props, 6),
-            code: CodeRenderer,
+            code: (props) => this.CodeRenderer(props, codeSelect),
         };
         return (
             <div className={cn("markdown content", this.props.extraClassName)} style={this.props.style}>

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -837,7 +837,6 @@ class CodeBlockMarkdown extends React.Component< {children: React.ReactNode, blo
         super(props);
         this.blockRef = React.createRef();
         this.blockIndex = GlobalModel.inputModel.addCodeBlockToCodeSelect(this.blockRef);
-        console.log("currentl block index: ", this.blockIndex);
     }
     
     render() {

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -824,57 +824,67 @@ function HeaderRenderer(props: any, hnum: number): any {
     return <div className={cn("title", "is-" + hnum)}>{props.children}</div>;
 }
 
-function CodeRenderer(props:any): any {
+function CodeRenderer(props: any): any {
     return <code className={cn({ inline: props.inline })}>{props.children}</code>;
 }
 
 @mobxReact.observer
-class CodeBlockMarkdown extends React.Component< {children: React.ReactNode, blockText: string, codeSelectSelectedIndex?: number}, {}> {
+class CodeBlockMarkdown extends React.Component<
+    { children: React.ReactNode; blockText: string; codeSelectSelectedIndex?: number },
+    {}
+> {
     blockIndex: number;
-    blockRef: React.RefObject<HTMLPreElement>
-    
-    constructor(props) { 
+    blockRef: React.RefObject<HTMLPreElement>;
+
+    constructor(props) {
         super(props);
         this.blockRef = React.createRef();
         this.blockIndex = GlobalModel.inputModel.addCodeBlockToCodeSelect(this.blockRef);
     }
-    
+
     render() {
-        let codeText = this.props.blockText; 
+        let codeText = this.props.blockText;
         let clickHandler: (e: React.MouseEvent<HTMLElement>, blockIndex: number) => void;
         let inputModel = GlobalModel.inputModel;
         clickHandler = (e: React.MouseEvent<HTMLElement>, blockIndex: number) => {
             inputModel.setCodeSelectSelectedCodeBlock(blockIndex);
-        };        
+        };
         let selected = this.blockIndex == this.props.codeSelectSelectedIndex;
         return (
-            <pre ref={this.blockRef} className={cn({"selected": selected})} onClick={(event) => clickHandler(event, this.blockIndex)}>{this.props.children}</pre>
-        )
-    } 
+            <pre
+                ref={this.blockRef}
+                className={cn({ selected: selected })}
+                onClick={(event) => clickHandler(event, this.blockIndex)}
+            >
+                {this.props.children}
+            </pre>
+        );
+    }
 }
 
 @mobxReact.observer
-class Markdown extends React.Component<{ text: string; style?: any; extraClassName?: string; codeSelect?: boolean}, {}> {
-
-    CodeBlockRenderer(props: any, codeSelect: boolean, codeSelectIndex: number): any { 
+class Markdown extends React.Component<
+    { text: string; style?: any; extraClassName?: string; codeSelect?: boolean },
+    {}
+> {
+    CodeBlockRenderer(props: any, codeSelect: boolean, codeSelectIndex: number): any {
         let codeText = codeSelect ? props.node.children[0].children[0].value : props.children;
-        if(codeText) {
-            codeText = codeText.replace(/\n$/, "") // remove trailing newline        
+        if (codeText) {
+            codeText = codeText.replace(/\n$/, ""); // remove trailing newline
         }
-        if(codeSelect) {
+        if (codeSelect) {
             return (
-                <CodeBlockMarkdown blockText={codeText} codeSelectSelectedIndex={codeSelectIndex}>{props.children}</CodeBlockMarkdown>
-            )
+                <CodeBlockMarkdown blockText={codeText} codeSelectSelectedIndex={codeSelectIndex}>
+                    {props.children}
+                </CodeBlockMarkdown>
+            );
         } else {
             let clickHandler = (e: React.MouseEvent<HTMLElement>) => {
                 navigator.clipboard.writeText(codeText);
             };
-            return (
-                <pre onClick={(event) => clickHandler(event)}>{props.children}</pre>
-            )
+            return <pre onClick={(event) => clickHandler(event)}>{props.children}</pre>;
         }
-    
-    } 
+    }
 
     render() {
         let text = this.props.text;
@@ -888,8 +898,8 @@ class Markdown extends React.Component<{ text: string; style?: any; extraClassNa
             h4: (props) => HeaderRenderer(props, 4),
             h5: (props) => HeaderRenderer(props, 5),
             h6: (props) => HeaderRenderer(props, 6),
-            code: (props) => CodeRenderer(props), 
-            pre: (props) => this.CodeBlockRenderer(props, codeSelect, curCodeSelectIndex), 
+            code: (props) => CodeRenderer(props),
+            pre: (props) => this.CodeBlockRenderer(props, codeSelect, curCodeSelectIndex),
         };
         return (
             <div className={cn("markdown content", this.props.extraClassName)} style={this.props.style}>

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -895,7 +895,6 @@ class Markdown extends React.Component<{ text: string; style?: any; extraClassNa
     render() {
         let text = this.props.text;
         let codeSelect = this.props.codeSelect;
-        console.log("codeSelect value: ", codeSelect);
         let markdownComponents = {
             a: LinkRenderer,
             h1: (props) => HeaderRenderer(props, 1),

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -110,15 +110,16 @@ class AIChat extends React.Component<{}, {}> {
                     return;
                 }
                 e.preventDefault();
-                inputModel.codeSelectIncrementCodeBlock();
+                inputModel.codeSelectSelectNextOldestCodeBlock();
                 resetCodeSelect = false;
             }
             if(e.code == "ArrowDown") {
-                if(inputModel.getCodeSelectSelectedIndex() == -1) {
+                if(inputModel.getCodeSelectSelectedIndex() == inputModel.codeSelectBottom) {
+                    console.log("code select index is -1, returning");
                     return; 
                 }
                 e.preventDefault();
-                inputModel.codeSelectDecrementCodeBlock();
+                inputModel.codeSelectSelectNextNewestCodeBlock();
                 resetCodeSelect = false;
             }
             
@@ -135,8 +136,8 @@ class AIChat extends React.Component<{}, {}> {
         return (
                 <div className="chat-msg-error">{err}</div>
         );
-
     }
+    
     
     renderChatMessage(chatItem: OpenAICmdInfoChatMessageType): any {
         let curKey = "chatmsg-" + (this.chatListKeyCount);
@@ -144,14 +145,26 @@ class AIChat extends React.Component<{}, {}> {
         let senderClassName = chatItem.isassistantresponse ? "chat-msg-assistant" : "chat-msg-user";
         let msgClassName = "chat-msg " + senderClassName;
         let innerHTML: React.JSX.Element = (
-            <p style={{whiteSpace:'pre-wrap'}}>{chatItem.userquery}</p>
+            <span>
+                <span style = {{display:"flex"}}>
+                    <i className="fa-sharp fa-solid fa-user" style={{marginRight:"5px", marginTop:"1px"}}></i>
+                    <p style={{marginRight:"5px"}}>You</p>
+                </span>
+                <p className="msg-text">{chatItem.userquery}</p>
+            </span>
         );
         if(chatItem.isassistantresponse) {
             if(chatItem.assistantresponse.error != null && chatItem.assistantresponse.error != "") {
                 innerHTML = this.renderError(chatItem.assistantresponse.error);
             } else {
                 innerHTML = (
-                    <Markdown text={chatItem.assistantresponse.message} codeSelect/> 
+                    <span>
+                        <span style = {{display:"flex"}}>
+                            <i className= "fa-sharp fa-solid fa-headset" style={{marginRight:"5px", marginTop:"1px"}}></i>
+                            <p style={{marginRight:"5px"}}>ChatGPT</p>
+                        </span>
+                        <Markdown text={chatItem.assistantresponse.message} codeSelect/> 
+                    </span>
                 );
             }
         }         

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -36,7 +36,7 @@ class AIChat extends React.Component<{}, {}> {
         }
         if (this.textAreaRef.current != null) {
             this.textAreaRef.current.focus();
-            inputModel.setCmdInfoChatTextAreaRef(this.textAreaRef);
+            inputModel.setCmdInfoChatTextAreaRef(this.textAreaRef)
         }
         this.requestChatUpdate();
     }       
@@ -164,6 +164,7 @@ class AIChat extends React.Component<{}, {}> {
                     onKeyDown={this.onKeyDown}
                     style={{height: textAreaInnerHeight, maxHeight: textAreaMaxHeight, fontSize: termFontSize }}
                     className={cn("chat-textarea")}
+                    placeholder="Send a Message to ChatGPT..."
                 ></textarea>
             </div>
 

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -135,6 +135,13 @@ class AIChat extends React.Component<{}, {}> {
         })()
     }
     
+    renderError(err: string): any {
+        return (
+                <div className="chat-msg-error">{err}</div>
+        );
+
+    }
+    
     renderChatMessage(chatItem: OpenAICmdInfoChatMessageType): any {
         let curKey = "chatmsg-" + (this.chatListKeyCount);
         this.chatListKeyCount++;
@@ -143,10 +150,15 @@ class AIChat extends React.Component<{}, {}> {
         let innerHTML: React.JSX.Element = (
             <p style={{whiteSpace:'pre-wrap'}}>{chatItem.userquery}</p>
         );
+        console.log(chatItem);
         if(chatItem.isassistantresponse) {
-            innerHTML = (
-                <Markdown text={chatItem.assistantresponse.message} codeSelect/> 
-            );
+            if(chatItem.assistantresponse.error != null && chatItem.assistantresponse.error != "") {
+                innerHTML = this.renderError(chatItem.assistantresponse.error);
+            } else {
+                innerHTML = (
+                    <Markdown text={chatItem.assistantresponse.message} codeSelect/> 
+                );
+            }
         }         
 
         return(

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -36,7 +36,7 @@ class AIChat extends React.Component<{}, {}> {
         }
         if (this.textAreaRef.current != null) {
             this.textAreaRef.current.focus();
-            inputModel.setCmdInfoChatTextAreaRef(this.textAreaRef)
+            inputModel.setCmdInfoChatRefs(this.textAreaRef, this.chatWindowScrollRef)
         }
         this.requestChatUpdate();
     }       
@@ -57,9 +57,7 @@ class AIChat extends React.Component<{}, {}> {
         let curLine = inputModel.getCurLine();
         let prtn = GlobalModel.submitChatInfoCommand(messageStr, curLine, false);
         prtn.then((rtn) => {
-            if(rtn.success) {
-                console.log("submit chat command success");
-            } else {
+            if(!rtn.success) {
                 console.log("submit chat command error: " + rtn.error);
             }
         })
@@ -87,7 +85,6 @@ class AIChat extends React.Component<{}, {}> {
                 if (!ctrlMod) { 
                     if(inputModel.getCodeSelectSelectedIndex() == -1) {
                         let messageStr = e.target.value;
-                        console.log("target value?:", messageStr);
                         this.submitChatMessage(messageStr);
                         e.target.value = "";
                     } else {
@@ -95,7 +92,6 @@ class AIChat extends React.Component<{}, {}> {
                     }
                 } else {
                     e.target.setRangeText("\n", e.target.selectionStart, e.target.selectionEnd, "end");
-                    console.log("shift enter - target value: ", e.target.value);
                 }
             }
             if (e.code == "Escape") {
@@ -150,7 +146,6 @@ class AIChat extends React.Component<{}, {}> {
         let innerHTML: React.JSX.Element = (
             <p style={{whiteSpace:'pre-wrap'}}>{chatItem.userquery}</p>
         );
-        console.log(chatItem);
         if(chatItem.isassistantresponse) {
             if(chatItem.assistantresponse.error != null && chatItem.assistantresponse.error != "") {
                 innerHTML = this.renderError(chatItem.assistantresponse.error);

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -11,46 +11,92 @@ import cn from "classnames";
 import { Prompt } from "../../common/prompt/prompt";
 import { TextAreaInput } from "./textareainput";
 import { If, For } from "tsx-control-statements/components";
+import type {OpenAICmdInfoChatMessageType} from "../../../types/types"
+import { Markdown } from "../../common/common";
+
 
 @mobxReact.observer
 class AIChat extends React.Component<{}, {}> {
+    chatListKeyCount: number = 0;
+    textAreaNumLines: mobx.IObservableValue<number> = mobx.observable.box(1, {name: "textAreaNumLines"});
+    chatWindowScrollRef: React.RefObject<HTMLDivElement>;
+
+    constructor(props: any) {
+        super(props);
+        this.chatWindowScrollRef = React.createRef();
+    }
 
     componentDidMount() {
     }       
 
-    @boundMethod
-    handleInnerHeightUpdate(): void {
+    componentDidUpdate() {
+        if(this.chatWindowScrollRef != null && this.chatWindowScrollRef.current != null){
+            this.chatWindowScrollRef.current.scrollTop = this.chatWindowScrollRef.current.scrollHeight;
+        } 
+    }
+
+    submitChatMessage(messageStr: string) {
+        let chatCommand = "/chat " + messageStr;
+        let prtn = GlobalModel.submitChatInfoCommand(chatCommand);
+        prtn.then((rtn) => {
+            if(rtn.success) {
+                console.log("submit chat command success");
+            } else {
+                console.log("submit chat command error: " + rtn.error);
+            }
+        })
+        .catch((error) => {
+        });
     }
 
     @mobx.action
     @boundMethod
     onKeyDown(e: any) {
-        console.log("mk1");
-        let model = GlobalModel;
-        let inputModel = model.inputModel;
-        let ctrlMod = e.getModifierState("Control") || e.getModifierState("Meta") || e.getModifierState("Shift");
-
-        if (e.code == "Enter") {
-            console.log("hello");
-            e.preventDefault();
-            if (!ctrlMod) { 
-                inputModel.addAIChatMessage(e.target.value);
-                console.log("target value?:", e.target.value);
-                e.target.value = "";
-                return;
+        mobx.action(() => {
+            let model = GlobalModel;
+            let inputModel = model.inputModel;
+            let ctrlMod = e.getModifierState("Control") || e.getModifierState("Meta") || e.getModifierState("Shift");
+            
+            if (e.code == "Enter") {
+                e.preventDefault();
+                if (!ctrlMod) { 
+                    let messageStr = e.target.value;
+                    console.log("target value?:", messageStr);
+                    this.submitChatMessage(messageStr);
+                    e.target.value = "";
+                } else {
+                    e.target.setRangeText("\n", e.target.selectionStart, e.target.selectionEnd, "end");
+                    console.log("shift enter - target value: ", e.target.value);
+                }
             }
-            e.target.setRangeText("\n", e.target.selectionStart, e.target.selectionEnd, "end");
-            console.log("shift enter - target value: ", e.target.value);
-            return;
-        }            
+            if (e.code == "Escape") {
+                e.preventDefault();
+                e.stopPropagation();
+                inputModel.closeAIAssistantChat();
+            }
+
+            // set height of textarea based on number of newlines
+            this.textAreaNumLines.set(e.target.value.split(/\n/).length); 
+        })()
     }
     
-    /*
-    
-    renderChatMessage(messageStr: string): any {
+    renderChatMessage(chatItem: OpenAICmdInfoChatMessageType): any {
+        let curKey = "chatmsg-" + (this.chatListKeyCount);
+        this.chatListKeyCount++;
+        let senderClassName = chatItem.isassistantresponse ? "chat-msg-assistant" : "chat-msg-user";
+        let msgClassName = "chat-msg " + senderClassName;
+        let innerHTML: React.JSX.Element = (
+            <p>{chatItem.userquery}</p>
+        );
+        if(chatItem.isassistantresponse) {
+            innerHTML = (
+                <Markdown text={chatItem.assistantresponse.message} /> 
+            );
+        }         
+
         return(
-            <div key={messageStr}>
-                {messageStr}
+            <div className={msgClassName} key={curKey}> 
+                {innerHTML}
             </div>
         );
 
@@ -59,10 +105,10 @@ class AIChat extends React.Component<{}, {}> {
     renderChatWindow(): any { 
         let model = GlobalModel;
         let inputModel = model.inputModel;
-        let chatMessageItems = inputModel.AIChatItems;
-        let chitem: string = null;
+        let chatMessageItems = inputModel.AICmdInfoChatItems.slice();
+        let chitem: OpenAICmdInfoChatMessageType = null;
         return (
-            <div> 
+            <div className="chat-window" ref={this.chatWindowScrollRef}> 
                 <For each="chitem" index="idx" of={chatMessageItems}>
                     {this.renderChatMessage(chitem)}
                 </For>
@@ -70,31 +116,31 @@ class AIChat extends React.Component<{}, {}> {
         );
 
     }
-    */
+    
 
     render() {
         let model = GlobalModel;
         let inputModel = model.inputModel;
 
-        let displayLines = 1;
-        let termFontSize = 14;
-        // fontSize*1.5 (line-height) + 2 * 0.5em padding
-        let computedInnerHeight = displayLines * (termFontSize * 1.5) + 2 * 0.5 * termFontSize;
-        // inner height + 2*1em padding
-        let computedOuterHeight = computedInnerHeight + 2 * 1.0 * termFontSize;
+        const termFontSize = 14;
+        const textAreaMaxLines = 4;
+        const textAreaLineHeight = (termFontSize * 1.5);
+        const textAreaPadding = 2 * 0.5 * termFontSize;
+        let textAreaMaxHeight = textAreaLineHeight * textAreaMaxLines + textAreaPadding;
+        let textAreaInnerHeight = this.textAreaNumLines.get() * textAreaLineHeight + textAreaPadding;
+        
         return (
-            <div className = "cmd-input-field">
-                <div className="control is-expanded" style={{ height: computedOuterHeight }} >
-                    <textarea
-                        key="main"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        id="main-cmd-input"
-                        onKeyDown={this.onKeyDown}
-                        style={{ height: computedInnerHeight, minHeight: computedInnerHeight, fontSize: termFontSize }}
-                        className={cn("textarea")}
-                    ></textarea>
-                </div>
+            <div className = "cmd-aichat">
+                {this.renderChatWindow()}
+                <textarea
+                    key="main"
+                    autoComplete="off"
+                    autoCorrect="off"
+                    id="chat-cmd-input"
+                    onKeyDown={this.onKeyDown}
+                    style={{height: textAreaInnerHeight, maxHeight: textAreaMaxHeight, fontSize: termFontSize }}
+                    className={cn("chat-textarea")}
+                ></textarea>
             </div>
 
         );

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -27,6 +27,10 @@ class AIChat extends React.Component<{}, {}> {
     }
 
     componentDidMount() {
+        if(this.chatWindowScrollRef != null && this.chatWindowScrollRef.current != null){
+            this.chatWindowScrollRef.current.scrollTop = this.chatWindowScrollRef.current.scrollHeight;
+        }  
+        this.requestChatUpdate();
     }       
 
     componentDidUpdate() {
@@ -34,10 +38,17 @@ class AIChat extends React.Component<{}, {}> {
             this.chatWindowScrollRef.current.scrollTop = this.chatWindowScrollRef.current.scrollHeight;
         } 
     }
+    
+    requestChatUpdate() {
+        this.submitChatMessage("");
+    }
 
     submitChatMessage(messageStr: string) {
+        let model = GlobalModel;
+        let inputModel = model.inputModel;
+        let curLine = inputModel.getCurLine();
         let chatCommand = "/chat " + messageStr;
-        let prtn = GlobalModel.submitChatInfoCommand(chatCommand);
+        let prtn = GlobalModel.submitChatInfoCommand(chatCommand, curLine);
         prtn.then((rtn) => {
             if(rtn.success) {
                 console.log("submit chat command success");

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -115,7 +115,6 @@ class AIChat extends React.Component<{}, {}> {
             }
             if(e.code == "ArrowDown") {
                 if(inputModel.getCodeSelectSelectedIndex() == inputModel.codeSelectBottom) {
-                    console.log("code select index is -1, returning");
                     return; 
                 }
                 e.preventDefault();

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -29,11 +29,14 @@ class AIChat extends React.Component<{}, {}> {
     }
 
     componentDidMount() {
+        let model = GlobalModel;
+        let inputModel = model.inputModel;
         if(this.chatWindowScrollRef != null && this.chatWindowScrollRef.current != null){
             this.chatWindowScrollRef.current.scrollTop = this.chatWindowScrollRef.current.scrollHeight;
         }
         if (this.textAreaRef.current != null) {
             this.textAreaRef.current.focus();
+            inputModel.setCmdInfoChatTextAreaRef(this.textAreaRef);
         }
         this.requestChatUpdate();
     }       
@@ -52,8 +55,7 @@ class AIChat extends React.Component<{}, {}> {
         let model = GlobalModel;
         let inputModel = model.inputModel;
         let curLine = inputModel.getCurLine();
-        let chatCommand = "/chat " + messageStr;
-        let prtn = GlobalModel.submitChatInfoCommand(chatCommand, curLine);
+        let prtn = GlobalModel.submitChatInfoCommand(messageStr, curLine, false);
         prtn.then((rtn) => {
             if(rtn.success) {
                 console.log("submit chat command success");
@@ -90,6 +92,11 @@ class AIChat extends React.Component<{}, {}> {
                 e.stopPropagation();
                 inputModel.closeAIAssistantChat();
             }
+            if(e.code = "KeyL" && e.getModifierState("Control")) {
+                e.preventDefault();
+                e.stopPropagation();
+                inputModel.clearAIAssistantChat()
+            }
 
             // set height of textarea based on number of newlines
             this.textAreaNumLines.set(e.target.value.split(/\n/).length); 
@@ -102,7 +109,7 @@ class AIChat extends React.Component<{}, {}> {
         let senderClassName = chatItem.isassistantresponse ? "chat-msg-assistant" : "chat-msg-user";
         let msgClassName = "chat-msg " + senderClassName;
         let innerHTML: React.JSX.Element = (
-            <p>{chatItem.userquery}</p>
+            <p style={{whiteSpace:'pre-wrap'}}>{chatItem.userquery}</p>
         );
         if(chatItem.isassistantresponse) {
             innerHTML = (

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -20,16 +20,21 @@ class AIChat extends React.Component<{}, {}> {
     chatListKeyCount: number = 0;
     textAreaNumLines: mobx.IObservableValue<number> = mobx.observable.box(1, {name: "textAreaNumLines"});
     chatWindowScrollRef: React.RefObject<HTMLDivElement>;
+    textAreaRef: React.RefObject<HTMLTextAreaElement>;
 
     constructor(props: any) {
         super(props);
         this.chatWindowScrollRef = React.createRef();
+        this.textAreaRef = React.createRef();
     }
 
     componentDidMount() {
         if(this.chatWindowScrollRef != null && this.chatWindowScrollRef.current != null){
             this.chatWindowScrollRef.current.scrollTop = this.chatWindowScrollRef.current.scrollHeight;
-        }  
+        }
+        if (this.textAreaRef.current != null) {
+            this.textAreaRef.current.focus();
+        }
         this.requestChatUpdate();
     }       
 
@@ -145,6 +150,7 @@ class AIChat extends React.Component<{}, {}> {
                 {this.renderChatWindow()}
                 <textarea
                     key="main"
+                    ref={this.textAreaRef}
                     autoComplete="off"
                     autoCorrect="off"
                     id="chat-cmd-input"

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -11,14 +11,13 @@ import cn from "classnames";
 import { Prompt } from "../../common/prompt/prompt";
 import { TextAreaInput } from "./textareainput";
 import { If, For } from "tsx-control-statements/components";
-import type {OpenAICmdInfoChatMessageType} from "../../../types/types"
+import type { OpenAICmdInfoChatMessageType } from "../../../types/types";
 import { Markdown } from "../../common/common";
-
 
 @mobxReact.observer
 class AIChat extends React.Component<{}, {}> {
     chatListKeyCount: number = 0;
-    textAreaNumLines: mobx.IObservableValue<number> = mobx.observable.box(1, {name: "textAreaNumLines"});
+    textAreaNumLines: mobx.IObservableValue<number> = mobx.observable.box(1, { name: "textAreaNumLines" });
     chatWindowScrollRef: React.RefObject<HTMLDivElement>;
     textAreaRef: React.RefObject<HTMLTextAreaElement>;
 
@@ -31,22 +30,22 @@ class AIChat extends React.Component<{}, {}> {
     componentDidMount() {
         let model = GlobalModel;
         let inputModel = model.inputModel;
-        if(this.chatWindowScrollRef != null && this.chatWindowScrollRef.current != null){
+        if (this.chatWindowScrollRef != null && this.chatWindowScrollRef.current != null) {
             this.chatWindowScrollRef.current.scrollTop = this.chatWindowScrollRef.current.scrollHeight;
         }
         if (this.textAreaRef.current != null) {
             this.textAreaRef.current.focus();
-            inputModel.setCmdInfoChatRefs(this.textAreaRef, this.chatWindowScrollRef)
+            inputModel.setCmdInfoChatRefs(this.textAreaRef, this.chatWindowScrollRef);
         }
         this.requestChatUpdate();
-    }       
+    }
 
     componentDidUpdate() {
-        if(this.chatWindowScrollRef != null && this.chatWindowScrollRef.current != null){
+        if (this.chatWindowScrollRef != null && this.chatWindowScrollRef.current != null) {
             this.chatWindowScrollRef.current.scrollTop = this.chatWindowScrollRef.current.scrollHeight;
-        } 
+        }
     }
-    
+
     requestChatUpdate() {
         this.submitChatMessage("");
     }
@@ -57,12 +56,10 @@ class AIChat extends React.Component<{}, {}> {
         let curLine = inputModel.getCurLine();
         let prtn = GlobalModel.submitChatInfoCommand(messageStr, curLine, false);
         prtn.then((rtn) => {
-            if(!rtn.success) {
+            if (!rtn.success) {
                 console.log("submit chat command error: " + rtn.error);
             }
-        })
-        .catch((error) => {
-        });
+        }).catch((error) => {});
     }
 
     getLinePos(elem: any): { numLines: number; linePos: number } {
@@ -79,16 +76,16 @@ class AIChat extends React.Component<{}, {}> {
             let inputModel = model.inputModel;
             let ctrlMod = e.getModifierState("Control") || e.getModifierState("Meta") || e.getModifierState("Shift");
             let resetCodeSelect = !ctrlMod;
-            
+
             if (e.code == "Enter") {
                 e.preventDefault();
-                if (!ctrlMod) { 
-                    if(inputModel.getCodeSelectSelectedIndex() == -1) {
+                if (!ctrlMod) {
+                    if (inputModel.getCodeSelectSelectedIndex() == -1) {
                         let messageStr = e.target.value;
                         this.submitChatMessage(messageStr);
                         e.target.value = "";
                     } else {
-                        inputModel.grabCodeSelectSelection(); 
+                        inputModel.grabCodeSelectSelection();
                     }
                 } else {
                     e.target.setRangeText("\n", e.target.selectionStart, e.target.selectionEnd, "end");
@@ -99,13 +96,13 @@ class AIChat extends React.Component<{}, {}> {
                 e.stopPropagation();
                 inputModel.closeAIAssistantChat();
             }
-            if(e.code == "KeyL" && e.getModifierState("Control")) {
+            if (e.code == "KeyL" && e.getModifierState("Control")) {
                 e.preventDefault();
                 e.stopPropagation();
-                inputModel.clearAIAssistantChat()
-            } 
-            if(e.code == "ArrowUp") {
-                if(this.getLinePos(e.target).linePos > 1) {
+                inputModel.clearAIAssistantChat();
+            }
+            if (e.code == "ArrowUp") {
+                if (this.getLinePos(e.target).linePos > 1) {
                     // normal up arrow
                     return;
                 }
@@ -113,84 +110,81 @@ class AIChat extends React.Component<{}, {}> {
                 inputModel.codeSelectSelectNextOldestCodeBlock();
                 resetCodeSelect = false;
             }
-            if(e.code == "ArrowDown") {
-                if(inputModel.getCodeSelectSelectedIndex() == inputModel.codeSelectBottom) {
-                    return; 
+            if (e.code == "ArrowDown") {
+                if (inputModel.getCodeSelectSelectedIndex() == inputModel.codeSelectBottom) {
+                    return;
                 }
                 e.preventDefault();
                 inputModel.codeSelectSelectNextNewestCodeBlock();
                 resetCodeSelect = false;
             }
-            
-            if(resetCodeSelect) {
+
+            if (resetCodeSelect) {
                 inputModel.codeSelectDeselectAll();
             }
 
             // set height of textarea based on number of newlines
-            this.textAreaNumLines.set(e.target.value.split(/\n/).length); 
-        })()
+            this.textAreaNumLines.set(e.target.value.split(/\n/).length);
+        })();
     }
-    
+
     renderError(err: string): any {
-        return (
-                <div className="chat-msg-error">{err}</div>
-        );
+        return <div className="chat-msg-error">{err}</div>;
     }
-    
-    
+
     renderChatMessage(chatItem: OpenAICmdInfoChatMessageType): any {
-        let curKey = "chatmsg-" + (this.chatListKeyCount);
+        let curKey = "chatmsg-" + this.chatListKeyCount;
         this.chatListKeyCount++;
         let senderClassName = chatItem.isassistantresponse ? "chat-msg-assistant" : "chat-msg-user";
         let msgClassName = "chat-msg " + senderClassName;
         let innerHTML: React.JSX.Element = (
             <span>
-                <span style = {{display:"flex"}}>
-                    <i className="fa-sharp fa-solid fa-user" style={{marginRight:"5px", marginTop:"1px"}}></i>
-                    <p style={{marginRight:"5px"}}>You</p>
+                <span style={{ display: "flex" }}>
+                    <i className="fa-sharp fa-solid fa-user" style={{ marginRight: "5px", marginTop: "1px" }}></i>
+                    <p style={{ marginRight: "5px" }}>You</p>
                 </span>
                 <p className="msg-text">{chatItem.userquery}</p>
             </span>
         );
-        if(chatItem.isassistantresponse) {
-            if(chatItem.assistantresponse.error != null && chatItem.assistantresponse.error != "") {
+        if (chatItem.isassistantresponse) {
+            if (chatItem.assistantresponse.error != null && chatItem.assistantresponse.error != "") {
                 innerHTML = this.renderError(chatItem.assistantresponse.error);
             } else {
                 innerHTML = (
                     <span>
-                        <span style = {{display:"flex"}}>
-                            <i className= "fa-sharp fa-solid fa-headset" style={{marginRight:"5px", marginTop:"1px"}}></i>
-                            <p style={{marginRight:"5px"}}>ChatGPT</p>
+                        <span style={{ display: "flex" }}>
+                            <i
+                                className="fa-sharp fa-solid fa-headset"
+                                style={{ marginRight: "5px", marginTop: "1px" }}
+                            ></i>
+                            <p style={{ marginRight: "5px" }}>ChatGPT</p>
                         </span>
-                        <Markdown text={chatItem.assistantresponse.message} codeSelect/> 
+                        <Markdown text={chatItem.assistantresponse.message} codeSelect />
                     </span>
                 );
             }
-        }         
+        }
 
-        return(
-            <div className={msgClassName} key={curKey}> 
+        return (
+            <div className={msgClassName} key={curKey}>
                 {innerHTML}
             </div>
         );
-
     }
-    
-    renderChatWindow(): any { 
+
+    renderChatWindow(): any {
         let model = GlobalModel;
         let inputModel = model.inputModel;
         let chatMessageItems = inputModel.AICmdInfoChatItems.slice();
         let chitem: OpenAICmdInfoChatMessageType = null;
         return (
-            <div className="chat-window" ref={this.chatWindowScrollRef}> 
+            <div className="chat-window" ref={this.chatWindowScrollRef}>
                 <For each="chitem" index="idx" of={chatMessageItems}>
                     {this.renderChatMessage(chitem)}
                 </For>
             </div>
         );
-
     }
-    
 
     render() {
         let model = GlobalModel;
@@ -198,13 +192,13 @@ class AIChat extends React.Component<{}, {}> {
 
         const termFontSize = 14;
         const textAreaMaxLines = 4;
-        const textAreaLineHeight = (termFontSize * 1.5);
+        const textAreaLineHeight = termFontSize * 1.5;
         const textAreaPadding = 2 * 0.5 * termFontSize;
         let textAreaMaxHeight = textAreaLineHeight * textAreaMaxLines + textAreaPadding;
         let textAreaInnerHeight = this.textAreaNumLines.get() * textAreaLineHeight + textAreaPadding;
-        
+
         return (
-            <div className = "cmd-aichat">
+            <div className="cmd-aichat">
                 {this.renderChatWindow()}
                 <textarea
                     key="main"
@@ -213,16 +207,13 @@ class AIChat extends React.Component<{}, {}> {
                     autoCorrect="off"
                     id="chat-cmd-input"
                     onKeyDown={this.onKeyDown}
-                    style={{height: textAreaInnerHeight, maxHeight: textAreaMaxHeight, fontSize: termFontSize }}
+                    style={{ height: textAreaInnerHeight, maxHeight: textAreaMaxHeight, fontSize: termFontSize }}
                     className={cn("chat-textarea")}
                     placeholder="Send a Message to ChatGPT..."
                 ></textarea>
             </div>
-
         );
     }
-    
-    
 }
 
-export {AIChat}
+export { AIChat };

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -1,0 +1,106 @@
+// Copyright 2023, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from "react";
+import * as mobxReact from "mobx-react";
+import * as mobx from "mobx";
+import { GlobalModel } from "../../../model/model";
+import { isBlank } from "../../../util/util";
+import { boundMethod } from "autobind-decorator";
+import cn from "classnames";
+import { Prompt } from "../../common/prompt/prompt";
+import { TextAreaInput } from "./textareainput";
+import { If, For } from "tsx-control-statements/components";
+
+@mobxReact.observer
+class AIChat extends React.Component<{}, {}> {
+
+    componentDidMount() {
+    }       
+
+    @boundMethod
+    handleInnerHeightUpdate(): void {
+    }
+
+    @mobx.action
+    @boundMethod
+    onKeyDown(e: any) {
+        console.log("mk1");
+        let model = GlobalModel;
+        let inputModel = model.inputModel;
+        let ctrlMod = e.getModifierState("Control") || e.getModifierState("Meta") || e.getModifierState("Shift");
+
+        if (e.code == "Enter") {
+            console.log("hello");
+            e.preventDefault();
+            if (!ctrlMod) { 
+                inputModel.addAIChatMessage(e.target.value);
+                console.log("target value?:", e.target.value);
+                e.target.value = "";
+                return;
+            }
+            e.target.setRangeText("\n", e.target.selectionStart, e.target.selectionEnd, "end");
+            console.log("shift enter - target value: ", e.target.value);
+            return;
+        }            
+    }
+    
+    /*
+    
+    renderChatMessage(messageStr: string): any {
+        return(
+            <div key={messageStr}>
+                {messageStr}
+            </div>
+        );
+
+    }
+    
+    renderChatWindow(): any { 
+        let model = GlobalModel;
+        let inputModel = model.inputModel;
+        let chatMessageItems = inputModel.AIChatItems;
+        let chitem: string = null;
+        return (
+            <div> 
+                <For each="chitem" index="idx" of={chatMessageItems}>
+                    {this.renderChatMessage(chitem)}
+                </For>
+            </div>
+        );
+
+    }
+    */
+
+    render() {
+        let model = GlobalModel;
+        let inputModel = model.inputModel;
+
+        let displayLines = 1;
+        let termFontSize = 14;
+        // fontSize*1.5 (line-height) + 2 * 0.5em padding
+        let computedInnerHeight = displayLines * (termFontSize * 1.5) + 2 * 0.5 * termFontSize;
+        // inner height + 2*1em padding
+        let computedOuterHeight = computedInnerHeight + 2 * 1.0 * termFontSize;
+        return (
+            <div className = "cmd-input-field">
+                <div className="control is-expanded" style={{ height: computedOuterHeight }} >
+                    <textarea
+                        key="main"
+                        autoComplete="off"
+                        autoCorrect="off"
+                        id="main-cmd-input"
+                        onKeyDown={this.onKeyDown}
+                        style={{ height: computedInnerHeight, minHeight: computedInnerHeight, fontSize: termFontSize }}
+                        className={cn("textarea")}
+                    ></textarea>
+                </div>
+            </div>
+
+        );
+    }
+    
+    
+}
+
+export {AIChat}

--- a/src/app/workspace/cmdinput/cmdinput.less
+++ b/src/app/workspace/cmdinput/cmdinput.less
@@ -246,12 +246,19 @@
             color: @term-white;
         }
 
-        .chat-msg-user {
-            color: @term-green;
+        .chat-msg-user { 
+
+            .msg-text {
+                font-family: @markdown-font;
+                font-size: 14px;
+                white-space: pre-wrap;
+            }
         }
-        
+         
         .chat-msg-error {
             color: @term-bright-red;
+            font-family: @markdown-font;
+            font-size: 14px;
         }
         
 

--- a/src/app/workspace/cmdinput/cmdinput.less
+++ b/src/app/workspace/cmdinput/cmdinput.less
@@ -215,7 +215,7 @@
             flex-shrink: 1;
             flex-direction: column-reverse;
         }
-        
+         
         .chat-textarea {
             color: @term-bright-white;
             background-color: @textarea-background;

--- a/src/app/workspace/cmdinput/cmdinput.less
+++ b/src/app/workspace/cmdinput/cmdinput.less
@@ -220,6 +220,7 @@
             color: @term-bright-white;
             background-color: @textarea-background;
             padding: 0.5em;
+            resize: none;
             overflow: auto;
             overflow-wrap: anywhere;
             border-color: transparent;
@@ -227,6 +228,7 @@
             font-family: @terminal-font;
             flex-shrink: 0;
             flex-grow: 1;
+            border-radius: 4px;
 
             &:focus {
                 box-shadow: none;

--- a/src/app/workspace/cmdinput/cmdinput.less
+++ b/src/app/workspace/cmdinput/cmdinput.less
@@ -42,6 +42,10 @@
         max-height: max(300px, 70%);
     }
 
+    &.has-aichat {
+        max-height: max(300px, 70%);
+    }
+
     .remote-status-warning {
         display: flex;
         flex-direction: row;
@@ -198,15 +202,15 @@
     }
     
     .cmd-aichat { 
-        max-height: 250px;
         display: flex;
         justify-content: flex-end;
         flex-flow: column nowrap;
         margin-bottom: 10px;
+        flex-shrink: 1;
+        overflow-y: auto;
 
         .chat-window {
             overflow-y: auto;
-            max-height: 200px;
             margin-bottom: 5px;
             flex-shrink: 1;
             flex-direction: column-reverse;
@@ -231,7 +235,6 @@
         }
 
         .chat-msg {
-            white-space: pre-line;
             margin-top:5px;
             margin-bottom:5px;
         }

--- a/src/app/workspace/cmdinput/cmdinput.less
+++ b/src/app/workspace/cmdinput/cmdinput.less
@@ -231,6 +231,7 @@
             &:focus {
                 box-shadow: none;
                 border: none;
+                outline: none;
             }
         }
 
@@ -245,6 +246,10 @@
 
         .chat-msg-user {
             color: @term-green;
+        }
+        
+        .chat-msg-error {
+            color: @term-bright-red;
         }
         
 

--- a/src/app/workspace/cmdinput/cmdinput.less
+++ b/src/app/workspace/cmdinput/cmdinput.less
@@ -196,6 +196,59 @@
             }
         }
     }
+    
+    .cmd-aichat { 
+        max-height: 250px;
+        display: flex;
+        justify-content: flex-end;
+        flex-flow: column nowrap;
+        margin-bottom: 10px;
+
+        .chat-window {
+            overflow-y: auto;
+            max-height: 200px;
+            margin-bottom: 5px;
+            flex-shrink: 1;
+            flex-direction: column-reverse;
+        }
+        
+        .chat-textarea {
+            color: @term-bright-white;
+            background-color: @textarea-background;
+            padding: 0.5em;
+            overflow: auto;
+            overflow-wrap: anywhere;
+            border-color: transparent;
+            border: none;
+            font-family: @terminal-font;
+            flex-shrink: 0;
+            flex-grow: 1;
+
+            &:focus {
+                box-shadow: none;
+                border: none;
+            }
+        }
+
+        .chat-msg {
+            white-space: pre-line;
+            margin-top:5px;
+            margin-bottom:5px;
+        }
+
+        .chat-msg-assistant {
+            color: @term-white;
+        }
+
+        .chat-msg-user {
+            color: @term-green;
+        }
+        
+
+        .grow-spacer {
+            flex: 1 0 10px;
+        }
+    }
 
     .cmd-history {
         color: @term-white;

--- a/src/app/workspace/cmdinput/cmdinput.tsx
+++ b/src/app/workspace/cmdinput/cmdinput.tsx
@@ -19,6 +19,7 @@ import { Prompt } from "../../common/prompt/prompt";
 import { ReactComponent as ExecIcon } from "../../assets/icons/exec.svg";
 import { ReactComponent as RotateIcon } from "../../assets/icons/line/rotate.svg";
 import "./cmdinput.less";
+import { AIChat } from "./aichat";
 
 dayjs.extend(localizedFormat);
 
@@ -116,6 +117,7 @@ class CmdInput extends React.Component<{}, {}> {
         }
         let infoShow = inputModel.infoShow.get();
         let historyShow = !infoShow && inputModel.historyShow.get();
+        let aiChatShow = inputModel.aIChatShow.get();
         let infoMsg = inputModel.infoMsg.get();
         let hasInfo = infoMsg != null;
         let focusVal = inputModel.physicalInputFocused.get();
@@ -131,6 +133,10 @@ class CmdInput extends React.Component<{}, {}> {
                 <If condition={historyShow}>
                     <div className="cmd-input-grow-spacer"></div>
                     <HistoryInfo />
+                </If>
+                <If condition={aiChatShow}>
+                    <div className="cmd-input-grow-spacer"></div>
+                    <AIChat />
                 </If>
                 <InfoMsg key="infomsg" />
                 <If condition={remote && remote.status != "connected"}>

--- a/src/app/workspace/cmdinput/cmdinput.tsx
+++ b/src/app/workspace/cmdinput/cmdinput.tsx
@@ -129,7 +129,15 @@ class CmdInput extends React.Component<{}, {}> {
             numRunningLines = mobx.computed(() => win.getRunningCmdLines().length).get();
         }
         return (
-            <div ref={this.cmdInputRef} className={cn("cmd-input", { "has-info": infoShow }, { "has-aichat": aiChatShow }, { active: focusVal })}>
+            <div
+                ref={this.cmdInputRef}
+                className={cn(
+                    "cmd-input",
+                    { "has-info": infoShow },
+                    { "has-aichat": aiChatShow },
+                    { active: focusVal }
+                )}
+            >
                 <If condition={historyShow}>
                     <div className="cmd-input-grow-spacer"></div>
                     <HistoryInfo />

--- a/src/app/workspace/cmdinput/cmdinput.tsx
+++ b/src/app/workspace/cmdinput/cmdinput.tsx
@@ -129,7 +129,7 @@ class CmdInput extends React.Component<{}, {}> {
             numRunningLines = mobx.computed(() => win.getRunningCmdLines().length).get();
         }
         return (
-            <div ref={this.cmdInputRef} className={cn("cmd-input", { "has-info": infoShow }, { active: focusVal })}>
+            <div ref={this.cmdInputRef} className={cn("cmd-input", { "has-info": infoShow }, { "has-aichat": aiChatShow }, { active: focusVal })}>
                 <If condition={historyShow}>
                     <div className="cmd-input-grow-spacer"></div>
                     <HistoryInfo />

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -314,10 +314,10 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
                     scrollDiv(div, e.code == "PageUp" ? -amt : amt);
                 }
             }
-            if(e.code == "Space" && e.getModifierState("Control")) {
-               e.preventDefault() 
-               console.log("Ctrl + Space pressed"); 
-               inputModel.openAIAssistantChat();
+            if (e.code == "Space" && e.getModifierState("Control")) {
+                e.preventDefault();
+                console.log("Ctrl + Space pressed");
+                inputModel.openAIAssistantChat();
             }
             // console.log(e.code, e.keyCode, e.key, event.which, ctrlMod, e);
         })();

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -316,7 +316,6 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
             }
             if (e.code == "Space" && e.getModifierState("Control")) {
                 e.preventDefault();
-                console.log("Ctrl + Space pressed");
                 inputModel.openAIAssistantChat();
             }
             // console.log(e.code, e.keyCode, e.key, event.which, ctrlMod, e);

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -230,6 +230,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
                 if (inputModel.inputMode.get() != null) {
                     inputModel.resetInputMode();
                 }
+                inputModel.closeAIAssistantChat();
                 return;
             }
             if (e.code == "KeyE" && e.getModifierState("Meta")) {

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -313,6 +313,11 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
                     scrollDiv(div, e.code == "PageUp" ? -amt : amt);
                 }
             }
+            if(e.code == "Space" && e.getModifierState("Control")) {
+               e.preventDefault() 
+               console.log("Ctrl + Space pressed"); 
+               inputModel.openAIAssistantChat();
+            }
             // console.log(e.code, e.keyCode, e.key, event.which, ctrlMod, e);
         })();
     }

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1752,7 +1752,7 @@ class InputModel {
         if(blockIndex >= 0 && blockIndex < this.codeSelectBlockRefArray.length) {
             this.codeSelectDeselectCodeBlock(this.codeSelectSelectedIndex, markdownID);
             this.codeSelectSelectedIndex = blockIndex;
-            this.codeSelectBlockRefArray[blockIndex].current.style.background = "yellow";
+            this.codeSelectBlockRefArray[blockIndex].current.style.backgroundColor = "rgba(252, 226, 5, 0.4)";
             this.setAIChatFocus();
         }  
     }
@@ -1882,7 +1882,6 @@ class InputModel {
                 return;
             }
             this.resetInput();
-            this.clearAIAssistantChat();
             GlobalModel.submitRawCommand(commandStr, true, true);
         })();
     }

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -4106,19 +4106,20 @@ class Model {
         return this.submitCommandPacket(pk, interactive);
     }
 
-    submitChatInfoCommand(cmdStr: string): Promise<CommandRtnType> {
+    submitChatInfoCommand(chatMsg: string, curLineStr: string): Promise<CommandRtnType> {
         let interactive = false;
         let pk: FeCmdPacketType = {
             type: "fecmd",
             metacmd: "eval",
-            args: [cmdStr],
+            args: [chatMsg],
             kwargs: {},
             uicontext: this.getUIContext(),
             interactive: interactive,
-            rawstr: cmdStr,
+            rawstr: chatMsg,
         };
         pk.kwargs["nohist"] = "1";
         pk.kwargs["cmdinfo"] = "1";
+        pk.kwargs["curline"] = curLineStr;
         return this.submitCommandPacket(pk, interactive);
 
     }

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1775,7 +1775,6 @@ class InputModel {
                 }
             }
             if(incBlockIndex >= 0 && incBlockIndex < this.codeSelectBlockRefArray.length) {
-                console.log("what the heck", incBlockIndex);
                 this.setCodeSelectSelectedCodeBlock(incBlockIndex);
             }
         })();
@@ -1835,11 +1834,9 @@ class InputModel {
     }
     
     clearAIAssistantChat(): void { 
-        console.log("AI Assistant test");
         let prtn = GlobalModel.submitChatInfoCommand("", "", true);
         prtn.then((rtn) => {
             if(rtn.success) {
-                console.log("Clear AI Assistant chat submit chat command success");
             } else {
                 console.log("submit chat command error: " + rtn.error);
             }

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1703,8 +1703,11 @@ class InputModel {
             }, timeoutMs);
         }
     }
-    
-    setCmdInfoChatRefs(textAreaRef: React.RefObject<HTMLTextAreaElement>, chatWindowRef: React.RefObject<HTMLDivElement>) {
+
+    setCmdInfoChatRefs(
+        textAreaRef: React.RefObject<HTMLTextAreaElement>,
+        chatWindowRef: React.RefObject<HTMLDivElement>
+    ) {
         this.aiChatTextAreaRef = textAreaRef;
         this.aiChatWindowRef = chatWindowRef;
     }

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1714,6 +1714,7 @@ class InputModel {
     closeAIAssistantChat(): void {
         console.log("Opening AI Assistant chat");
         this.aIChatShow.set(false);
+        this.giveFocus();
     }
 
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -65,7 +65,7 @@ import type {
     CommandRtnType,
     WebCmd,
     WebRemote,
-    OpenAICmdInfoChatMessageType
+    OpenAICmdInfoChatMessageType,
 } from "../types/types";
 import * as T from "../types/types";
 import { WSControl } from "./ws";
@@ -1240,10 +1240,10 @@ class InputModel {
     aiChatWindowRef: React.RefObject<HTMLDivElement>;
     codeSelectBlockRefArray: Array<React.RefObject<HTMLElement>>;
     codeSelectSelectedIndex: OV<number> = mobx.observable.box(-1);
-    
+
     AICmdInfoChatItems: mobx.IObservableArray<OpenAICmdInfoChatMessageType> = mobx.observable.array([], {
-        name: "aicmdinfo-chat"
-    }); 
+        name: "aicmdinfo-chat",
+    });
     readonly codeSelectTop: number = -2;
     readonly codeSelectBottom: number = -1;
 
@@ -1288,7 +1288,7 @@ class InputModel {
             this.codeSelectBlockRefArray = [];
         })();
     }
-    
+
     setInputMode(inputMode: null | "comment" | "global"): void {
         mobx.action(() => {
             this.inputMode.set(inputMode);
@@ -1415,7 +1415,7 @@ class InputModel {
         this.AICmdInfoChatItems.replace(chat);
         this.codeSelectBlockRefArray = [];
     }
-     
+
     setHistoryShow(show: boolean): void {
         if (this.historyShow.get() == show) {
             return;
@@ -1711,114 +1711,116 @@ class InputModel {
         this.aiChatTextAreaRef = textAreaRef;
         this.aiChatWindowRef = chatWindowRef;
     }
-    
+
     setAIChatFocus() {
         if (this.aiChatTextAreaRef != null && this.aiChatTextAreaRef.current != null) {
             this.aiChatTextAreaRef.current.focus();
         }
     }
-    
+
     grabCodeSelectSelection() {
-        if(this.codeSelectSelectedIndex.get() >= 0 && this.codeSelectSelectedIndex.get() < this.codeSelectBlockRefArray.length) {
-            let curBlockRef = this.codeSelectBlockRefArray[this.codeSelectSelectedIndex.get()]
+        if (
+            this.codeSelectSelectedIndex.get() >= 0 &&
+            this.codeSelectSelectedIndex.get() < this.codeSelectBlockRefArray.length
+        ) {
+            let curBlockRef = this.codeSelectBlockRefArray[this.codeSelectSelectedIndex.get()];
             let codeText = curBlockRef.current.innerText;
-            codeText = codeText.replace(/\n$/, "") // remove trailing newline        
+            codeText = codeText.replace(/\n$/, ""); // remove trailing newline
             let newLineValue = this.getCurLine() + " " + codeText;
             this.setCurLine(newLineValue);
             this.giveFocus();
         }
     }
-     
+
     addCodeBlockToCodeSelect(blockRef: React.RefObject<HTMLElement>): number {
         let rtn = -1;
-        rtn = this.codeSelectBlockRefArray.length;            
+        rtn = this.codeSelectBlockRefArray.length;
         this.codeSelectBlockRefArray.push(blockRef);
         return rtn;
     }
-    
-    
 
-    setCodeSelectSelectedCodeBlock(blockIndex:number) { 
+    setCodeSelectSelectedCodeBlock(blockIndex: number) {
         mobx.action(() => {
-            if(blockIndex >= 0 && blockIndex < this.codeSelectBlockRefArray.length) {
+            if (blockIndex >= 0 && blockIndex < this.codeSelectBlockRefArray.length) {
                 this.codeSelectSelectedIndex.set(blockIndex);
                 let currentRef = this.codeSelectBlockRefArray[blockIndex].current;
-                if(currentRef != null) {
-                    if(this.aiChatWindowRef != null && this.aiChatWindowRef.current != null) {
+                if (currentRef != null) {
+                    if (this.aiChatWindowRef != null && this.aiChatWindowRef.current != null) {
                         let chatWindowTop = this.aiChatWindowRef.current.scrollTop;
                         let chatWindowBottom = chatWindowTop + this.aiChatWindowRef.current.clientHeight - 100;
                         let elemTop = currentRef.offsetTop;
                         let elemBottom = elemTop - currentRef.offsetHeight;
-                        let elementIsInView = (elemBottom < chatWindowBottom && elemTop > chatWindowTop);
-                        if(!elementIsInView) {
-                            this.aiChatWindowRef.current.scrollTop = elemBottom - (this.aiChatWindowRef.current.clientHeight / 3);                        
+                        let elementIsInView = elemBottom < chatWindowBottom && elemTop > chatWindowTop;
+                        if (!elementIsInView) {
+                            this.aiChatWindowRef.current.scrollTop =
+                                elemBottom - this.aiChatWindowRef.current.clientHeight / 3;
                         }
                     }
                 }
                 this.codeSelectBlockRefArray = [];
                 this.setAIChatFocus();
-            }  
+            }
         })();
     }
-    
+
     codeSelectSelectNextNewestCodeBlock() {
         // oldest code block = index 0 in array
         // this decrements codeSelectSelected index
         mobx.action(() => {
-            if(this.codeSelectSelectedIndex.get() == this.codeSelectTop) {
+            if (this.codeSelectSelectedIndex.get() == this.codeSelectTop) {
                 this.codeSelectSelectedIndex.set(this.codeSelectBottom);
             } else if (this.codeSelectSelectedIndex.get() == this.codeSelectBottom) {
                 return;
             }
             let incBlockIndex = this.codeSelectSelectedIndex.get() + 1;
-            if(this.codeSelectSelectedIndex.get() == this.codeSelectBlockRefArray.length-1) {
+            if (this.codeSelectSelectedIndex.get() == this.codeSelectBlockRefArray.length - 1) {
                 this.codeSelectDeselectAll();
-                if(this.aiChatWindowRef != null && this.aiChatWindowRef.current != null) {
+                if (this.aiChatWindowRef != null && this.aiChatWindowRef.current != null) {
                     this.aiChatWindowRef.current.scrollTop = this.aiChatWindowRef.current.scrollHeight;
                 }
             }
-            if(incBlockIndex >= 0 && incBlockIndex < this.codeSelectBlockRefArray.length) {
+            if (incBlockIndex >= 0 && incBlockIndex < this.codeSelectBlockRefArray.length) {
                 this.setCodeSelectSelectedCodeBlock(incBlockIndex);
             }
         })();
     }
-    
+
     codeSelectSelectNextOldestCodeBlock() {
         mobx.action(() => {
-            if(this.codeSelectSelectedIndex.get() == this.codeSelectBottom) {
-                if(this.codeSelectBlockRefArray.length > 0) {
+            if (this.codeSelectSelectedIndex.get() == this.codeSelectBottom) {
+                if (this.codeSelectBlockRefArray.length > 0) {
                     this.codeSelectSelectedIndex.set(this.codeSelectBlockRefArray.length);
                 } else {
                     return;
                 }
-            } else if(this.codeSelectSelectedIndex.get() == this.codeSelectTop) {
+            } else if (this.codeSelectSelectedIndex.get() == this.codeSelectTop) {
                 return;
             }
             let decBlockIndex = this.codeSelectSelectedIndex.get() - 1;
-            if(decBlockIndex < 0) {
+            if (decBlockIndex < 0) {
                 this.codeSelectDeselectAll(this.codeSelectTop);
-                if(this.aiChatWindowRef != null && this.aiChatWindowRef.current != null) {
+                if (this.aiChatWindowRef != null && this.aiChatWindowRef.current != null) {
                     this.aiChatWindowRef.current.scrollTop = 0;
-                } 
+                }
             }
-            if(decBlockIndex >= 0 && decBlockIndex < this.codeSelectBlockRefArray.length) {
+            if (decBlockIndex >= 0 && decBlockIndex < this.codeSelectBlockRefArray.length) {
                 this.setCodeSelectSelectedCodeBlock(decBlockIndex);
-            }  
-        })()
+            }
+        })();
     }
-    
+
     getCodeSelectSelectedIndex() {
         return this.codeSelectSelectedIndex.get();
     }
-    
-    getCodeSelectRefArrayLength(){
+
+    getCodeSelectRefArrayLength() {
         return this.codeSelectBlockRefArray.length;
     }
 
     codeBlockIsSelected(blockIndex: number): boolean {
         return blockIndex == this.codeSelectSelectedIndex.get();
     }
-    
+
     codeSelectDeselectAll(direction: number = this.codeSelectBottom) {
         mobx.action(() => {
             this.codeSelectSelectedIndex.set(direction);
@@ -1835,20 +1837,18 @@ class InputModel {
         this.aIChatShow.set(false);
         this.giveFocus();
     }
-    
-    clearAIAssistantChat(): void { 
+
+    clearAIAssistantChat(): void {
         let prtn = GlobalModel.submitChatInfoCommand("", "", true);
         prtn.then((rtn) => {
-            if(rtn.success) {
+            if (rtn.success) {
             } else {
                 console.log("submit chat command error: " + rtn.error);
             }
-        })
-        .catch((error) => {
+        }).catch((error) => {
             console.log("submit chat command error: ", error);
         });
     }
-
 
     hasScrollingInfoMsg(): boolean {
         if (!this.infoShow.get()) {
@@ -4002,7 +4002,7 @@ class Model {
             this.sessionListLoaded.set(true);
             this.remotesLoaded.set(true);
         }
-        if("openaicmdinfochat" in update) { 
+        if ("openaicmdinfochat" in update) {
             this.inputModel.setOpenAICmdInfoChat(update.openaicmdinfochat);
         }
         // console.log("run-update>", Date.now(), interactive, update);
@@ -4252,16 +4252,14 @@ class Model {
             rawstr: chatMsg,
         };
         pk.kwargs["nohist"] = "1";
-        if(clear) {
+        if (clear) {
             pk.kwargs["cmdinfoclear"] = "1";
         } else {
             pk.kwargs["cmdinfo"] = "1";
         }
         pk.kwargs["curline"] = curLineStr;
         return this.submitCommandPacket(pk, interactive);
-
     }
-
 
     submitRawCommand(cmdStr: string, addToHistory: boolean, interactive: boolean): Promise<CommandRtnType> {
         let pk: FeCmdPacketType = {

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1233,7 +1233,12 @@ function getDefaultHistoryQueryOpts(): HistoryQueryOpts {
 class InputModel {
     historyShow: OV<boolean> = mobx.observable.box(false);
     infoShow: OV<boolean> = mobx.observable.box(false);
+    aIChatShow: OV<boolean> = mobx.observable.box(false);
     cmdInputHeight: OV<number> = mobx.observable.box(0);
+    
+    AIChatItems: mobx.IObservableArray<string> = mobx.observable.array(["AI Chat Message"], {
+        name: "AIChatItems"
+    }); 
 
     historyType: mobx.IObservableValue<HistoryTypeStrs> = mobx.observable.box("screen");
     historyLoading: mobx.IObservableValue<boolean> = mobx.observable.box(false);
@@ -1272,7 +1277,7 @@ class InputModel {
             return this._getFilteredHistoryItems();
         });
     }
-
+    
     setInputMode(inputMode: null | "comment" | "global"): void {
         mobx.action(() => {
             this.inputMode.set(inputMode);
@@ -1393,6 +1398,27 @@ class InputModel {
             setTimeout(() => this.setHistoryIndex(bestIndex, true), 10);
             return;
         })();
+    }
+    
+    setAIChatShow(show: boolean): void {
+        if(this.aIChatShow.get() == show) {
+            return
+        }
+        mobx.action(() => {
+            this.aIChatShow.set(show);
+            if(this.hasFocus()) {
+                this.giveFocus();
+            }
+        })
+        
+    }
+     
+    addAIChatMessage(messageStr:string): void {
+        console.log("mk3")
+        mobx.action(() => {
+            console.log("mk4");
+            this.AIChatItems.push(messageStr);            
+        });
     }
 
     setHistoryShow(show: boolean): void {
@@ -1681,6 +1707,11 @@ class InputModel {
                 this.clearInfoMsg(false);
             }, timeoutMs);
         }
+    }
+    
+    openAIAssistantChat(): void {
+        console.log("Opening AI Assistant chat");
+        this.aIChatShow.set(true);
     }
 
     hasScrollingInfoMsg(): boolean {

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1699,7 +1699,7 @@ class InputModel {
     }
     
     setAIChatFocus() {
-        if (this.aiChatTextAreaRef.current != null) {
+        if (this.aiChatTextAreaRef != null && this.aiChatTextAreaRef.current != null) {
             this.aiChatTextAreaRef.current.focus();
         }
     }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -271,13 +271,13 @@ type OpenAIPacketOutputType = {
     finish_reason: string;
     message: string;
     error?: string;
-}
+};
 
 type OpenAICmdInfoChatMessageType = {
     isassistantresponse?: boolean;
     assistantresponse?: OpenAIPacketOutputType;
     userquery?: string;
-}
+};
 
 type ModelUpdateType = {
     interactive: boolean;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -265,6 +265,19 @@ type ScreenLinesType = {
     cmds: CmdDataType[];
 };
 
+type OpenAIPacketOutputType = {
+    model: string;
+    created: number;
+    finish_reason: string;
+    message: string;
+}
+
+type OpenAICmdInfoChatMessageType = {
+    isassistantresponse?: boolean;
+    assistantresponse?: OpenAIPacketOutputType;
+    userquery?: string;
+}
+
 type ModelUpdateType = {
     interactive: boolean;
     sessions?: SessionDataType[];
@@ -285,6 +298,7 @@ type ModelUpdateType = {
     clientdata?: ClientDataType;
     historyviewdata?: HistoryViewDataType;
     remoteview?: RemoteViewType;
+    openaicmdinfochat?: OpenAICmdInfoChatMessageType[];
     alertmessage?: AlertMessageType;
 };
 
@@ -763,4 +777,5 @@ export type {
     ModalStoreEntry,
     StrWithPos,
     CmdInputTextPacketType,
+    OpenAICmdInfoChatMessageType,
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -270,6 +270,7 @@ type OpenAIPacketOutputType = {
     created: number;
     finish_reason: string;
     message: string;
+    error?: string;
 }
 
 type OpenAICmdInfoChatMessageType = {

--- a/waveshell/pkg/packet/packet.go
+++ b/waveshell/pkg/packet/packet.go
@@ -858,6 +858,7 @@ type OpenAICmdInfoChatMessage struct {
 	IsAssistantResponse bool                           `json:"isassistantresponse,omitempty"`
 	AssistantResponse   *OpenAICmdInfoPacketOutputType `json:"assistantresponse,omitempty"`
 	UserQuery           string                         `json:"userquery,omitempty"`
+	UserEngineeredQuery string                         `json:"userengineeredquery,omitempty"`
 }
 
 type OpenAIPromptMessageType struct {

--- a/waveshell/pkg/packet/packet.go
+++ b/waveshell/pkg/packet/packet.go
@@ -729,6 +729,14 @@ type OpenAIUsageType struct {
 	TotalTokens      int `json:"total_tokens,omitempty"`
 }
 
+type OpenAICmdInfoPacketOutputType struct {
+	Model        string `json:"model,omitempty"`
+	Created      int64  `json:"created,omitempty"`
+	FinishReason string `json:"finish_reason,omitempty"`
+	Message      string `json:"message,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
 type OpenAIPacketType struct {
 	Type         string           `json:"type"`
 	Model        string           `json:"model,omitempty"`
@@ -841,6 +849,13 @@ func MakeWriteFileDonePacket(reqId string) *WriteFileDonePacketType {
 		Type:   WriteFileDonePacketStr,
 		RespId: reqId,
 	}
+}
+
+type OpenAICmdInfoChatMessage struct {
+	MessageID           int                            `json:"messageid"`
+	IsAssistantResponse bool                           `json:"isassistantresponse,omitempty"`
+	AssistantResponse   *OpenAICmdInfoPacketOutputType `json:"assistantresponse,omitempty"`
+	UserQuery           string                         `json:"userquery,omitempty"`
 }
 
 type OpenAIPromptMessageType struct {

--- a/waveshell/pkg/packet/packet.go
+++ b/waveshell/pkg/packet/packet.go
@@ -70,6 +70,8 @@ const PacketEOFStr = "EOF"
 
 var TypeStrToFactory map[string]reflect.Type
 
+const OpenAICmdInfoChatGreetingMessage = "Hello, may I help you with this command? \n(Press ESC to close and Ctrl+L to clear chat buffer)"
+
 func init() {
 	TypeStrToFactory = make(map[string]reflect.Type)
 	TypeStrToFactory[RunPacketStr] = reflect.TypeOf(RunPacketType{})

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -2018,13 +2018,11 @@ func updateAsstResponseAndWriteToUpdateBus(ctx context.Context, cmd *sstore.CmdT
 }
 
 func getCmdInfoEngineeredPrompt(userQuery string, curLineStr string) string {
-	rtn := "You are an expert on the command line terminal. Your task is to help a user write a command."
+	rtn := "You are an expert on the command line terminal. Your task is to help me write a command."
 	if curLineStr != "" {
-		rtn += "The user's current command is: " + curLineStr + ". Their question is: "
-	} else {
-		rtn += "The user's question is: "
+		rtn += "My current command is: " + curLineStr
 	}
-	rtn += userQuery
+	rtn += ". My question is: " + userQuery + "."
 	return rtn
 }
 
@@ -2244,6 +2242,7 @@ func OpenAICommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (sstor
 		userQueryPk := &packet.OpenAICmdInfoChatMessage{UserQuery: promptStr, MessageID: sstore.ScreenMemGetCmdInfoMessageCount(cmd.ScreenId)}
 		writePacketToUpdateBus(ctx, cmd, userQueryPk)
 		engineeredQuery := getCmdInfoEngineeredPrompt(promptStr, curLineStr)
+		userQueryPk.UserEngineeredQuery = engineeredQuery
 		prompt[0].Content = engineeredQuery
 		go doOpenAICmdInfoCompletion(cmd, clientData.ClientId, opts, prompt, curLineStr)
 		update := &sstore.ModelUpdate{}

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -2054,7 +2054,6 @@ func doOpenAICmdInfoCompletion(cmd *sstore.CmdType, clientId string, opts *sstor
 		log.Printf("Run stream error, figure out what to do here")
 		return
 	}
-
 	asstOutputPk := &packet.OpenAICmdInfoPacketOutputType{
 		Model:        "",
 		Created:      0,
@@ -2064,7 +2063,6 @@ func doOpenAICmdInfoCompletion(cmd *sstore.CmdType, clientId string, opts *sstor
 	asstOutputMessageID := sstore.ScreenMemGetCmdInfoMessageCount(cmd.ScreenId)
 	asstMessagePk := &packet.OpenAICmdInfoChatMessage{IsAssistantResponse: true, AssistantResponse: asstOutputPk, MessageID: asstOutputMessageID}
 	writePacketToUpdateBus(ctx, cmd, asstMessagePk)
-
 	doneWaitingForPackets := false
 	for !doneWaitingForPackets {
 		select {

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -2197,6 +2197,9 @@ func BuildOpenAIPromptArrayWithContext(messages []*packet.OpenAICmdInfoChatMessa
 	rtn := make([]packet.OpenAIPromptMessageType, 0)
 	for _, msg := range messages {
 		content := msg.UserEngineeredQuery
+		if msg.UserEngineeredQuery == "" {
+			content = msg.UserQuery
+		}
 		msgRole := sstore.OpenAIRoleUser
 		if msg.IsAssistantResponse {
 			msgRole = sstore.OpenAIRoleAssistant

--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -748,6 +748,7 @@ func InsertScreen(ctx context.Context, sessionId string, origScreenName string, 
 			return nil, txErr
 		}
 		update.Sessions = []*SessionType{bareSession}
+		update.OpenAICmdInfoChat = ScreenMemGetCmdInfoChat(newScreenId).Messages
 	}
 	return update, nil
 }
@@ -856,14 +857,17 @@ func GetCmdByScreenId(ctx context.Context, screenId string, lineId string) (*Cmd
 
 func UpdateWithAddNewOpenAICmdInfoPacket(ctx context.Context, screenId string, pk *packet.OpenAICmdInfoChatMessage) (*ModelUpdate, error) {
 	ScreenMemAddCmdInfoChatMessage(screenId, pk)
+	return UpdateWithCurrentOpenAICmdInfoChat(screenId)
+}
+
+func UpdateWithCurrentOpenAICmdInfoChat(screenId string) (*ModelUpdate, error) {
 	cmdInfoUpdate := ScreenMemGetCmdInfoChat(screenId).Messages
 	return &ModelUpdate{OpenAICmdInfoChat: cmdInfoUpdate}, nil
 }
 
 func UpdateWithUpdateOpenAICmdInfoPacket(ctx context.Context, screenId string, messageID int, pk *packet.OpenAICmdInfoChatMessage) (*ModelUpdate, error) {
 	ScreenMemUpdateCmdInfoChatMessage(screenId, messageID, pk)
-	cmdInfoUpdate := ScreenMemGetCmdInfoChat(screenId).Messages
-	return &ModelUpdate{OpenAICmdInfoChat: cmdInfoUpdate}, nil
+	return UpdateWithCurrentOpenAICmdInfoChat(screenId)
 }
 
 func UpdateCmdDoneInfo(ctx context.Context, ck base.CommandKey, donePk *packet.CmdDonePacketType, status string) (*ModelUpdate, error) {
@@ -1051,6 +1055,7 @@ func SwitchScreenById(ctx context.Context, sessionId string, screenId string) (*
 	memState := GetScreenMemState(screenId)
 	if memState != nil {
 		update.CmdLine = &memState.CmdInputText
+		update.OpenAICmdInfoChat = ScreenMemGetCmdInfoChat(screenId).Messages
 	}
 	return update, nil
 }

--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -854,6 +854,18 @@ func GetCmdByScreenId(ctx context.Context, screenId string, lineId string) (*Cmd
 	})
 }
 
+func UpdateWithAddNewOpenAICmdInfoPacket(ctx context.Context, screenId string, pk *packet.OpenAICmdInfoChatMessage) (*ModelUpdate, error) {
+	ScreenMemAddCmdInfoChatMessage(screenId, pk)
+	cmdInfoUpdate := ScreenMemGetCmdInfoChat(screenId).Messages
+	return &ModelUpdate{OpenAICmdInfoChat: cmdInfoUpdate}, nil
+}
+
+func UpdateWithUpdateOpenAICmdInfoPacket(ctx context.Context, screenId string, messageID int, pk *packet.OpenAICmdInfoChatMessage) (*ModelUpdate, error) {
+	ScreenMemUpdateCmdInfoChatMessage(screenId, messageID, pk)
+	cmdInfoUpdate := ScreenMemGetCmdInfoChat(screenId).Messages
+	return &ModelUpdate{OpenAICmdInfoChat: cmdInfoUpdate}, nil
+}
+
 func UpdateCmdDoneInfo(ctx context.Context, ck base.CommandKey, donePk *packet.CmdDonePacketType, status string) (*ModelUpdate, error) {
 	if donePk == nil {
 		return nil, fmt.Errorf("invalid cmddone packet")

--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -855,6 +855,11 @@ func GetCmdByScreenId(ctx context.Context, screenId string, lineId string) (*Cmd
 	})
 }
 
+func UpdateWithClearOpenAICmdInfo(screenId string) (*ModelUpdate, error) {
+	ScreenMemClearCmdInfoChat(screenId)
+	return UpdateWithCurrentOpenAICmdInfoChat(screenId)
+}
+
 func UpdateWithAddNewOpenAICmdInfoPacket(ctx context.Context, screenId string, pk *packet.OpenAICmdInfoChatMessage) (*ModelUpdate, error) {
 	ScreenMemAddCmdInfoChatMessage(screenId, pk)
 	return UpdateWithCurrentOpenAICmdInfoChat(screenId)

--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -871,7 +871,10 @@ func UpdateWithCurrentOpenAICmdInfoChat(screenId string) (*ModelUpdate, error) {
 }
 
 func UpdateWithUpdateOpenAICmdInfoPacket(ctx context.Context, screenId string, messageID int, pk *packet.OpenAICmdInfoChatMessage) (*ModelUpdate, error) {
-	ScreenMemUpdateCmdInfoChatMessage(screenId, messageID, pk)
+	err := ScreenMemUpdateCmdInfoChatMessage(screenId, messageID, pk)
+	if err != nil {
+		return nil, err
+	}
 	return UpdateWithCurrentOpenAICmdInfoChat(screenId)
 }
 

--- a/wavesrv/pkg/sstore/memops.go
+++ b/wavesrv/pkg/sstore/memops.go
@@ -62,10 +62,19 @@ func ScreenMemInitCmdInfoChat(screenId string) {
 		MessageID:           0,
 		IsAssistantResponse: true,
 		AssistantResponse: &packet.OpenAICmdInfoPacketOutputType{
-			Message: "Hello, do you need help with this command?",
+			Message: packet.OpenAICmdInfoChatGreetingMessage,
 		},
 	}
 	ScreenMemStore[screenId].AICmdInfoChat = &OpenAICmdInfoChatStore{MessageCount: 1, Messages: []*packet.OpenAICmdInfoChatMessage{greetingMessagePk}}
+}
+
+func ScreenMemClearCmdInfoChat(screenId string) {
+	MemLock.Lock()
+	defer MemLock.Unlock()
+	if ScreenMemStore[screenId] == nil {
+		ScreenMemStore[screenId] = &ScreenMemState{}
+	}
+	ScreenMemInitCmdInfoChat(screenId)
 }
 
 func ScreenMemAddCmdInfoChatMessage(screenId string, msg *packet.OpenAICmdInfoChatMessage) {

--- a/wavesrv/pkg/sstore/memops.go
+++ b/wavesrv/pkg/sstore/memops.go
@@ -61,23 +61,12 @@ type ScreenMemState struct {
 func ScreenMemDeepCopyCmdInfoChatStore(store *OpenAICmdInfoChatStore) *OpenAICmdInfoChatStore {
 	rtnMessages := []*packet.OpenAICmdInfoChatMessage{}
 	for index := 0; index < len(store.Messages); index++ {
-		messageToCopy := store.Messages[index]
-		rtnCurMessage := &packet.OpenAICmdInfoChatMessage{
-			MessageID:           messageToCopy.MessageID,
-			IsAssistantResponse: messageToCopy.IsAssistantResponse,
-			UserQuery:           messageToCopy.UserQuery,
-			UserEngineeredQuery: messageToCopy.UserEngineeredQuery,
-		}
+		messageToCopy := *store.Messages[index]
 		if messageToCopy.AssistantResponse != nil {
-			rtnCurMessage.AssistantResponse = &packet.OpenAICmdInfoPacketOutputType{
-				Message:      messageToCopy.AssistantResponse.Message,
-				Model:        messageToCopy.AssistantResponse.Model,
-				FinishReason: messageToCopy.AssistantResponse.FinishReason,
-				Created:      messageToCopy.AssistantResponse.Created,
-				Error:        messageToCopy.AssistantResponse.Error,
-			}
+			assistantResponseCopy := *messageToCopy.AssistantResponse
+			messageToCopy.AssistantResponse = &assistantResponseCopy
 		}
-		rtnMessages = append(rtnMessages, rtnCurMessage)
+		rtnMessages = append(rtnMessages, &messageToCopy)
 	}
 	rtn := &OpenAICmdInfoChatStore{MessageCount: store.MessageCount, Messages: rtnMessages}
 	return rtn

--- a/wavesrv/pkg/sstore/memops.go
+++ b/wavesrv/pkg/sstore/memops.go
@@ -5,6 +5,7 @@
 package sstore
 
 import (
+	"fmt"
 	"log"
 	"sync"
 
@@ -142,7 +143,7 @@ func ScreenMemGetCmdInfoChat(screenId string) *OpenAICmdInfoChatStore {
 	return ScreenMemDeepCopyCmdInfoChatStore(ScreenMemStore[screenId].AICmdInfoChat)
 }
 
-func ScreenMemUpdateCmdInfoChatMessage(screenId string, messageID int, msg *packet.OpenAICmdInfoChatMessage) {
+func ScreenMemUpdateCmdInfoChatMessage(screenId string, messageID int, msg *packet.OpenAICmdInfoChatMessage) error {
 	MemLock.Lock()
 	defer MemLock.Unlock()
 	if ScreenMemStore[screenId] == nil {
@@ -155,8 +156,9 @@ func ScreenMemUpdateCmdInfoChatMessage(screenId string, messageID int, msg *pack
 	if messageID >= 0 && messageID < len(CmdInfoChat.Messages) {
 		CmdInfoChat.Messages[messageID] = msg
 	} else {
-		log.Printf("ScreenMemUpdateCmdInfoChatMessage: error: Message Id out of range: %d", messageID)
+		return fmt.Errorf("ScreenMemUpdateCmdInfoChatMessage: error: Message Id out of range: %d", messageID)
 	}
+	return nil
 }
 
 func ScreenMemSetCmdInputText(screenId string, sp utilfn.StrWithPos, seqNum int) {

--- a/wavesrv/pkg/sstore/memops.go
+++ b/wavesrv/pkg/sstore/memops.go
@@ -57,6 +57,31 @@ type ScreenMemState struct {
 	AICmdInfoChat      *OpenAICmdInfoChatStore `json:"aicmdinfochat,omitempty"`
 }
 
+func ScreenMemDeepCopyCmdInfoChatStore(store *OpenAICmdInfoChatStore) *OpenAICmdInfoChatStore {
+	rtnMessages := []*packet.OpenAICmdInfoChatMessage{}
+	for index := 0; index < len(store.Messages); index++ {
+		messageToCopy := store.Messages[index]
+		rtnCurMessage := &packet.OpenAICmdInfoChatMessage{
+			MessageID:           messageToCopy.MessageID,
+			IsAssistantResponse: messageToCopy.IsAssistantResponse,
+			UserQuery:           messageToCopy.UserQuery,
+			UserEngineeredQuery: messageToCopy.UserEngineeredQuery,
+		}
+		if messageToCopy.AssistantResponse != nil {
+			rtnCurMessage.AssistantResponse = &packet.OpenAICmdInfoPacketOutputType{
+				Message:      messageToCopy.AssistantResponse.Message,
+				Model:        messageToCopy.AssistantResponse.Model,
+				FinishReason: messageToCopy.AssistantResponse.FinishReason,
+				Created:      messageToCopy.AssistantResponse.Created,
+				Error:        messageToCopy.AssistantResponse.Error,
+			}
+		}
+		rtnMessages = append(rtnMessages, rtnCurMessage)
+	}
+	rtn := &OpenAICmdInfoChatStore{MessageCount: store.MessageCount, Messages: rtnMessages}
+	return rtn
+}
+
 func ScreenMemInitCmdInfoChat(screenId string) {
 	greetingMessagePk := &packet.OpenAICmdInfoChatMessage{
 		MessageID:           0,
@@ -114,7 +139,7 @@ func ScreenMemGetCmdInfoChat(screenId string) *OpenAICmdInfoChatStore {
 	if ScreenMemStore[screenId].AICmdInfoChat == nil {
 		ScreenMemInitCmdInfoChat(screenId)
 	}
-	return ScreenMemStore[screenId].AICmdInfoChat
+	return ScreenMemDeepCopyCmdInfoChatStore(ScreenMemStore[screenId].AICmdInfoChat)
 }
 
 func ScreenMemUpdateCmdInfoChatMessage(screenId string, messageID int, msg *packet.OpenAICmdInfoChatMessage) {

--- a/wavesrv/pkg/sstore/updatebus.go
+++ b/wavesrv/pkg/sstore/updatebus.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"sync"
 
+	"github.com/wavetermdev/waveterm/waveshell/pkg/packet"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/utilfn"
 )
 
@@ -38,29 +39,30 @@ func (*PtyDataUpdate) UpdateType() string {
 func (pdu *PtyDataUpdate) Clean() {}
 
 type ModelUpdate struct {
-	Sessions          []*SessionType          `json:"sessions,omitempty"`
-	ActiveSessionId   string                  `json:"activesessionid,omitempty"`
-	Screens           []*ScreenType           `json:"screens,omitempty"`
-	ScreenLines       *ScreenLinesType        `json:"screenlines,omitempty"`
-	Line              *LineType               `json:"line,omitempty"`
-	Lines             []*LineType             `json:"lines,omitempty"`
-	Cmd               *CmdType                `json:"cmd,omitempty"`
-	CmdLine           *utilfn.StrWithPos      `json:"cmdline,omitempty"`
-	Info              *InfoMsgType            `json:"info,omitempty"`
-	ClearInfo         bool                    `json:"clearinfo,omitempty"`
-	Remotes           []RemoteRuntimeState    `json:"remotes,omitempty"`
-	History           *HistoryInfoType        `json:"history,omitempty"`
-	Interactive       bool                    `json:"interactive"`
-	Connect           bool                    `json:"connect,omitempty"`
-	MainView          string                  `json:"mainview,omitempty"`
-	Bookmarks         []*BookmarkType         `json:"bookmarks,omitempty"`
-	SelectedBookmark  string                  `json:"selectedbookmark,omitempty"`
-	HistoryViewData   *HistoryViewData        `json:"historyviewdata,omitempty"`
-	ClientData        *ClientData             `json:"clientdata,omitempty"`
-	RemoteView        *RemoteViewType         `json:"remoteview,omitempty"`
-	ScreenTombstones  []*ScreenTombstoneType  `json:"screentombstones,omitempty"`
-	SessionTombstones []*SessionTombstoneType `json:"sessiontombstones,omitempty"`
-	AlertMessage      *AlertMessageType       `json:"alertmessage,omitempty"`
+	Sessions          []*SessionType                     `json:"sessions,omitempty"`
+	ActiveSessionId   string                             `json:"activesessionid,omitempty"`
+	Screens           []*ScreenType                      `json:"screens,omitempty"`
+	ScreenLines       *ScreenLinesType                   `json:"screenlines,omitempty"`
+	Line              *LineType                          `json:"line,omitempty"`
+	Lines             []*LineType                        `json:"lines,omitempty"`
+	Cmd               *CmdType                           `json:"cmd,omitempty"`
+	CmdLine           *utilfn.StrWithPos                 `json:"cmdline,omitempty"`
+	Info              *InfoMsgType                       `json:"info,omitempty"`
+	ClearInfo         bool                               `json:"clearinfo,omitempty"`
+	Remotes           []RemoteRuntimeState               `json:"remotes,omitempty"`
+	History           *HistoryInfoType                   `json:"history,omitempty"`
+	Interactive       bool                               `json:"interactive"`
+	Connect           bool                               `json:"connect,omitempty"`
+	MainView          string                             `json:"mainview,omitempty"`
+	Bookmarks         []*BookmarkType                    `json:"bookmarks,omitempty"`
+	SelectedBookmark  string                             `json:"selectedbookmark,omitempty"`
+	HistoryViewData   *HistoryViewData                   `json:"historyviewdata,omitempty"`
+	ClientData        *ClientData                        `json:"clientdata,omitempty"`
+	RemoteView        *RemoteViewType                    `json:"remoteview,omitempty"`
+	ScreenTombstones  []*ScreenTombstoneType             `json:"screentombstones,omitempty"`
+	SessionTombstones []*SessionTombstoneType            `json:"sessiontombstones,omitempty"`
+	OpenAICmdInfoChat []*packet.OpenAICmdInfoChatMessage `json:"openaicmdinfochat,omitempty"`
+	AlertMessage      *AlertMessageType                  `json:"alertmessage,omitempty"`
 }
 
 func (*ModelUpdate) UpdateType() string {


### PR DESCRIPTION
This feature creates a chat window that the user can open with Ctrl + Space that will allow them to query chatgpt for help on their current command. ChatGPT will know the command that they are running and will be able to help directly

I have a chat window that opens when the user presses ctrl + space, a functional chatgpt chat, and various qol and ux features, such as ability to easily capture code blocks, a clear hotkey, etc

Bugs
- seems like sometimes on the first ui action things can get messed up. I've noticed that sometimes the first time I clear the chat window the lines window doesn't get updated correctly, leaving a black empty space, which gets fixed next time the window updates. I also noticed that sometimes the first time I switch tabs the chat window doesn't change to reflect the data of the new screen. These errors are spurious and rare and I think they're below the level of my code, unless there are special events for first time actions. Should still investigate further, but I think these are rare enough to be non blocking, unless others disagree
- Mike mentioned he didn't get history correctly. I think this has been fixed but should verify before merging