### PR TITLE
I18n fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "@tanstack/react-table": "^8.10.3",
         "@types/semver": "^7.5.6",
         "autobind-decorator": "^2.4.0",
+        "base64-js": "^1.5.1",
         "classnames": "^2.3.1",
         "dayjs": "^1.11.3",
         "dompurify": "^3.0.2",

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -9,6 +9,8 @@ import { boundMethod } from "autobind-decorator";
 import { debounce } from "throttle-debounce";
 import {
     handleJsonFetchResponse,
+    base64ToString,
+    stringToBase64,
     base64ToArray,
     genMergeData,
     genMergeDataMap,
@@ -335,7 +337,7 @@ class Cmd {
             type: "feinput",
             ck: this.screenId + "/" + this.lineId,
             remote: this.remote,
-            inputdata64: btoa(data),
+            inputdata64: stringToBase64(data),
         };
         GlobalModel.sendInputPacket(inputPacket);
     }
@@ -2865,7 +2867,7 @@ class RemotesModalModel {
         let inputPacket: RemoteInputPacketType = {
             type: "remoteinput",
             remoteid: remoteId,
-            inputdata64: btoa(event.key),
+            inputdata64: stringToBase64(event.key),
         };
         GlobalModel.sendInputPacket(inputPacket);
     }
@@ -3044,7 +3046,7 @@ class RemotesModel {
         let inputPacket: RemoteInputPacketType = {
             type: "remoteinput",
             remoteid: remoteId,
-            inputdata64: btoa(event.key),
+            inputdata64: stringToBase64(event.key),
         };
         GlobalModel.sendInputPacket(inputPacket);
     }
@@ -4196,7 +4198,7 @@ class Model {
                     return resp.text() as any;
                 }
                 contentType = resp.headers.get("Content-Type");
-                fileInfo = JSON.parse(atob(resp.headers.get("X-FileInfo")));
+                fileInfo = JSON.parse(base64ToString(resp.headers.get("X-FileInfo")));
                 return resp.blob();
             })
             .then((blobOrText: any) => {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -6,6 +6,7 @@ import { sprintf } from "sprintf-js";
 import dayjs from "dayjs";
 import localizedFormat from "dayjs/plugin/localizedFormat";
 import type { RemoteType, CommandRtnType } from "../types/types";
+import base64 from "base64-js";
 
 type OV<V> = mobx.IObservableValue<V>;
 
@@ -68,6 +69,16 @@ function handleJsonFetchResponse(url: URL, resp: any): Promise<any> {
     }
     let rtnData = fetchJsonData(resp, true);
     return rtnData;
+}
+
+function base64ToString(b64: string): string {
+    let stringBytes = base64.toByteArray(b64)
+    return new TextDecoder().decode(stringBytes)
+}
+
+function stringToBase64(input: string): string {
+    let stringBytes = new TextEncoder().encode(input)
+    return base64.fromByteArray(stringBytes)
 }
 
 function base64ToArray(b64: string): Uint8Array {
@@ -225,26 +236,6 @@ function genMergeDataMap<ObjType extends IObjType<DataType>, DataType extends ID
             continue;
         }
         obj.mergeData(dataItem);
-    }
-    return rtn;
-}
-
-function parseEnv0(envStr64: string): Map<string, string> {
-    let envStr = atob(envStr64);
-    let parts = envStr.split("\x00");
-    let rtn: Map<string, string> = new Map();
-    for (let i = 0; i < parts.length; i++) {
-        let part = parts[i];
-        if (part == "") {
-            continue;
-        }
-        let eqIdx = part.indexOf("=");
-        if (eqIdx == -1) {
-            continue;
-        }
-        let varName = part.substr(0, eqIdx);
-        let varVal = part.substr(eqIdx + 1);
-        rtn.set(varName, varVal);
     }
     return rtn;
 }
@@ -414,11 +405,12 @@ function getRemoteName(remote: RemoteType): string {
 
 export {
     handleJsonFetchResponse,
+    base64ToString,
+    stringToBase64,
     base64ToArray,
     genMergeData,
     genMergeDataMap,
     genMergeSimpleData,
-    parseEnv0,
     boundInt,
     isModKeyPress,
     incObs,

--- a/waveshell/pkg/packet/packet.go
+++ b/waveshell/pkg/packet/packet.go
@@ -927,14 +927,6 @@ func ParseJsonPacket(jsonBuf []byte) (PacketType, error) {
 	return pk, nil
 }
 
-func sanitizeBytes(buf []byte) {
-	for idx, b := range buf {
-		if b >= 127 || (b < 32 && b != 10 && b != 13) {
-			buf[idx] = '?'
-		}
-	}
-}
-
 type SendError struct {
 	IsWriteError   bool // fatal
 	IsMarshalError bool // not fatal
@@ -970,7 +962,6 @@ func MarshalPacket(packet PacketType) ([]byte, error) {
 	outBuf.Write(jsonBytes)
 	outBuf.WriteByte('\n')
 	outBytes := outBuf.Bytes()
-	sanitizeBytes(outBytes)
 	return outBytes, nil
 }
 

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -1126,6 +1126,7 @@ func addScVarsToState(state *packet.ShellState) *packet.ShellState {
 	envMap := shexec.DeclMapFromState(&rtn)
 	envMap["PROMPT"] = &shexec.DeclareDeclType{Name: "PROMPT", Value: "1", Args: "x"}
 	envMap["PROMPT_VERSION"] = &shexec.DeclareDeclType{Name: "PROMPT_VERSION", Value: scbase.WaveVersion, Args: "x"}
+	envMap["LANG"] = &shexec.DeclareDeclType{Name: "LANG", Value: scbase.DetermineLang(), Args: "x"}
 	rtn.ShellVars = shexec.SerializeDeclMap(envMap)
 	return &rtn
 }


### PR DESCRIPTION
This change addresses several issues around internationalization support. These changes fix issues #88 and #190 as well as improving some additional areas not discussed in those.

The first and most important is that it removes a filter used to sanitize json bytes prior to serializing them. This was removing non-ascii characters which broke commands containing non-ascii code.

The next change is fixing a couple instances in the frontend where `atob` and `btoa` were misused. Those functions don't work as expected, so they have been replaced with the base64-js library to handle the conversion. Note that this library was previously included as a dependency to another dependency in use, but it has been added to package.json to make that explicit.

There is another small dead code removal in the frontend for a utility function that is never used.

Lastly, this adds the ability to detect the locale of the OS and use it within waveterm. This is specifically required to show characters properly when they are in the filesystem. This locale is converted into a LANG variable and shared with the remote you are using to ensure both are in agreement. That said, I do have some concerns around a few areas of this. For one, it may be possible that multilingual users expect to have different locales on different remotes. Additionally, it does appear to be possible to set different locales to be used with different programs, but we don't support that currently. I think this is acceptable in the meantime, but these could become issues further down the line.