### PR TITLE
Fix sidebar width not persisting when un-collapsing

### DIFF
--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -1358,7 +1358,6 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
             } else if (newWidth > snapPoint) {
                 mainSidebarModel.setTempWidthAndTempCollapsed(newWidth, false);
             }
-            console.log(mainSidebarModel.tempWidth.get(), mainSidebarModel.tempCollapsed.get());
         } else {
             if (newWidth <= MagicLayout.MainSidebarMinWidth) {
                 mainSidebarModel.setTempWidthAndTempCollapsed(newWidth, true);

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -1312,13 +1312,13 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
     onMouseMove(event: MouseEvent) {
         event.preventDefault();
 
-        let { parentRef, enableSnap, position } = this.props;
-        let parentRect = parentRef.current?.getBoundingClientRect();
-        let mainSidebarModel = GlobalModel.mainSidebarModel;
+        const { parentRef, enableSnap, position } = this.props;
+        const parentRect = parentRef.current?.getBoundingClientRect();
+        const mainSidebarModel = GlobalModel.mainSidebarModel;
 
         if (!mainSidebarModel.isDragging.get() || !parentRect) return;
 
-        let delta, newWidth;
+        let delta: number, newWidth: number;
 
         if (position === "right") {
             delta = parentRect.right - event.clientX - this.startX;
@@ -1329,10 +1329,11 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
         newWidth = this.resizeStartWidth + delta;
 
         if (enableSnap) {
-            let minWidth = MagicLayout.MainSidebarMinWidth;
-            let snapPoint = minWidth + MagicLayout.MainSidebarSnapThreshold;
-            let dragResistance = MagicLayout.MainSidebarDragResistance;
-            let dragDirection;
+            const minWidth = MagicLayout.MainSidebarMinWidth;
+            const snapPoint = minWidth + MagicLayout.MainSidebarSnapThreshold;
+            const dragResistance = MagicLayout.MainSidebarDragResistance;
+            console.log("onMouseMove snap newWidth", newWidth);
+            let dragDirection: string;
 
             if (delta - this.prevDelta > 0) {
                 dragDirection = "+";
@@ -1345,6 +1346,7 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
             } else {
                 dragDirection = "-";
             }
+            console.log("onMouseMove snap dragDirection", dragDirection);
 
             this.prevDelta = delta;
             this.prevDragDirection = dragDirection;
@@ -1358,7 +1360,13 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
             } else if (newWidth > snapPoint) {
                 mainSidebarModel.setTempWidthAndTempCollapsed(newWidth, false);
             }
+            console.log(
+                "end of onMouseMove, current temp width and collapsed",
+                mainSidebarModel.tempWidth.get(),
+                mainSidebarModel.tempCollapsed.get()
+            );
         } else {
+            console.log("onMouseMove noSnap newWidth", newWidth);
             if (newWidth <= MagicLayout.MainSidebarMinWidth) {
                 mainSidebarModel.setTempWidthAndTempCollapsed(newWidth, true);
             } else {
@@ -1379,6 +1387,7 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
                 mainSidebarModel.isDragging.set(false);
             })();
         });
+        console.log("stopResizing", mainSidebarModel.tempWidth.get(), mainSidebarModel.tempCollapsed.get());
 
         document.removeEventListener("mousemove", this.onMouseMove);
         document.removeEventListener("mouseup", this.stopResizing);
@@ -1387,26 +1396,21 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
 
     @boundMethod
     toggleCollapsed() {
-        let mainSidebarModel = GlobalModel.mainSidebarModel;
+        console.log("toggleCollapsed start");
+        const mainSidebarModel = GlobalModel.mainSidebarModel;
 
-        let tempCollapsed = mainSidebarModel.getCollapsed();
-        let width = MagicLayout.MainSidebarDefaultWidth;
-        let newWidth;
-        if (tempCollapsed) {
-            newWidth = width;
-        } else {
-            newWidth = MagicLayout.MainSidebarMinWidth;
-        }
-
-        mainSidebarModel.setTempWidthAndTempCollapsed(newWidth, !tempCollapsed);
-        GlobalCommandRunner.clientSetSidebar(newWidth, !tempCollapsed);
+        const tempCollapsed = mainSidebarModel.getCollapsed();
+        const width = mainSidebarModel.getWidth(true);
+        console.log("toggleCollapsed", width, !tempCollapsed);
+        mainSidebarModel.setTempWidthAndTempCollapsed(width, !tempCollapsed);
+        GlobalCommandRunner.clientSetSidebar(width, !tempCollapsed);
     }
 
     render() {
-        let { className, children } = this.props;
-        let mainSidebarModel = GlobalModel.mainSidebarModel;
-        let width = mainSidebarModel.getWidth();
-        let isCollapsed = mainSidebarModel.getCollapsed();
+        const { className, children } = this.props;
+        const mainSidebarModel = GlobalModel.mainSidebarModel;
+        const width = mainSidebarModel.getWidth();
+        const isCollapsed = mainSidebarModel.getCollapsed();
 
         return (
             <div className={cn("sidebar", className, { collapsed: isCollapsed })} style={{ width }}>

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -1332,7 +1332,6 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
             const minWidth = MagicLayout.MainSidebarMinWidth;
             const snapPoint = minWidth + MagicLayout.MainSidebarSnapThreshold;
             const dragResistance = MagicLayout.MainSidebarDragResistance;
-            console.log("onMouseMove snap newWidth", newWidth);
             let dragDirection: string;
 
             if (delta - this.prevDelta > 0) {
@@ -1346,7 +1345,6 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
             } else {
                 dragDirection = "-";
             }
-            console.log("onMouseMove snap dragDirection", dragDirection);
 
             this.prevDelta = delta;
             this.prevDragDirection = dragDirection;
@@ -1360,13 +1358,8 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
             } else if (newWidth > snapPoint) {
                 mainSidebarModel.setTempWidthAndTempCollapsed(newWidth, false);
             }
-            console.log(
-                "end of onMouseMove, current temp width and collapsed",
-                mainSidebarModel.tempWidth.get(),
-                mainSidebarModel.tempCollapsed.get()
-            );
+            console.log(mainSidebarModel.tempWidth.get(), mainSidebarModel.tempCollapsed.get());
         } else {
-            console.log("onMouseMove noSnap newWidth", newWidth);
             if (newWidth <= MagicLayout.MainSidebarMinWidth) {
                 mainSidebarModel.setTempWidthAndTempCollapsed(newWidth, true);
             } else {
@@ -1387,7 +1380,6 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
                 mainSidebarModel.isDragging.set(false);
             })();
         });
