### PR TITLE
Add support for opening web links in the default browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "@tanstack/match-sorter-utils": "^8.8.4",
         "@tanstack/react-table": "^8.10.3",
         "@types/semver": "^7.5.6",
+        "@xterm/addon-web-links": "^0.10.0-beta.1",
         "autobind-decorator": "^2.4.0",
         "base64-js": "^1.5.1",
         "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
         "@tanstack/match-sorter-utils": "^8.8.4",
         "@tanstack/react-table": "^8.10.3",
         "@types/semver": "^7.5.6",
-        "@xterm/addon-web-links": "^0.10.0-beta.1",
         "autobind-decorator": "^2.4.0",
         "base64-js": "^1.5.1",
         "classnames": "^2.3.1",
@@ -37,7 +36,8 @@
         "tsx-control-statements": "^4.1.1",
         "uuid": "^9.0.0",
         "winston": "^3.8.2",
-        "xterm": "^5.0.0"
+        "xterm": "^5.0.0",
+        "xterm-addon-web-links": "^0.9.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.17.10",

--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -253,7 +253,6 @@ function createMainWindow(clientData) {
         icon: unamePlatform == "linux" ? "public/logos/wave-logo-dark.png" : undefined,
         webPreferences: {
             preload: path.join(getAppBasePath(), DistDir, "preload.js"),
-            nodeIntegration: true,
         },
     });
     let indexHtml = isDev ? "index-dev.html" : "index.html";

--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -683,7 +683,6 @@ function runActiveTimer() {
     setTimeout(runActiveTimer, 60000);
 }
 
