### PR TITLE
Fixed chat bug "r.replace is not a function"

### DIFF
--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -868,11 +868,11 @@ class Markdown extends React.Component<
     {}
 > {
     CodeBlockRenderer(props: any, codeSelect: boolean, codeSelectIndex: number): any {
-        let codeText:string ="";
+        let codeText: string = "";
         try {
             codeText = props.node.children[0].children[0].value;
-        } catch (e) { 
-            console.log("code block text not parsed correctly")
+        } catch (e) {
+            console.log("code block text not parsed correctly");
         }
         if (codeText) {
             codeText = codeText.replace(/\n$/, ""); // remove trailing newline
@@ -1252,8 +1252,8 @@ class Modal extends React.Component<ModalProps> {
 }
 
 interface StatusIndicatorProps {
-    level: StatusIndicatorLevel
-    className?: string
+    level: StatusIndicatorLevel;
+    className?: string;
 }
 
 class StatusIndicator extends React.Component<StatusIndicatorProps> {
@@ -1273,7 +1273,11 @@ class StatusIndicator extends React.Component<StatusIndicatorProps> {
                     statusIndicatorClass = "error";
                     break;
             }
-            statusIndicator = <div className={`${this.props.className} fa-sharp fa-solid fa-circle-small status-indicator ${statusIndicatorClass}`}></div>;
+            statusIndicator = (
+                <div
+                    className={`${this.props.className} fa-sharp fa-solid fa-circle-small status-indicator ${statusIndicatorClass}`}
+                ></div>
+            );
         }
         return statusIndicator;
     }

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -830,7 +830,7 @@ function CodeRenderer(props: any): any {
 
 @mobxReact.observer
 class CodeBlockMarkdown extends React.Component<
-    { children: React.ReactNode; blockText: string; codeSelectSelectedIndex?: number },
+    { children: React.ReactNode; codeSelectSelectedIndex?: number },
     {}
 > {
     blockIndex: number;
@@ -843,7 +843,6 @@ class CodeBlockMarkdown extends React.Component<
     }
 
     render() {
-        let codeText = this.props.blockText;
         let clickHandler: (e: React.MouseEvent<HTMLElement>, blockIndex: number) => void;
         let inputModel = GlobalModel.inputModel;
         clickHandler = (e: React.MouseEvent<HTMLElement>, blockIndex: number) => {
@@ -868,24 +867,20 @@ class Markdown extends React.Component<
     {}
 > {
     CodeBlockRenderer(props: any, codeSelect: boolean, codeSelectIndex: number): any {
-        let codeText: string = "";
-        try {
-            codeText = props.node.children[0].children[0].value;
-        } catch (e) {
-            console.log("code block text not parsed correctly");
-        }
-        if (codeText) {
-            codeText = codeText.replace(/\n$/, ""); // remove trailing newline
-        }
         if (codeSelect) {
             return (
-                <CodeBlockMarkdown blockText={codeText} codeSelectSelectedIndex={codeSelectIndex}>
+                <CodeBlockMarkdown codeSelectSelectedIndex={codeSelectIndex}>
                     {props.children}
                 </CodeBlockMarkdown>
             );
         } else {
             let clickHandler = (e: React.MouseEvent<HTMLElement>) => {
-                navigator.clipboard.writeText(codeText);
+                let blockText = e.target.innerText;
+                console.log("Block Text: ", blockText)
+                if(blockText) {
+                    blockText = blockText.replace(/\n$/, ""); // remove trailing newline
+                    navigator.clipboard.writeText(blockText);
+                }
             };
             return <pre onClick={(event) => clickHandler(event)}>{props.children}</pre>;
         }

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -868,7 +868,12 @@ class Markdown extends React.Component<
     {}
 > {
     CodeBlockRenderer(props: any, codeSelect: boolean, codeSelectIndex: number): any {
-        let codeText = codeSelect ? props.node.children[0].children[0].value : props.children;
+        let codeText:string ="";
+        try {
+            codeText = props.node.children[0].children[0].value;
+        } catch (e) { 
+            console.log("code block text not parsed correctly")
+        }
         if (codeText) {
             codeText = codeText.replace(/\n$/, ""); // remove trailing newline
         }

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -829,10 +829,7 @@ function CodeRenderer(props: any): any {
 }
 
 @mobxReact.observer
-class CodeBlockMarkdown extends React.Component<
-    { children: React.ReactNode; codeSelectSelectedIndex?: number },
-    {}
-> {
+class CodeBlockMarkdown extends React.Component<{ children: React.ReactNode; codeSelectSelectedIndex?: number }, {}> {
     blockIndex: number;
     blockRef: React.RefObject<HTMLPreElement>;
 
@@ -868,16 +865,11 @@ class Markdown extends React.Component<
 > {
     CodeBlockRenderer(props: any, codeSelect: boolean, codeSelectIndex: number): any {
         if (codeSelect) {
-            return (
-                <CodeBlockMarkdown codeSelectSelectedIndex={codeSelectIndex}>
-                    {props.children}
-                </CodeBlockMarkdown>
-            );
+            return <CodeBlockMarkdown codeSelectSelectedIndex={codeSelectIndex}>{props.children}</CodeBlockMarkdown>;
         } else {
             let clickHandler = (e: React.MouseEvent<HTMLElement>) => {
                 let blockText = e.target.innerText;
-                console.log("Block Text: ", blockText)
-                if(blockText) {
+                if (blockText) {
                     blockText = blockText.replace(/\n$/, ""); // remove trailing newline
                     navigator.clipboard.writeText(blockText);
                 }


### PR DESCRIPTION
This pr fixes the chat bug when rendering code blocks. The issue was that I had old code for finding the text value of a `<code>` block, but after a refactor, only `<pre>` elements were going through the CodeBlockRender function

