### PR TITLE
Fix History view not honoring sidebar width

### DIFF
--- a/src/app/history/history.tsx
+++ b/src/app/history/history.tsx
@@ -420,8 +420,7 @@ class HistoryView extends React.Component<{}, {}> {
         let remoteIds = Object.keys(rnames);
         let remoteId: string = null;
 
-        // Has to calc manually because when tabs overflow, the width of the session view is increased for some reason causing inconsistent width.
-        // 6px is the right margin of session view.
+        // TODO: something is weird with how we calculate width for views. Before, history view was not honoring tab width. This fix is copied from workspaceview.tsx, which had a similar issue.
         const width = window.innerWidth - 6 - GlobalModel.mainSidebarModel.getWidth();
         return (
             <div

--- a/src/app/history/history.tsx
+++ b/src/app/history/history.tsx
@@ -419,8 +419,17 @@ class HistoryView extends React.Component<{}, {}> {
         let sessionId: string = null;
         let remoteIds = Object.keys(rnames);
         let remoteId: string = null;
+
+        // Has to calc manually because when tabs overflow, the width of the session view is increased for some reason causing inconsistent width.
+        // 6px is the right margin of session view.
+        const width = window.innerWidth - 6 - GlobalModel.mainSidebarModel.getWidth();
         return (
-            <div className={cn("history-view", { "is-hidden": isHidden })}>
+            <div
+                className={cn("history-view", "view", { "is-hidden": isHidden })}
+                style={{
+                    width: `${width}px`,
+                }}
+            >
                 <div className="header">
                     <div className="history-title">History</div>
                     <div className="history-search">


### PR DESCRIPTION
This fixes an issue where History view was not honoring the sidebar width. It applies the same workaround used on Workspace view. This seems like a band-aid, but it helps. I also updated it to use the `view` class, so that it gets the fancy rounded corners of the other views.