### PR TITLE
Update to latest Go action in build-helper

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: macos-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: actions/setup-go@v4
+            - uses: actions/setup-go@v5
               with:
                   go-version: ${{env.GO_VERSION}}
                   cache-dependency-path: |
@@ -34,7 +34,7 @@ jobs:
         runs-on: macos-latest-xlarge
         steps:
             - uses: actions/checkout@v4
-            - uses: actions/setup-go@v4
+            - uses: actions/setup-go@v5
               with:
                   go-version: ${{env.GO_VERSION}}
                   cache-dependency-path: |
@@ -63,7 +63,7 @@ jobs:
               with:
                   repository: scripthaus-dev/scripthaus
                   path: scripthaus
-            - uses: actions/setup-go@v4
+            - uses: actions/setup-go@v5
               with:
                   go-version: ${{env.GO_VERSION}}
                   cache-dependency-path: |


### PR DESCRIPTION
Resolve deprecation warning for `actions/setup-go@v4`, which relied on a deprecated Node version.