### PR TITLE
Shellpref for sshconfig import

### DIFF
--- a/src/app/common/modals/editremoteconn.less
+++ b/src/app/common/modals/editremoteconn.less
@@ -20,6 +20,12 @@
                 width: 100%;
             }
 
+            .import-edit-warning {
+                display: flex;
+                flex-direction: row;
+                align-items: flex-start;
+            }
+
             .name-actions-section {
                 margin-bottom: 10px;
                 display: flex;

--- a/src/app/common/modals/editremoteconn.tsx
+++ b/src/app/common/modals/editremoteconn.tsx
@@ -58,6 +58,10 @@ class EditRemoteConnModal extends React.Component<{}, {}> {
         return this.selectedRemote?.local;
     }
 
+    isImportedRemote(): boolean {
+        return this.selectedRemote?.sshconfigsrc == "sshconfig-import";
+    }
+
     componentDidMount(): void {
         mobx.action(() => {
             this.tempAlias.set(this.selectedRemote?.remotealias);
@@ -259,6 +263,27 @@ class EditRemoteConnModal extends React.Component<{}, {}> {
         );
     }
 
+    renderImportedRemoteEditWarning() {
+        return (
+            <div className="import-edit-warning">
+                <Tooltip
+                    message={
+                        <span>
+                            Most options for connections imported from an ssh config file cannot be edited. For these
+                            changes, you must edit the config file and import it again. The shell preference can be
+                            edited, but will return to the default if you import again. It will stay changed if you
+                            follow <a href="https://docs.waveterm.dev/features/sshconfig-imports">this procedure</a>.
+                        </span>
+                    }
+                    icon={<i className="fa-sharp fa-regular fa-fw fa-triangle-exclamation" />}
+                >
+                    <i className="fa-sharp fa-regular fa-fw fa-triangle-exclamation" />
+                </Tooltip>
+                &nbsp;SSH Config Import Behavior
+            </div>
+        );
+    }
+
     renderAuthMode() {
         let authMode = this.tempAuthMode.get();
         return (
@@ -344,6 +369,7 @@ class EditRemoteConnModal extends React.Component<{}, {}> {
             return null;
         }
         let isLocal = this.isLocalRemote();
+        let isImported = this.isImportedRemote();
         return (
             <Modal className="erconn-modal">
                 <Modal.Header title="Edit Connection" onClose={this.model.closeModal} />
@@ -351,9 +377,10 @@ class EditRemoteConnModal extends React.Component<{}, {}> {
                     <div className="name-actions-section">
                         <div className="name text-primary">{util.getRemoteName(this.selectedRemote)}</div>
                     </div>
-                    <If condition={!isLocal}>{this.renderAlias()}</If>
-                    <If condition={!isLocal}>{this.renderAuthMode()}</If>
-                    <If condition={!isLocal}>{this.renderConnectMode()}</If>
+                    <If condition={!isLocal && !isImported}>{this.renderAlias()}</If>
+                    <If condition={!isLocal && !isImported}>{this.renderAuthMode()}</If>
+                    <If condition={!isLocal && !isImported}>{this.renderConnectMode()}</If>
+                    <If condition={isImported}>{this.renderImportedRemoteEditWarning()}</If>
                     {this.renderShellPref()}
                     <If condition={!util.isBlank(this.remoteEdit?.errorstr)}>
                         <div className="settings-field settings-error">Error: {this.remoteEdit?.errorstr}</div>

--- a/src/app/common/modals/modals.tsx
+++ b/src/app/common/modals/modals.tsx
@@ -1026,17 +1026,6 @@ class ViewRemoteConnDetailModal extends React.Component<{}, {}> {
             cancelInstallButton = <></>;
         }
         if (remote.sshconfigsrc == "sshconfig-import") {
-            updateAuthButton = (
-                <Button theme="secondary" disabled={true}>
-                    Edit
-                    <Tooltip
-                        message={`Connections imported from an ssh config file cannot be edited inside waveterm. To edit these, you must edit the config file and import it again.`}
-                        icon={<i className="fa-sharp fa-regular fa-fw fa-ban" />}
-                    >
-                        <i className="fa-sharp fa-regular fa-fw fa-ban" />
-                    </Tooltip>
-                </Button>
-            );
             archiveButton = (
                 <Button theme="secondary" onClick={() => this.clickArchive()}>
                     Delete

--- a/src/app/common/modals/viewremoteconndetail.tsx
+++ b/src/app/common/modals/viewremoteconndetail.tsx
@@ -209,17 +209,6 @@ class ViewRemoteConnDetailModal extends React.Component<{}, {}> {
             cancelInstallButton = <></>;
         }
         if (remote.sshconfigsrc == "sshconfig-import") {
-            updateAuthButton = (
-                <Button theme="secondary" disabled={true}>
-                    Edit
-                    <Tooltip
-                        message={`Connections imported from an ssh config file cannot be edited inside waveterm. To edit these, you must edit the config file and import it again.`}
-                        icon={<i className="fa-sharp fa-regular fa-fw fa-ban" />}
-                    >
-                        <i className="fa-sharp fa-regular fa-fw fa-ban" />
-                    </Tooltip>
-                </Button>
-            );
             archiveButton = (
                 <Button theme="secondary" onClick={() => this.clickArchive()}>
                     Delete

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1420,9 +1420,6 @@ func RemoteSetCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (ss
 	if err != nil {
 		return nil, err
 	}
-	if ids.Remote.RState.SSHConfigSrc == sstore.SSHConfigSrcTypeImport {
-		return nil, fmt.Errorf("/remote:new cannot update imported remote")
-	}
 	visualEdit := resolveBool(pk.Kwargs["visual"], false)
 	isSubmitted := resolveBool(pk.Kwargs["submit"], false)
 	editArgs, err := parseRemoteEditArgs(false, pk, ids.Remote.MShell.IsLocal())

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1542,6 +1542,7 @@ type HostInfoType struct {
 	SshKeyFile    string
 	ConnectMode   string
 	Ignore        bool
+	ShellPref     string
 }
 
 func createSshImportSummary(changeList map[string][]string) string {
@@ -1637,6 +1638,13 @@ func NewHostInfo(hostName string) (*HostInfoType, error) {
 		connectMode = sstore.ConnectModeManual
 	}
 
+	shellPref := sstore.ShellTypePref_Detect
+	if cfgWaveOptions["shellpref"] == "bash" {
+		shellPref = "bash"
+	} else if cfgWaveOptions["shellpref"] == "zsh" {
+		shellPref = "zsh"
+	}
+
 	outHostInfo := new(HostInfoType)
 	outHostInfo.Host = hostName
 	outHostInfo.User = userName
@@ -1645,6 +1653,7 @@ func NewHostInfo(hostName string) (*HostInfoType, error) {
 	outHostInfo.SshKeyFile = sshKeyFile
 	outHostInfo.ConnectMode = connectMode
 	outHostInfo.Ignore = shouldIgnore
+	outHostInfo.ShellPref = shellPref
 	return outHostInfo, nil
 }
 
@@ -1709,6 +1718,7 @@ func RemoteConfigParseCommand(ctx context.Context, pk *scpacket.FeCommandPacketT
 			if hostInfo.SshKeyFile != "" {
 				editMap[sstore.RemoteField_SSHKey] = hostInfo.SshKeyFile
 			}
+			editMap[sstore.RemoteField_ShellPref] = hostInfo.ShellPref
 			msh := remote.GetRemoteById(previouslyImportedRemote.RemoteId)
 			if msh == nil {
 				remoteChangeList["updateErr"] = append(remoteChangeList["updateErr"], hostInfo.CanonicalName)
@@ -1716,7 +1726,7 @@ func RemoteConfigParseCommand(ctx context.Context, pk *scpacket.FeCommandPacketT
 				continue
 			}
 
-			if msh.Remote.ConnectMode == hostInfo.ConnectMode && msh.Remote.SSHOpts.SSHIdentity == hostInfo.SshKeyFile && msh.Remote.RemoteAlias == hostInfo.Host {
+			if msh.Remote.ConnectMode == hostInfo.ConnectMode && msh.Remote.SSHOpts.SSHIdentity == hostInfo.SshKeyFile && msh.Remote.RemoteAlias == hostInfo.Host && msh.Remote.ShellPref == hostInfo.ShellPref {
 				// silently skip this one. it didn't fail, but no changes were needed
 				continue
 			}
@@ -1753,6 +1763,7 @@ func RemoteConfigParseCommand(ctx context.Context, pk *scpacket.FeCommandPacketT
 				AutoInstall:         true,
 				SSHOpts:             sshOpts,
 				SSHConfigSrc:        sstore.SSHConfigSrcTypeImport,
+				ShellPref:           sstore.ShellTypePref_Detect,
 			}
 			err := remote.AddRemote(ctx, r, false)
 			if err != nil {


### PR DESCRIPTION
The shell preference did not properly work with the imported ssh config options. This fixes that and makes it possible to manually edit the shell preference after the fact.