### PR TITLE
Fix bug where active session ID is sometimes not persisted

### DIFF
--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -1056,6 +1056,7 @@ func getNextId(ids []string, delId string) string {
 }
 
 func SwitchScreenById(ctx context.Context, sessionId string, screenId string) (*ModelUpdate, error) {
+	SetActiveSessionId(ctx, sessionId)
 	txErr := WithTx(ctx, func(tx *TxWrap) error {
 		query := `SELECT screenid FROM screen WHERE sessionid = ? AND screenid = ?`
 		if !tx.Exists(query, sessionId, screenId) {


### PR DESCRIPTION
This mainly impacts users of the new command pallet, since other UIs call the SessionCommand when switching workspaces. This would manifest as screen status indicators showing up even on the active screen.