### PR TITLE
Prevent the status indicator flickering for quick-returning commands

### DIFF
--- a/src/app/common/icons/icons.less
+++ b/src/app/common/icons/icons.less
@@ -48,10 +48,21 @@
     }
 }
 
+/* 
+The following accounts for a debounce in the status indicator. We will only display the status indicator icon if the parent indicates that it should be visible AND one of the following is true:
+1. There is a status to be shown.
+2. There is a spinner to be shown and the required delay has passed.
+*/
 .status-indicator-visible {
-    .positional-icon-visible;
+    &.spinner-visible,
+    &.output,
+    &.error,
+    &.success {
+        .positional-icon-visible;
+    }
 
-    &.spin.spinner-visible {
+    // This is set by the timeout in the status indicator component.
+    &.spinner-visible {
         #spinner {
             visibility: visible;
         }

--- a/src/app/common/icons/icons.less
+++ b/src/app/common/icons/icons.less
@@ -48,13 +48,22 @@
     }
 }
 
+.status-indicator-visible {
+    .positional-icon-visible;
+
+    &.spin.spinner-visible {
+        #spinner {
+            visibility: visible;
+        }
+    }
+}
+
 .status-indicator {
     #spinner,
     #indicator {
         visibility: hidden;
     }
     .spin #spinner {
-        visibility: visible;
         stroke: @term-white;
     }
     &.error #indicator {

--- a/src/app/common/icons/icons.tsx
+++ b/src/app/common/icons/icons.tsx
@@ -188,7 +188,7 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
     }
 
     render() {
-        const { level, className } = this.props;
+        const { level, className, runningCommands } = this.props;
         const spinnerVisible = this.spinnerVisible.get();
         let statusIndicator = null;
         if (level != StatusIndicatorLevel.None || spinnerVisible) {
@@ -216,7 +216,7 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
             );
         }
         return (
-            <SyncSpin classRef={this.iconRef} shouldSync={spinnerVisible}>
+            <SyncSpin classRef={this.iconRef} shouldSync={runningCommands}>
                 {statusIndicator}
             </SyncSpin>
         );

--- a/src/app/common/icons/icons.tsx
+++ b/src/app/common/icons/icons.tsx
@@ -10,6 +10,8 @@ interface PositionalIconProps {
     children?: React.ReactNode;
     className?: string;
     onClick?: React.MouseEventHandler<HTMLDivElement>;
+    onMount?: () => void;
+    onUnmount?: () => void;
     divRef?: React.RefObject<HTMLDivElement>;
 }
 
