### PR TITLE
Fix onMouseDown causing width to snap back to persisted width

### DIFF
--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -1286,7 +1286,6 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
     @boundMethod
     startResizing(event: React.MouseEvent<HTMLDivElement>) {
         event.preventDefault();
-        console.log("startResizing");
 
         const { parentRef, position } = this.props;
         const parentRect = parentRef.current?.getBoundingClientRect();
@@ -1334,7 +1333,6 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
         }
 
         newWidth = this.resizeStartWidth + delta;
-        console.log("newWidth", newWidth);
 
         if (enableSnap) {
             const minWidth = MagicLayout.MainSidebarMinWidth;
@@ -1395,7 +1393,6 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
 
     @boundMethod
     toggleCollapsed() {
-        console.log("toggleCollapsed");
         const mainSidebarModel = GlobalModel.mainSidebarModel;
 
         const tempCollapsed = mainSidebarModel.getCollapsed();

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -1302,15 +1302,13 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
         const collapsed = mainSidebarModel.getCollapsed();
 
         this.resizeStartWidth = collapsed ? MagicLayout.MainSidebarMinWidth : mainSidebarModel.getWidth();
-        mainSidebarModel.setTempWidthAndTempCollapsed(this.resizeStartWidth, collapsed);
         document.addEventListener("mousemove", this.onMouseMove);
         document.addEventListener("mouseup", this.stopResizing);
 
         document.body.style.cursor = "col-resize";
         mobx.action(() => {
-            const sbm = GlobalModel.mainSidebarModel;
-            sbm.setTempWidthAndTempCollapsed(this.resizeStartWidth, sbm.getCollapsed());
-            sbm.isDragging.set(true);
+            mainSidebarModel.setTempWidthAndTempCollapsed(this.resizeStartWidth, collapsed);
+            mainSidebarModel.isDragging.set(true);
         })();
     }
 

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -1286,9 +1286,10 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
     @boundMethod
     startResizing(event: React.MouseEvent<HTMLDivElement>) {
         event.preventDefault();
+        console.log("startResizing");
 
-        let { parentRef, position } = this.props;
-        let parentRect = parentRef.current?.getBoundingClientRect();
+        const { parentRef, position } = this.props;
+        const parentRect = parentRef.current?.getBoundingClientRect();
 
         if (!parentRect) return;
 
@@ -1298,7 +1299,11 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
             this.startX = event.clientX - parentRect.left;
         }
 
-        this.resizeStartWidth = GlobalModel.mainSidebarModel.getWidth();
+        const sidebarModel = GlobalModel.mainSidebarModel;
+        const collapsed = sidebarModel.getCollapsed();
+
+        this.resizeStartWidth = collapsed ? MagicLayout.MainSidebarMinWidth : sidebarModel.getWidth();
+        sidebarModel.setTempWidthAndTempCollapsed(this.resizeStartWidth, collapsed);
         document.addEventListener("mousemove", this.onMouseMove);
         document.addEventListener("mouseup", this.stopResizing);
 
@@ -1329,6 +1334,7 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
         }
 
         newWidth = this.resizeStartWidth + delta;
+        console.log("newWidth", newWidth);
 
         if (enableSnap) {
             const minWidth = MagicLayout.MainSidebarMinWidth;
@@ -1389,6 +1395,7 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
 
     @boundMethod
     toggleCollapsed() {
+        console.log("toggleCollapsed");
         const mainSidebarModel = GlobalModel.mainSidebarModel;
 
         const tempCollapsed = mainSidebarModel.getCollapsed();

--- a/src/app/common/common.tsx
+++ b/src/app/common/common.tsx
@@ -1299,11 +1299,11 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
             this.startX = event.clientX - parentRect.left;
         }
 
-        const sidebarModel = GlobalModel.mainSidebarModel;
-        const collapsed = sidebarModel.getCollapsed();
+        const mainSidebarModel = GlobalModel.mainSidebarModel;
+        const collapsed = mainSidebarModel.getCollapsed();
 
-        this.resizeStartWidth = collapsed ? MagicLayout.MainSidebarMinWidth : sidebarModel.getWidth();
-        sidebarModel.setTempWidthAndTempCollapsed(this.resizeStartWidth, collapsed);
+        this.resizeStartWidth = collapsed ? MagicLayout.MainSidebarMinWidth : mainSidebarModel.getWidth();
+        mainSidebarModel.setTempWidthAndTempCollapsed(this.resizeStartWidth, collapsed);
         document.addEventListener("mousemove", this.onMouseMove);
         document.addEventListener("mouseup", this.stopResizing);
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -2632,6 +2632,8 @@ class MainSidebarModel {
     setTempWidthAndTempCollapsed(newWidth: number, newCollapsed: boolean): void {
         const width = Math.max(MagicLayout.MainSidebarMinWidth, Math.min(newWidth, MagicLayout.MainSidebarMaxWidth));
 
+        console.log("setTempWidthAndTempCollapsed", newWidth, width, newCollapsed);
+
         mobx.action(() => {
             this.tempWidth.set(width);
             this.tempCollapsed.set(newCollapsed);

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -2632,8 +2632,6 @@ class MainSidebarModel {
     setTempWidthAndTempCollapsed(newWidth: number, newCollapsed: boolean): void {
         const width = Math.max(MagicLayout.MainSidebarMinWidth, Math.min(newWidth, MagicLayout.MainSidebarMaxWidth));
 
-        console.log("setTempWidthAndTempCollapsed", newWidth, width, newCollapsed);
-
         mobx.action(() => {
             this.tempWidth.set(width);
             this.tempCollapsed.set(newCollapsed);


### PR DESCRIPTION
If you toggled to collapse a sidebar and then tried to drag it to a new width, the sidebar would jump to whatever was the last set temp width. Now, if the sidebar is collapsed and you go to move it, it will start at the collapsed width.