### PR TITLE
Allow dots in alias and add port to canonical name

### DIFF
--- a/wavesrv/db/migrations/000029_canonicalport.down.sql
+++ b/wavesrv/db/migrations/000029_canonicalport.down.sql
@@ -1,0 +1,12 @@
+UPDATE remote
+SET remotecanonicalname = SUBSTR(remotecanonicalname, 1, INSTR(remotecanonicalname, ':') - 1)
+WHERE INSTR(remotecanonicalname, ':');
+
+DELETE FROM remote
+WHERE remoteid NOT IN (
+    SELECT remoteid FROM (
+        SELECT MIN(archived), remoteid, remotecanonicalname
+        FROM remote
+        GROUP BY remotecanonicalname
+    )
+);

--- a/wavesrv/db/migrations/000029_canonicalport.up.sql
+++ b/wavesrv/db/migrations/000029_canonicalport.up.sql
@@ -1,4 +1,3 @@
 UPDATE remote
-SET remotecanonicalname = case when json_extract(sshopts, '$.issudo') then 'sudo@' else '' end ||
-       remoteuser || '@' || remotehost || COALESCE(':' || json_extract(sshopts, '$.sshport'), '')
+SET remotecanonicalname = remotecanonicalname || COALESCE( ":" || json_extract(sshopts, '$.sshport'), "")
 WHERE json_extract(sshopts, '$.sshport') != 22;

--- a/wavesrv/db/migrations/000029_canonicalport.up.sql
+++ b/wavesrv/db/migrations/000029_canonicalport.up.sql
@@ -1,0 +1,4 @@
+UPDATE remote
+SET remotecanonicalname = case when json_extract(sshopts, '$.issudo') then 'sudo@' else '' end ||
+       remoteuser || '@' || remotehost || COALESCE(':' || json_extract(sshopts, '$.sshport'), '')
+WHERE json_extract(sshopts, '$.sshport') != 22;

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -115,7 +115,7 @@ var SetVarScopes = []SetVarScope{
 	{ScopeName: "remote", VarNames: []string{}},
 }
 
-var userHostRe = regexp.MustCompile("^(sudo@)?([a-z][a-z0-9._@-]*)@([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$")
+var userHostRe = regexp.MustCompile(`^(sudo@)?([a-z][a-z0-9._@\\-]*)@([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$`)
 var remoteAliasRe = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 var genericNameRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_ .()<>,/\"'\\[\\]{}=+$@!*-]*$")
 var rendererRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_.:-]*$")

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -116,7 +116,7 @@ var SetVarScopes = []SetVarScope{
 }
 
 var userHostRe = regexp.MustCompile("^(sudo@)?([a-z][a-z0-9._@-]*)@([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$")