@@ -28,13 +30,19 @@ export class FrontIcon extends React.Component<PositionalIconProps> {
 }
 
 export class CenteredIcon extends React.Component<PositionalIconProps> {
+    componentDidMount(): void {
+        if (this.props.onMount) {
+            this.props.onMount();
+        }
+    }
+    componentWillUnmount(): void {
+        if (this.props.onUnmount) {
+            this.props.onUnmount();
+        }
+    }
     render() {
         return (
-            <div
-                ref={this.props.divRef}
-                className={cn("centered-icon", "positional-icon", this.props.className)}
-                onClick={this.props.onClick}
-            >
+            <div className={cn("centered-icon", "positional-icon", this.props.className)} onClick={this.props.onClick}>
                 <div className="positional-icon-inner">{this.props.children}</div>
             </div>
         );

--- a/src/app/common/icons/icons.tsx
+++ b/src/app/common/icons/icons.tsx
@@ -32,7 +32,11 @@ export class FrontIcon extends React.Component<PositionalIconProps> {
 export class CenteredIcon extends React.Component<PositionalIconProps> {
     render() {
         return (
-            <div className={cn("centered-icon", "positional-icon", this.props.className)} onClick={this.props.onClick}>
+            <div
+                ref={this.props.divRef}
+                className={cn("centered-icon", "positional-icon", this.props.className)}
+                onClick={this.props.onClick}
+            >
                 <div className="positional-icon-inner">{this.props.children}</div>
             </div>
         );

--- a/src/app/common/icons/icons.tsx
+++ b/src/app/common/icons/icons.tsx
@@ -192,16 +192,16 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
         const spinnerVisible = this.spinnerVisible.get();
         let statusIndicator = null;
         if (level != StatusIndicatorLevel.None || spinnerVisible) {
-            let levelClass = null;
+            let indicatorLevelClass = null;
             switch (level) {
                 case StatusIndicatorLevel.Output:
-                    levelClass = "output";
+                    indicatorLevelClass = "output";
                     break;
                 case StatusIndicatorLevel.Success:
-                    levelClass = "success";
+                    indicatorLevelClass = "success";
                     break;
                 case StatusIndicatorLevel.Error:
-                    levelClass = "error";
+                    indicatorLevelClass = "error";
                     break;
             }
 
@@ -209,7 +209,7 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
             statusIndicator = (
                 <CenteredIcon
                     divRef={this.iconRef}
-                    className={cn(className, levelClass, spinnerVisibleClass, "status-indicator")}
+                    className={cn(className, indicatorLevelClass, spinnerVisibleClass, "status-indicator")}
                 >
                     <SpinnerIndicator className={spinnerVisible ? "spin" : null} />
                 </CenteredIcon>

--- a/src/app/common/icons/icons.tsx
+++ b/src/app/common/icons/icons.tsx
@@ -12,8 +12,6 @@ interface PositionalIconProps {
     children?: React.ReactNode;
     className?: string;
     onClick?: React.MouseEventHandler<HTMLDivElement>;
-    onMount?: () => void;
-    onUnmount?: () => void;
     divRef?: React.RefObject<HTMLDivElement>;
 }
 
@@ -32,16 +30,6 @@ export class FrontIcon extends React.Component<PositionalIconProps> {
 }
 
 export class CenteredIcon extends React.Component<PositionalIconProps> {
-    componentDidMount(): void {
-        if (this.props.onMount) {
-            this.props.onMount();
-        }
-    }
-    componentWillUnmount(): void {
-        if (this.props.onUnmount) {
-            this.props.onUnmount();
-        }
-    }
     render() {
         return (
             <div className={cn("centered-icon", "positional-icon", this.props.className)} onClick={this.props.onClick}>
@@ -136,20 +124,66 @@ class SyncSpin extends React.Component<{
 }
 
 interface StatusIndicatorProps {
+    /**
+     * The level of the status indicator. This will determine the color of the status indicator.
+     */
     level: StatusIndicatorLevel;
     className?: string;
+    /**
+     * If true, a spinner will be shown around the status indicator.
+     */
     runningCommands?: boolean;
 }
 
+/**
+ * This component is used to show the status of a command. It will show a spinner around the status indicator if there are running commands. It will also delay showing the spinner for a short time to prevent flickering.
+ */
 @mobxReact.observer
 export class StatusIndicator extends React.Component<StatusIndicatorProps> {
     iconRef: React.RefObject<HTMLDivElement> = React.createRef();
-    visible: mobx.IObservableValue<boolean> = mobx.observable.box(false);
-    timeout: number = 0;
+    spinnerVisible: mobx.IObservableValue<boolean> = mobx.observable.box(false);
+    timeout: NodeJS.Timeout;
+
+    /**
+     * This will apply a delay after there is a running command before showing the spinner. This prevents flickering for commands that return quickly.
+     */
+    updateMountCallback() {
+        const runningCommands = this.props.runningCommands ?? false;
+        if (runningCommands && !this.timeout) {
+            this.timeout = setTimeout(
+                mobx.action(() => {
+                    this.spinnerVisible.set(true);
+                }),
+                1000
+            );
+        } else if (!runningCommands && this.timeout) {
+            clearTimeout(this.timeout);
+            this.timeout = null;
+        }
+    }
+
+    componentDidUpdate(): void {
+        this.updateMountCallback();
+    }
+
+    componentDidMount(): void {
+        this.updateMountCallback();
+    }
+
+    componentWillUnmount(): void {
+        mobx.action(() => {
+            this.spinnerVisible.set(false);
+        })();
+        if (this.timeout) {
+            clearTimeout(this.timeout);
+            this.timeout = null;
+        }
+    }
 
     render() {
         const { level, className, runningCommands } = this.props;
         let statusIndicator = null;
+        const spinnerVisibleClass = this.spinnerVisible.get() ? "spinner-visible" : null;
         if (level != StatusIndicatorLevel.None || runningCommands) {
             let levelClass = null;
             switch (level) {
@@ -163,8 +197,12 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
                     levelClass = "error";
                     break;
             }
+
             statusIndicator = (
-                <CenteredIcon divRef={this.iconRef} className={cn(className, levelClass, "status-indicator")}>
+                <CenteredIcon
+                    divRef={this.iconRef}
+                    className={cn(className, levelClass, spinnerVisibleClass, "status-indicator")}
+                >
                     <SpinnerIndicator className={runningCommands ? "spin" : null} />
                 </CenteredIcon>
             );

--- a/src/app/common/icons/icons.tsx
+++ b/src/app/common/icons/icons.tsx
@@ -3,6 +3,8 @@ import { StatusIndicatorLevel } from "../../../types/types";
 import cn from "classnames";
 import { ReactComponent as SpinnerIndicator } from "../../assets/icons/spinner-indicator.svg";
 import { boundMethod } from "autobind-decorator";
+import * as mobx from "mobx";
+import * as mobxReact from "mobx-react";
 
 import { ReactComponent as RotateIconSvg } from "../../assets/icons/line/rotate.svg";
 
@@ -139,8 +141,11 @@ interface StatusIndicatorProps {
     runningCommands?: boolean;
 }
 
+@mobxReact.observer
 export class StatusIndicator extends React.Component<StatusIndicatorProps> {
     iconRef: React.RefObject<HTMLDivElement> = React.createRef();
+    visible: mobx.IObservableValue<boolean> = mobx.observable.box(false);
+    timeout: number = 0;
 
     render() {
         const { level, className, runningCommands } = this.props;

--- a/src/app/common/icons/icons.tsx
+++ b/src/app/common/icons/icons.tsx
@@ -148,6 +148,16 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
     spinnerVisible: mobx.IObservableValue<boolean> = mobx.observable.box(false);
     timeout: NodeJS.Timeout;
 
+    clearSpinnerTimeout() {
+        if (this.timeout) {
+            clearTimeout(this.timeout);
+            this.timeout = null;
+        }
+        mobx.action(() => {
+            this.spinnerVisible.set(false);
+        })();
+    }
+
     /**
      * This will apply a delay after there is a running command before showing the spinner. This prevents flickering for commands that return quickly.
      */
@@ -163,16 +173,6 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
         } else if (!runningCommands) {
             this.clearSpinnerTimeout();
         }
-    }
-
-    clearSpinnerTimeout() {
-        if (this.timeout) {
-            clearTimeout(this.timeout);
-            this.timeout = null;
-        }
-        mobx.action(() => {
-            this.spinnerVisible.set(false);
-        })();
     }
 
     componentDidUpdate(): void {

--- a/src/app/common/icons/icons.tsx
+++ b/src/app/common/icons/icons.tsx
@@ -161,14 +161,18 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
                 100
             );
         } else if (!runningCommands) {
-            if (this.timeout) {
-                clearTimeout(this.timeout);
-                this.timeout = null;
-            }
-            mobx.action(() => {
-                this.spinnerVisible.set(false);
-            })();
+            this.clearSpinnerTimeout();
         }
+    }
+
+    clearSpinnerTimeout() {
+        if (this.timeout) {
+            clearTimeout(this.timeout);
+            this.timeout = null;
+        }
+        mobx.action(() => {
+            this.spinnerVisible.set(false);
+        })();
     }
 
     componentDidUpdate(): void {
@@ -180,13 +184,7 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
     }
 
     componentWillUnmount(): void {
-        mobx.action(() => {
-            this.spinnerVisible.set(false);
-        })();
-        if (this.timeout) {
-            clearTimeout(this.timeout);
-            this.timeout = null;
-        }
+        this.clearSpinnerTimeout();
     }
 
     render() {

--- a/src/app/common/icons/icons.tsx
+++ b/src/app/common/icons/icons.tsx
@@ -158,11 +158,16 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
                 mobx.action(() => {
                     this.spinnerVisible.set(true);
                 }),
-                1000
+                100
             );
-        } else if (!runningCommands && this.timeout) {
-            clearTimeout(this.timeout);
-            this.timeout = null;
+        } else if (!runningCommands) {
+            if (this.timeout) {
+                clearTimeout(this.timeout);
+                this.timeout = null;
+            }
+            mobx.action(() => {
+                this.spinnerVisible.set(false);
+            })();
         }
     }
 
@@ -187,7 +192,6 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
     render() {
         const { level, className, runningCommands } = this.props;
         let statusIndicator = null;
-        const spinnerVisibleClass = this.spinnerVisible.get() ? "spinner-visible" : null;
         if (level != StatusIndicatorLevel.None || runningCommands) {
             let levelClass = null;
             switch (level) {
@@ -202,6 +206,7 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
                     break;
             }
 
+            const spinnerVisibleClass = this.spinnerVisible.get() ? "spinner-visible" : null;
             statusIndicator = (
                 <CenteredIcon
                     divRef={this.iconRef}

--- a/src/app/common/icons/icons.tsx
+++ b/src/app/common/icons/icons.tsx
@@ -188,9 +188,10 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
     }
 
     render() {
-        const { level, className, runningCommands } = this.props;
+        const { level, className } = this.props;
+        const spinnerVisible = this.spinnerVisible.get();
         let statusIndicator = null;
-        if (level != StatusIndicatorLevel.None || runningCommands) {
+        if (level != StatusIndicatorLevel.None || spinnerVisible) {
             let levelClass = null;
             switch (level) {
                 case StatusIndicatorLevel.Output:
@@ -204,18 +205,18 @@ export class StatusIndicator extends React.Component<StatusIndicatorProps> {
                     break;
             }
 
-            const spinnerVisibleClass = this.spinnerVisible.get() ? "spinner-visible" : null;
+            const spinnerVisibleClass = spinnerVisible ? "spinner-visible" : null;
             statusIndicator = (
                 <CenteredIcon
                     divRef={this.iconRef}
                     className={cn(className, levelClass, spinnerVisibleClass, "status-indicator")}
                 >
-                    <SpinnerIndicator className={runningCommands ? "spin" : null} />
+                    <SpinnerIndicator className={spinnerVisible ? "spin" : null} />
                 </CenteredIcon>
             );
         }
         return (
-            <SyncSpin classRef={this.iconRef} shouldSync={runningCommands}>
+            <SyncSpin classRef={this.iconRef} shouldSync={spinnerVisible}>
                 {statusIndicator}
             </SyncSpin>
         );

--- a/src/app/sidebar/sidebar.less
+++ b/src/app/sidebar/sidebar.less
@@ -188,7 +188,7 @@
         }
 
         &:not(:hover) .status-indicator {
-            .positional-icon-visible;
+            .status-indicator-visible;
         }
 
         &.workspaces {

--- a/src/app/workspace/screen/tabs.less
+++ b/src/app/workspace/screen/tabs.less
@@ -287,7 +287,7 @@
         }
 
         &:not(:hover) .status-indicator {
-            .positional-icon-visible;
+            .status-indicator-visible;
         }
 
         &:hover {


### PR DESCRIPTION
Before, the status indicator spinner would flicker on and then immediately off for commands that returned quickly. Now, we will apply a delay of 100ms before showing the spinner and we will clear the delay if the command returns before it expires.