### PR TITLE
Tweak the color of the output status indicator, adjust the placement of the tab end-icons a bit

### DIFF
--- a/src/app/common/common.less
+++ b/src/app/common/common.less
@@ -1162,7 +1162,6 @@
 .status-indicator {
     position: relative;
     top: 1px;
-    margin-right: 3px;
 
     &.error {
         color: @term-red;

--- a/src/app/common/common.less
+++ b/src/app/common/common.less
@@ -1171,6 +1171,6 @@
         color: @term-green;
     }
     &.output {
-        color: @text-primary;
+        color: @term-white;
     }
 }

--- a/src/app/workspace/screen/tab.tsx
+++ b/src/app/workspace/screen/tab.tsx
@@ -124,9 +124,11 @@ class ScreenTab extends React.Component<
                     {screen.name.get()}
                 </div>
                 <div className="end-icon">
-                    <StatusIndicator level={statusIndicatorLevel} />
-                    {tabIndex}
-                    {settings}
+                    <div className="end-icon-inner">
+                        <StatusIndicator level={statusIndicatorLevel}/>
+                        {tabIndex}
+                        {settings}
+                    </div>
                 </div>
             </Reorder.Item>
         );

--- a/src/app/workspace/screen/tabs.less
+++ b/src/app/workspace/screen/tabs.less
@@ -293,23 +293,25 @@
                 }
             }
 
