### PR TITLE
Fix tab drag events not registering state update

### DIFF
--- a/src/app/magiclayout.ts
+++ b/src/app/magiclayout.ts
@@ -22,7 +22,7 @@ let MagicLayout = {
     TermDescendersHeight: 3,
     TermWidthBuffer: 15,
 
-    TabWidth: 175,
+    TabWidth: 154,
 
     ScreenSidebarWidthPadding: 5,
     ScreenSidebarMinWidth: 200,

--- a/src/app/workspace/screen/tabs.tsx
+++ b/src/app/workspace/screen/tabs.tsx
@@ -21,7 +21,6 @@ class ScreenTabs extends React.Component<
     { showingScreens: Screen[]; scrollIntoViewTimeout: number }
 > {
     tabsRef: React.RefObject<any> = React.createRef();
-    tabRefs: { [screenId: string]: React.RefObject<any> } = {};
     lastActiveScreenId: string = null;
     dragEndTimeout = null;
     scrollIntoViewTimeoutId = null;
@@ -167,16 +166,6 @@ class ScreenTabs extends React.Component<
             event.preventDefault();
         }
         // For touchpad events, do nothing and let the browser handle it
-    }
-
-    @boundMethod
-    openScreenSettings(e: any, screen: Screen): void {
-        e.preventDefault();
-        e.stopPropagation();
-        mobx.action(() => {
-            GlobalModel.screenSettingsModal.set({ sessionId: screen.sessionId, screenId: screen.screenId });
-        })();
-        GlobalModel.modalsModel.pushModal(constants.SCREEN_SETTINGS);
     }
 
     render() {


### PR DESCRIPTION
Adjust the calculated tab width in `MagicLayout` to match the new narrower tab width. This fixes an issue where tabs dragged by one position were failing to update the tab order. Also removes some unused functions and variables in `tabs.tsx`.