-var remoteAliasRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_-]*$")
+var remoteAliasRe = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 var genericNameRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_ .()<>,/\"'\\[\\]{}=+$@!*-]*$")
 var rendererRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_.:-]*$")
 var positionRe = regexp.MustCompile("^((S?\\+|E?-)?[0-9]+|(\\+|-|S|E))$")

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1629,13 +1629,9 @@ func RemoteConfigParseCommand(ctx context.Context, pk *scpacket.FeCommandPacketT
 		if previouslyImportedRemote != nil && !previouslyImportedRemote.Archived {
 			// this already existed and was created via import
 			// it needs to be updated instead of created
-
 			editMap := make(map[string]interface{})
 			editMap[sstore.RemoteField_Alias] = hostInfo.Host
 			editMap[sstore.RemoteField_ConnectMode] = hostInfo.ConnectMode
-			// changing port is unique to imports because it lets us avoid conflicts
-			// if the port is changed in the ssh config
-			editMap[sstore.RemoteField_SSHPort] = hostInfo.Port
 			if hostInfo.SshKeyFile != "" {
 				editMap[sstore.RemoteField_SSHKey] = hostInfo.SshKeyFile
 			}

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1257,6 +1257,9 @@ func parseRemoteEditArgs(isNew bool, pk *scpacket.FeCommandPacketType, isLocal b
 		}
 		sshOpts.SSHPort = portVal
 		canonicalName = remoteUser + "@" + remoteHost
+		if portVal != 0 && portVal != 22 {
+			canonicalName = canonicalName + ":" + strconv.Itoa(portVal)
+		}
 		if isSudo {
 			canonicalName = "sudo@" + canonicalName
 		}
@@ -1528,7 +1531,8 @@ func NewHostInfo(hostName string) (*HostInfoType, error) {
 
 	portStr, _ := ssh_config.GetStrict(hostName, "Port")
 	var portVal int
-	if portStr != "" {
+	if portStr != "" && portStr != "22" {
+		canonicalName = canonicalName + ":" + portStr
 		var err error
 		portVal, err = strconv.Atoi(portStr)
 		if err != nil {
@@ -1539,7 +1543,6 @@ func NewHostInfo(hostName string) (*HostInfoType, error) {
 			return nil, fmt.Errorf("could not parse port \"%d\": number is not valid for a port\n", portVal)
 		}
 	}
-
 	identityFile, _ := ssh_config.GetStrict(hostName, "IdentityFile")
 	passwordAuth, _ := ssh_config.GetStrict(hostName, "PasswordAuthentication")
 

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -115,7 +115,7 @@ var SetVarScopes = []SetVarScope{
 	{ScopeName: "remote", VarNames: []string{}},
 }
 
-var userHostRe = regexp.MustCompile(`^(sudo@)?([a-z][a-z0-9._@\\-]*)@([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$`)
+var userHostRe = regexp.MustCompile("^(sudo@)?([a-z][a-z0-9._@-]*)@([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$")
 var remoteAliasRe = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 var genericNameRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_ .()<>,/\"'\\[\\]{}=+$@!*-]*$")
 var rendererRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_.:-]*$")

--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -1704,7 +1704,6 @@ const (
 	RemoteField_ConnectMode = "connectmode" // string
 	RemoteField_SSHKey      = "sshkey"      // string
 	RemoteField_SSHPassword = "sshpassword" // string
-	RemoteField_SSHPort     = "sshport"     // string
 	RemoteField_Color       = "color"       // string
 )
 
@@ -1735,10 +1734,6 @@ func UpdateRemote(ctx context.Context, remoteId string, editMap map[string]inter
 		if sshPassword, found := editMap[RemoteField_SSHPassword]; found {
 			query = `UPDATE remote SET sshopts = json_set(sshopts, '$.sshpassword', ?) WHERE remoteid = ?`
 			tx.Exec(query, sshPassword, remoteId)
-		}
-		if sshPort, found := editMap[RemoteField_SSHPort]; found {
-			query = `UPDATE remote SET sshopts = json_set(sshopts, '$.sshport', ?) WHERE remoteid = ?`
-			tx.Exec(query, sshPort, remoteId)
 		}
 		if color, found := editMap[RemoteField_Color]; found {
 			query = `UPDATE remote SET remoteopts = json_set(remoteopts, '$.color', ?) WHERE remoteid = ?`

--- a/wavesrv/pkg/sstore/migrate.go
+++ b/wavesrv/pkg/sstore/migrate.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 )
 
-const MaxMigration = 28
+const MaxMigration = 29
 const MigratePrimaryScreenVersion = 9
 const CmdScreenSpecialMigration = 13
 const CmdLineSpecialMigration = 20


### PR DESCRIPTION
This has two changes to ssh.

The first is a small change that resolves #202 by allowing dots to be used in the alias for a remote connection.

The second is a slightly larger change that adds ports to the end of the canonical name if the port isn't 22. This addresses #204 by tracking each user/host/port as its own remote. As a small note, the down migration for this will delete duplicate user@hostname remotes to resolve conflicts with stripping off the port numbers in the canonical name. This should not be an issue for almost all users.