### PR TITLE
SSH Configuration Import Alert Modal

### DIFF
--- a/src/app/common/modals/modals.tsx
+++ b/src/app/common/modals/modals.tsx
@@ -996,7 +996,7 @@ class ViewRemoteConnDetailModal extends React.Component<{}, {}> {
                 <Button theme="secondary" disabled={true}>
                     Edit
                     <Tooltip
-                        message={`Remotes imported from an ssh config file cannot be edited inside waveterm. To edit these, you must edit the config file and import it again.`}
+                        message={`Connections imported from an ssh config file cannot be edited inside waveterm. To edit these, you must edit the config file and import it again.`}
                         icon={<i className="fa-sharp fa-regular fa-fw fa-ban" />}
                     >
                         <i className="fa-sharp fa-regular fa-fw fa-ban" />
@@ -1009,7 +1009,7 @@ class ViewRemoteConnDetailModal extends React.Component<{}, {}> {
                     <Tooltip
                         message={
                             <span>
-                                Remotes imported from an ssh config file can be deleted, but will come back upon
+                                Connections imported from an ssh config file can be deleted, but will come back upon
                                 importing again. They will stay removed if you follow{" "}
                                 <a href="https://docs.waveterm.dev/features/sshconfig-imports">this procedure</a>.
                             </span>

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -3755,6 +3755,10 @@ class Model {
                 this.remotesModel.openEditModal({ ...rview.remoteedit });
             }
         }
+        if (interactive && "alertmessage" in update) {
+            let alertMessage: AlertMessageType = update.alertmessage;
+            this.showAlert(alertMessage);
+        }
         if ("cmdline" in update) {
             this.inputModel.updateCmdLine(update.cmdline);
         }
@@ -4422,7 +4426,7 @@ class CommandRunner {
     }
 
     importSshConfig() {
-        GlobalModel.submitCommand("remote", "parse", null, null, false);
+        GlobalModel.submitCommand("remote", "parse", null, { nohist: "1", visual: "1" }, true);
     }
 
     screenSelectLine(lineArg: string, focusVal?: string) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -285,6 +285,7 @@ type ModelUpdateType = {
     clientdata?: ClientDataType;
     historyviewdata?: HistoryViewDataType;
     remoteview?: RemoteViewType;
+    alertmessage?: AlertMessageType;
 };
 
 type HistoryViewDataType = {

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1556,7 +1556,7 @@ func createSshImportSummary(changeList map[string][]string) string {
 	} else {
 		pluralize = "s"
 	}
-	return fmt.Sprintf("%d remote%s changed:\n\n%s", totalNumChanges, pluralize, strings.Join(outMsgs, "\n\n"))
+	return fmt.Sprintf("%d connection%s changed:\n\n%s", totalNumChanges, pluralize, strings.Join(outMsgs, "\n\n"))
 }
 
 func NewHostInfo(hostName string) (*HostInfoType, error) {

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1524,12 +1524,12 @@ func createSshImportSummary(changeList map[string][]string) string {
 		return "No changes made from ssh config import"
 	}
 	remoteStatusMsgs := map[string]string{
-		"delete":    "Deleted %d remote%s: %s",
-		"create":    "Created %d remote%s: %s",
-		"update":    "Edited %d remote%s: %s",
-		"deleteErr": "Error deleting %d remote%s: %s",
-		"createErr": "Error creating %d remote%s: %s",
-		"updateErr": "Error editing %d remote%s: %s",
+		"delete":    "Deleted %d connection%s: %s",
+		"create":    "Created %d connection%s: %s",
+		"update":    "Edited %d connection%s: %s",
+		"deleteErr": "Error deleting %d connection%s: %s",
+		"createErr": "Error creating %d connection%s: %s",
+		"updateErr": "Error editing %d connection%s: %s",
 	}
 
 	changeTypeKeys := []string{"delete", "create", "update", "deleteErr", "createErr", "updateErr"}

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1681,14 +1681,27 @@ func RemoteConfigParseCommand(ctx context.Context, pk *scpacket.FeCommandPacketT
 		}
 	}
 
-	update := &sstore.ModelUpdate{Remotes: remote.GetAllRemoteRuntimeState()}
-	update.Info = &sstore.InfoMsgType{}
+	var outMsg string
 	if len(updatedRemotes) == 0 {
-		update.Info.InfoMsg = "no connections imported from ssh config."
+		outMsg = "no connections imported from ssh config."
 	} else {
-		update.Info.InfoMsg = fmt.Sprintf("imported %d connection(s) from ssh config file: %s\n", len(updatedRemotes), strings.Join(updatedRemotes, ", "))
+		outMsg = fmt.Sprintf("imported %d connection(s) from ssh config file: %s\n", len(updatedRemotes), strings.Join(updatedRemotes, ", "))
 	}
-	return update, nil
+
+	visualEdit := resolveBool(pk.Kwargs["visual"], false)
+	if visualEdit {
+		update := &sstore.ModelUpdate{}
+		update.AlertMessage = &sstore.AlertMessageType{
+			Title:   "SSH Config Import",
+			Message: outMsg,
+		}
+		return update, nil
+	} else {
+		update := &sstore.ModelUpdate{}
+		update.Info = &sstore.InfoMsgType{}
+		update.Info.InfoMsg = outMsg
+		return update, nil
+	}
 }
 
 func ScreenShowAllCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (sstore.UpdatePacket, error) {

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1255,6 +1255,10 @@ func parseRemoteEditArgs(isNew bool, pk *scpacket.FeCommandPacketType, isLocal b
 		if portVal == 0 && uhPort != 0 {
 			portVal = uhPort
 		}
+		if portVal < 0 || portVal > 65535 {
+			// 0 is used as a sentinel value for the default in this case
+			return nil, fmt.Errorf("invalid port argument, \"%d\" is not in the range of 1 to 65535", portVal)
+		}
 		sshOpts.SSHPort = portVal
 		canonicalName = remoteUser + "@" + remoteHost
 		if portVal != 0 && portVal != 22 {
@@ -1580,7 +1584,7 @@ func NewHostInfo(hostName string) (*HostInfoType, error) {
 			// do not make assumptions about port if incorrectly configured
 			return nil, fmt.Errorf("could not parse \"%s\" (%s) - %s could not be converted to a valid port\n", hostName, canonicalName, portStr)
 		}
-		if int(int16(portVal)) != portVal {
+		if portVal <= 0 || portVal > 65535 {
 			return nil, fmt.Errorf("could not parse port \"%d\": number is not valid for a port\n", portVal)
 		}
 	}

--- a/wavesrv/pkg/sstore/updatebus.go
+++ b/wavesrv/pkg/sstore/updatebus.go
@@ -60,6 +60,7 @@ type ModelUpdate struct {
 	RemoteView        *RemoteViewType         `json:"remoteview,omitempty"`
 	ScreenTombstones  []*ScreenTombstoneType  `json:"screentombstones,omitempty"`
 	SessionTombstones []*SessionTombstoneType `json:"sessiontombstones,omitempty"`
+	AlertMessage      *AlertMessageType       `json:"alertmessage,omitempty"`
 }
 
 func (*ModelUpdate) UpdateType() string {
@@ -126,6 +127,13 @@ type RemoteEditType struct {
 	InfoStr     string `json:"infostr,omitempty"`
 	KeyStr      string `json:"keystr,omitempty"`
 	HasPassword bool   `json:"haspassword,omitempty"`
+}
+
+type AlertMessageType struct {
+	Title    string `json:"title,omitempty"`
+	Message  string `json:"message"`
+	Confirm  bool   `json:"confirm,omitempty"`
+	Markdown bool   `json:"markdown,omitempty"`
 }
 
 type InfoMsgType struct {


### PR DESCRIPTION
Previously, pressing the ssh configuration button left it unclear if anything changed. This changes that by popping up an alert modal that explains the deletions, creations, and updates made as a part of the import. The modal does not pop up when directly using the CLI.

Also, as a part of this change, the summary message that displays has been updated to give more detail about the types of changes that were made.