### PR TITLE
Add view menu with zoom controls

### DIFF
--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -189,10 +189,13 @@ let menuTemplate = [
     },
     {
         label: "File",
-        submenu: [{ role: "close" }, { role: "forceReload" }],
+        submenu: [{ role: "close" },],
     },
     {
         role: "editMenu",
+    },
+    {
+        role: "viewMenu",
     },
     {
         role: "windowMenu",


### PR DESCRIPTION
This adds the default View menu, which contains controls for window zoom (and the corresponding default keybindings), and reload and devtools controls. Since the view menu is the default location for reload, I've removed it from the File menu.

I've tested the zoom and did not see any issues with formatting.