+            // Only one of these will be visible at a time
             .end-icon {
                 margin: 0 6px;
-                .icon {
-                    margin: 0;
-                    padding: 0 6px;
-                    width: 0;
-                    border-radius: 50%;
-                }
                 .status-indicator {
                     display: block;
+                    // The status indicator is a little shorter than the text; this raises it up a bit so it's more centered vertically
+                    padding-bottom: 1px;
+                    margin-top: -1px;
                 }
                 .tab-gear {
                     display: none;
-                    // Account for the fact that the ellipsis icon is a little taller than the other icons
-                    margin-bottom: -2px;
+                    .icon {    
+                        // The ellipsis icon is a little narrower than the other icons; this pushes it to the right a bit so it's more centered horizontally
+                        padding: 0 8px 0 0;
+                        margin: 0 0 -2px 0;
+                        width: 0;
+                        border-radius: 50%;
+                    }
                 }
-
                 .tab-index {
                     display: none;
                     font-size: 0.9em;

--- a/src/app/workspace/screen/tabs.less
+++ b/src/app/workspace/screen/tabs.less
@@ -262,14 +262,14 @@
             display: flex;
             flex-direction: row;
             height: 3em;
-            min-width: 14em;
-            max-width: 14em;
+            min-width: 13.6em;
+            max-width: 13.6em;
             align-items: center;
             cursor: pointer;
-            padding: 0 4px 0 0;
+            padding: 0 8px 0 8px;
 
             .front-icon {
-                margin: 0 5px 0 8px;
+                margin-right: 5px;
                 .svg-icon svg {
                     width: 14px;
                     height: 14px;
@@ -282,6 +282,7 @@
 
             .tab-name {
                 flex-grow: 1;
+                width: 100%;
             }
 
             &.is-active {
@@ -298,7 +299,7 @@
             // Only one of these will be visible at a time
             .end-icon {
                 // This makes the calculations below easier since we don't need to account for the right margin on the parent tab.
-                margin: 0 -4px 0 0;
+                margin: 0 -8px 0 0;
                 .end-icon-inner {
                     & > div {
                         text-align: center;

--- a/src/app/workspace/screen/tabs.less
+++ b/src/app/workspace/screen/tabs.less
@@ -268,7 +268,7 @@
             cursor: pointer;
 
             .front-icon {
-                margin: 0 5px 0 5px;
+                margin: 0 5px 0 6px;
                 .svg-icon svg {
                     width: 14px;
                     height: 14px;
@@ -281,7 +281,6 @@
 
             .tab-name {
                 flex-grow: 1;
-                margin-right: 5px;
             }
 
             &.is-active {
@@ -297,30 +296,31 @@
 
             // Only one of these will be visible at a time
             .end-icon {
+                .end-icon-inner {
+                    & > div {
+                        text-align: center;
+                        align-items: center;
+                        & > * {
+                            margin: auto auto;
+                        }
+                        width: 20px;
+                    }
+                }
                 .status-indicator {
                     display: block;
                     // The status indicator is a little shorter than the text; this raises it up a bit so it's more centered vertically
                     padding-bottom: 1px;
                     margin-top: -1px;
-                    margin-right: 9px;
                 }
                 .tab-gear {
                     display: none;
-                    .icon {    
-                        // The ellipsis icon is a little narrower than the other icons; this pushes it to the right a bit so it's more centered horizontally
-                        // Using padding instead of margin so the clickable area is larger
-                        padding: 0 14px 0 0;
-                        margin: 0 0 -4px 0;
-                        width: 0;
+                    .icon {
                         border-radius: 50%;
                     }
                 }
                 .tab-index {
                     display: none;
                     font-size: 0.9em;
-                    // Slightly less padding to account for its width.
-                    margin-left: -1px;
-                    padding-right: 5px;
                 }
             }
 

--- a/src/app/workspace/screen/tabs.less
+++ b/src/app/workspace/screen/tabs.less
@@ -266,9 +266,10 @@
             max-width: 14em;
             align-items: center;
             cursor: pointer;
+            padding: 0 4px 0 0;
 
             .front-icon {
-                margin: 0 5px 0 6px;
+                margin: 0 5px 0 8px;
                 .svg-icon svg {
                     width: 14px;
                     height: 14px;
@@ -296,6 +297,8 @@
 
             // Only one of these will be visible at a time
             .end-icon {
+                // This makes the calculations below easier since we don't need to account for the right margin on the parent tab.
+                margin: 0 -4px 0 0;
                 .end-icon-inner {
                     & > div {
                         text-align: center;

--- a/src/app/workspace/screen/tabs.less
+++ b/src/app/workspace/screen/tabs.less
@@ -6,6 +6,7 @@
 
     &:first-child {
         border-radius: 8px 0px 0px 0px;
+        padding-left: 2px;
     }
 
     &.color-green,
@@ -267,10 +268,10 @@
             cursor: pointer;
 
             .front-icon {
-                margin: 0 12px;
+                margin: 0 6px 0 6px;
                 .svg-icon svg {
-                        width: 14px;
-                        height: 14px;
+                    width: 14px;
+                    height: 14px;
                 }
                 .fa-icon {
                     font-size: 16px;
@@ -295,7 +296,7 @@
 
             // Only one of these will be visible at a time
             .end-icon {
-                margin: 0 6px;
+                margin: 0 6px 0 0;
                 .status-indicator {
                     display: block;
                     // The status indicator is a little shorter than the text; this raises it up a bit so it's more centered vertically

--- a/src/app/workspace/screen/tabs.less
+++ b/src/app/workspace/screen/tabs.less
@@ -282,7 +282,6 @@
 
             .tab-name {
                 flex-grow: 1;
-                width: 100%;
             }
 
             &.is-active {

--- a/src/app/workspace/screen/tabs.less
+++ b/src/app/workspace/screen/tabs.less
@@ -277,7 +277,6 @@
                 .fa-icon {
                     font-size: 16px;
                 }
-    
             }
 
             .tab-name {

--- a/src/app/workspace/screen/tabs.less
+++ b/src/app/workspace/screen/tabs.less
@@ -6,7 +6,7 @@
 
     &:first-child {
         border-radius: 8px 0px 0px 0px;
-        padding-left: 2px;
+        padding-left: 5px;
     }
 
     &.color-green,
@@ -268,7 +268,7 @@
             cursor: pointer;
 
             .front-icon {
-                margin: 0 6px 0 6px;
+                margin: 0 5px 0 5px;
                 .svg-icon svg {
                     width: 14px;
                     height: 14px;
@@ -281,6 +281,7 @@
 
             .tab-name {
                 flex-grow: 1;
+                margin-right: 5px;
             }
 
             &.is-active {
@@ -296,19 +297,20 @@
 
             // Only one of these will be visible at a time
             .end-icon {
-                margin: 0 6px 0 0;
                 .status-indicator {
                     display: block;
                     // The status indicator is a little shorter than the text; this raises it up a bit so it's more centered vertically
                     padding-bottom: 1px;
                     margin-top: -1px;
+                    margin-right: 9px;
                 }
                 .tab-gear {
                     display: none;
                     .icon {    
                         // The ellipsis icon is a little narrower than the other icons; this pushes it to the right a bit so it's more centered horizontally
-                        padding: 0 8px 0 0;
-                        margin: 0 0 -2px 0;
+                        // Using padding instead of margin so the clickable area is larger
+                        padding: 0 14px 0 0;
+                        margin: 0 0 -4px 0;
                         width: 0;
                         border-radius: 50%;
                     }
@@ -316,6 +318,9 @@
                 .tab-index {
                     display: none;
                     font-size: 0.9em;
+                    // Slightly less padding to account for its width.
+                    margin-left: -1px;
+                    padding-right: 5px;
                 }
             }
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -4057,7 +4057,7 @@ class Model {
             this.inputModel.setOpenAICmdInfoChat(update.openaicmdinfochat);
         }
         if ("screenstatusindicator" in update) {
-            this.getScreenById_single(update.screenstatusindicator.screenid).setStatusIndicator(update.screenstatusindicator.status);
+            this.getScreenById_single(update.screenstatusindicator.screenid)?.setStatusIndicator(update.screenstatusindicator.status);
         }
         // console.log("run-update>", Date.now(), interactive, update);
     }


### PR DESCRIPTION
This adjusts the color of the output status indicator to be a little less vibrant. It also adjusts the margins and padding on the icons so they're all aligned better. I've reduced the margins on the `front-icon` to eke out a few more chars of title space. I've added a bit more padding to the first tab so it doesn't encroach on the sidebar too much. I've shrunk the tab width by a bit because the truncated text was overflowing a bit and getting too close to the edge of the tab