-        console.log("stopResizing", mainSidebarModel.tempWidth.get(), mainSidebarModel.tempCollapsed.get());
 
         document.removeEventListener("mousemove", this.onMouseMove);
         document.removeEventListener("mouseup", this.stopResizing);
@@ -1396,12 +1388,10 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
 
     @boundMethod
     toggleCollapsed() {
-        console.log("toggleCollapsed start");
         const mainSidebarModel = GlobalModel.mainSidebarModel;
 
         const tempCollapsed = mainSidebarModel.getCollapsed();
         const width = mainSidebarModel.getWidth(true);
-        console.log("toggleCollapsed", width, !tempCollapsed);
         mainSidebarModel.setTempWidthAndTempCollapsed(width, !tempCollapsed);
         GlobalCommandRunner.clientSetSidebar(width, !tempCollapsed);
     }

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -1304,7 +1304,9 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
 
         document.body.style.cursor = "col-resize";
         mobx.action(() => {
-            GlobalModel.mainSidebarModel.isDragging.set(true);
+            const sbm = GlobalModel.mainSidebarModel;
+            sbm.setTempWidthAndTempCollapsed(this.resizeStartWidth, sbm.getCollapsed());
+            sbm.isDragging.set(true);
         })();
     }
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -2645,7 +2645,6 @@ class MainSidebarModel {
      */
     getWidth(ignoreCollapse: boolean = false): number {
         const clientData = GlobalModel.clientData.get();
-        console.log("width before", clientData?.clientopts?.mainsidebar?.width);
         let width = clientData?.clientopts?.mainsidebar?.width ?? MagicLayout.MainSidebarDefaultWidth;
         if (this.isDragging.get()) {
             if (this.tempWidth.get() == null && width == null) {
@@ -2654,31 +2653,25 @@ class MainSidebarModel {
             if (this.tempWidth.get() == null) {
                 return width;
             }
-            console.log("dragging, tempWidth", this.tempWidth.get());
             return this.tempWidth.get();
         }
         // Set by CLI and collapsed
         if (this.getCollapsed()) {
             console.log("collapsed, width", width);
             if (ignoreCollapse) {
-                console.log("ignoreCollapse", ignoreCollapse);
                 return width;
             } else {
-                console.log("returning MagicLayout.MainSidebarMinWidth", MagicLayout.MainSidebarMinWidth);
                 return MagicLayout.MainSidebarMinWidth;
             }
         } else {
             if (width <= MagicLayout.MainSidebarMinWidth) {
-                console.log("width <= MagicLayout.MainSidebarMinWidth", width, MagicLayout.MainSidebarMinWidth);
                 width = MagicLayout.MainSidebarDefaultWidth;
             }
             const snapPoint = MagicLayout.MainSidebarMinWidth + MagicLayout.MainSidebarSnapThreshold;
             if (width < snapPoint || width > MagicLayout.MainSidebarMaxWidth) {
-                console.log("width < snapPoint || width > MagicLayout.MainSidebarMaxWidth", width, snapPoint);
                 width = MagicLayout.MainSidebarDefaultWidth;
             }
         }
-        console.log("width after", width);
         this.setTempWidthAndTempCollapsed(width, false);
         return width;
     }

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -2671,7 +2671,6 @@ class MainSidebarModel {
                 width = MagicLayout.MainSidebarDefaultWidth;
             }
         }
-        this.setTempWidthAndTempCollapsed(width, false);
         return width;
     }
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -2638,8 +2638,14 @@ class MainSidebarModel {
         })();
     }
 
