### PR TITLE
removed i/l options in bash

### DIFF
--- a/waveshell/pkg/shellapi/bashapi.go
+++ b/waveshell/pkg/shellapi/bashapi.go
@@ -145,7 +145,7 @@ func GetBashShellState() (*packet.ShellState, error) {
 	ctx, cancelFn := context.WithTimeout(context.Background(), GetStateTimeout)
 	defer cancelFn()
 	cmdStr := BaseBashOpts + "; " + GetBashShellStateCmd()
-	ecmd := exec.CommandContext(ctx, GetLocalBashPath(), "-l", "-i", "-c", cmdStr)
+	ecmd := exec.CommandContext(ctx, GetLocalBashPath(), "-c", cmdStr)
 	outputBytes, err := RunSimpleCmdInPty(ecmd)
 	if err != nil {
 		return nil, err

--- a/waveshell/pkg/shellapi/zshapi.go
+++ b/waveshell/pkg/shellapi/zshapi.go
@@ -164,14 +164,14 @@ func (z zshShellApi) MakeRunCommand(cmdStr string, opts RunCommandOpts) string {
 }
 
 func (z zshShellApi) MakeShExecCommand(cmdStr string, rcFileName string, usePty bool) *exec.Cmd {
-	return exec.Command(GetLocalZshPath(), "-l", "-i", "-c", cmdStr)
+	return exec.Command(GetLocalZshPath(), "-c", cmdStr)
 }
 
 func (z zshShellApi) GetShellState() (*packet.ShellState, error) {
 	ctx, cancelFn := context.WithTimeout(context.Background(), GetStateTimeout)
 	defer cancelFn()
 	cmdStr := BaseZshOpts + "; " + GetZshShellStateCmd(StateOutputFdNum)
-	ecmd := exec.CommandContext(ctx, GetLocalZshPath(), "-l", "-i", "-c", cmdStr)
+	ecmd := exec.CommandContext(ctx, GetLocalZshPath(), "-c", cmdStr)
 	_, outputBytes, err := RunCommandWithExtraFd(ecmd, StateOutputFdNum)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The interactive/login options in bash/zsh end up causing considerable lag when executing each command because they reload the .profile, .bashrc, .zshrc. Since the state is provided explicitly by the temporary rc files there is no need to reload the default files. 