-
 // ====== MAIN ====== //
 
 (async () => {

--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -253,6 +253,7 @@ function createMainWindow(clientData) {
         icon: unamePlatform == "linux" ? "public/logos/wave-logo-dark.png" : undefined,
         webPreferences: {
             preload: path.join(getAppBasePath(), DistDir, "preload.js"),
+            nodeIntegration: true,
         },
     });
     let indexHtml = isDev ? "index-dev.html" : "index.html";
@@ -485,6 +486,14 @@ electron.ipcMain.on("reload-window", (event) => {
     return;
 });
 
+electron.ipcMain.on("open-external-link", async (_, url) => {
+    try {
+        await electron.shell.openExternal(url);
+    } catch (err) {
+        console.warn("error opening external link", err);
+    }
+});
+
 electron.ipcMain.on("get-last-logs", async (event, numberOfLines) => {
     try {
         const logPath = path.join(getWaveHomeDir(), "wavesrv.log");
@@ -674,6 +683,7 @@ function runActiveTimer() {
     logActiveState();
     setTimeout(runActiveTimer, 60000);
 }
+
 
 // ====== MAIN ====== //
 

--- a/src/electron/preload.js
+++ b/src/electron/preload.js
@@ -12,6 +12,7 @@ contextBridge.exposeInMainWorld("api", {
     },
     restartWaveSrv: () => ipcRenderer.sendSync("restart-server"),
     reloadWindow: () => ipcRenderer.sendSync("reload-window"),
+    openExternalLink: (url) => ipcRenderer.send("open-external-link", url),
     onTCmd: (callback) => ipcRenderer.on("t-cmd", callback),
     onICmd: (callback) => ipcRenderer.on("i-cmd", callback),
     onLCmd: (callback) => ipcRenderer.on("l-cmd", callback),

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -195,6 +195,7 @@ type ElectronApi = {
     getWaveSrvStatus: () => boolean;
     restartWaveSrv: () => boolean;
     reloadWindow: () => void;
+    openExternalLink: (url: string) => void;
     onTCmd: (callback: (mods: KeyModsType) => void) => void;
     onICmd: (callback: (mods: KeyModsType) => void) => void;
     onLCmd: (callback: (mods: KeyModsType) => void) => void;
@@ -3254,6 +3255,16 @@ class Model {
 
     refreshClient(): void {
         getApi().reloadWindow();
+    }
+
+    /**
+     * Opens a new default browser window to the given url
+     * @param {string} url The url to open
+     */
+    static openExternalLink(url: string): void {
+        console.log("opening external link: " + url);
+        getApi().openExternalLink(url);
+        console.log("finished opening external link");
     }
 
     refocus() {

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -3261,7 +3261,7 @@ class Model {
      * Opens a new default browser window to the given url
      * @param {string} url The url to open
      */
-    static openExternalLink(url: string): void {
+    openExternalLink(url: string): void {
         console.log("opening external link: " + url);
         getApi().openExternalLink(url);
         console.log("finished opening external link");

--- a/src/plugins/terminal/term.ts
+++ b/src/plugins/terminal/term.ts
@@ -3,10 +3,12 @@
 
 import * as mobx from "mobx";
 import { Terminal } from "xterm";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import { sprintf } from "sprintf-js";
 import { boundMethod } from "autobind-decorator";
 import { windowWidthToCols, windowHeightToRows } from "../../util/textmeasure";
 import { boundInt } from "../../util/util";
+import { Model } from "../../model/model"
 import type {
     TermContextUnion,
     TermOptsType,
@@ -96,6 +98,10 @@ class TermWrap {
             fontFamily: "JetBrains Mono",
             theme: { foreground: terminal.foreground, background: terminal.background },
         });
+        this.terminal.loadAddon(new WebLinksAddon((e, uri) => {
+            e.preventDefault();
+            Model.openExternalLink(uri);
+        }));
         this.terminal._core._inputHandler._parser.setErrorHandler((state) => {
             this.numParseErrors++;
             return state;

--- a/src/plugins/terminal/term.ts
+++ b/src/plugins/terminal/term.ts
@@ -3,12 +3,13 @@
 
 import * as mobx from "mobx";
 import { Terminal } from "xterm";
-import { WebLinksAddon } from "@xterm/addon-web-links";
+//TODO: replace with `@xterm/addon-web-links` when it's available as stable
+import { WebLinksAddon } from "xterm-addon-web-links";
 import { sprintf } from "sprintf-js";
 import { boundMethod } from "autobind-decorator";
 import { windowWidthToCols, windowHeightToRows } from "../../util/textmeasure";
 import { boundInt } from "../../util/util";
-import { Model } from "../../model/model"
+import { GlobalModel } from "../../model/model"
 import type {
     TermContextUnion,
     TermOptsType,
@@ -100,7 +101,18 @@ class TermWrap {
         });
         this.terminal.loadAddon(new WebLinksAddon((e, uri) => {
             e.preventDefault();
-            Model.openExternalLink(uri);
+            switch (GlobalModel.platform) {
+                case "darwin":
+                    if (e.metaKey) {
+                        GlobalModel.openExternalLink(uri);
+                    }
+                    break;
+                default:
+                    if (e.ctrlKey) {
+                        GlobalModel.openExternalLink(uri);
+                    }
+                    break;
+            }
         }));
         this.terminal._core._inputHandler._parser.setErrorHandler((state) => {
             this.numParseErrors++;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2478,6 +2478,11 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
+"@xterm/addon-web-links@^0.10.0-beta.1":
+  version "0.10.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-web-links/-/addon-web-links-0.10.0-beta.1.tgz#6f2d629f54faf3ccbe55f6df1c7e4c0d4dd66959"
+  integrity sha512-eVsIGY8CNk/mJfHWTkPCQ0E/buOxVWKd+awk9EI8GF5rcQJWNHrm1agnZhtGzCTCBXirhnl4lNqyY+z1uwBADQ==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2478,11 +2478,6 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
-"@xterm/addon-web-links@^0.10.0-beta.1":
-  version "0.10.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@xterm/addon-web-links/-/addon-web-links-0.10.0-beta.1.tgz#6f2d629f54faf3ccbe55f6df1c7e4c0d4dd66959"
-  integrity sha512-eVsIGY8CNk/mJfHWTkPCQ0E/buOxVWKd+awk9EI8GF5rcQJWNHrm1agnZhtGzCTCBXirhnl4lNqyY+z1uwBADQ==
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -8470,6 +8465,11 @@ xmlbuilder@^15.1.1:
   version "15.1.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
   integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
+
+xterm-addon-web-links@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.9.0.tgz#c65b18588d1f613e703eb6feb7f129e7ff1c63e7"
+  integrity sha512-LIzi4jBbPlrKMZF3ihoyqayWyTXAwGfu4yprz1aK2p71e9UKXN6RRzVONR0L+Zd+Ik5tPVI9bwp9e8fDTQh49Q==
 
 xterm@^5.0.0:
   version "5.3.0"


### PR DESCRIPTION
Adds support for the xterm web-links addon, which identifies links in terminal output and makes them Cmd+Clickable (or Ctrl+Click for non-macOS). I intercept this event and send an asynchronous IPC to emain to open the link using `shell.openExternal()`.