-    getWidth(): number {
+    /**
+     * Gets the intended width for the sidebar. If the sidebar is being dragged, returns the tempWidth. If the sidebar is collapsed, returns the default width.
+     * @param ignoreCollapse If true, returns the persisted width even if the sidebar is collapsed.
+     * @returns The intended width for the sidebar or the default width if the sidebar is collapsed. Can be overridden using ignoreCollapse.
+     */
+    getWidth(ignoreCollapse: boolean = false): number {
         const clientData = GlobalModel.clientData.get();
+        console.log("width before", clientData?.clientopts?.mainsidebar?.width);
         let width = clientData?.clientopts?.mainsidebar?.width ?? MagicLayout.MainSidebarDefaultWidth;
         if (this.isDragging.get()) {
             if (this.tempWidth.get() == null && width == null) {
@@ -2648,26 +2654,32 @@ class MainSidebarModel {
             if (this.tempWidth.get() == null) {
                 return width;
             }
+            console.log("dragging, tempWidth", this.tempWidth.get());
             return this.tempWidth.get();
         }
         // Set by CLI and collapsed
-        if (this.getCollapsed() && width != MagicLayout.MainSidebarMinWidth) {
-            this.setTempWidthAndTempCollapsed(MagicLayout.MainSidebarMinWidth, true);
-            return MagicLayout.MainSidebarMinWidth;
-        }
-        // Set by CLI and not collapsed
-        if (!this.getCollapsed()) {
+        if (this.getCollapsed()) {
+            console.log("collapsed, width", width);
+            if (ignoreCollapse) {
+                console.log("ignoreCollapse", ignoreCollapse);
+                return width;
+            } else {
+                console.log("returning MagicLayout.MainSidebarMinWidth", MagicLayout.MainSidebarMinWidth);
+                return MagicLayout.MainSidebarMinWidth;
+            }
+        } else {
             if (width <= MagicLayout.MainSidebarMinWidth) {
+                console.log("width <= MagicLayout.MainSidebarMinWidth", width, MagicLayout.MainSidebarMinWidth);
                 width = MagicLayout.MainSidebarDefaultWidth;
             }
             const snapPoint = MagicLayout.MainSidebarMinWidth + MagicLayout.MainSidebarSnapThreshold;
             if (width < snapPoint || width > MagicLayout.MainSidebarMaxWidth) {
+                console.log("width < snapPoint || width > MagicLayout.MainSidebarMaxWidth", width, snapPoint);
                 width = MagicLayout.MainSidebarDefaultWidth;
             }
-            this.setTempWidthAndTempCollapsed(width, false);
-            return width;
         }
-        this.setTempWidthAndTempCollapsed(width, this.getCollapsed());
+        console.log("width after", width);
+        this.setTempWidthAndTempCollapsed(width, false);
         return width;
     }
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -2657,7 +2657,6 @@ class MainSidebarModel {
         }
         // Set by CLI and collapsed
         if (this.getCollapsed()) {
-            console.log("collapsed, width", width);
             if (ignoreCollapse) {
                 return width;
             } else {


### PR DESCRIPTION
The minimum sidebar width was being persisted in the database when the sidebar was collapsed, which meant that when uncollapsing, we would set it back to the default sidebar width. With this change, we only persist widths to the database if the sidebar is uncollapsed. This way, when toggling the sidebar from collapsed to uncollapsed, we restore the previous sidebar width from the database.