### PR TITLE
Make build-helper more generic

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -5,9 +5,20 @@ env:
     GO_VERSION: "1.21.5"
     NODE_VERSION: "21.5.0"
 jobs:
-    runbuild-darwin-x64:
-        name: "Build MacOS x64"
-        runs-on: macos-latest
+    runbuild:
+        strategy:
+            matrix:
+                include:
+                    - platform: "darwin"
+                      arch: "x64"
+                      runner: "macos-latest"
+                    - platform: "darwin"
+                      arch: "arm64"
+                      runner: "macos-latest-xlarge"
+                    - platform: "linux"
+                      arch: "x64"
+                      runner: "ubuntu-latest"
+        runs-on: ${{ matrix.runner }}
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-go@v5
@@ -26,64 +37,29 @@ jobs:
             - run: scripthaus run build-package
             - uses: actions/upload-artifact@v4
               with:
-                  name: waveterm-build-darwin-x64
-                  path: out/make/zip/darwin/x64/*.zip
+                  name: waveterm-build-${{ matrix.platform }}-${{ matrix.arch }}
+                  path: out/make/zip/${{ matrix.platform }}/${{ matrix.arch }}/*.zip
                   retention-days: 2
-    runbuild-darwin-arm64:
-        name: "Build MacOS arm64"
-        runs-on: macos-latest-xlarge
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-go@v5
-              with:
-                  go-version: ${{env.GO_VERSION}}
-                  cache-dependency-path: |
-                      wavesrv/go.sum
-                      waveshell/go.sum
-            - run: brew tap scripthaus-dev/scripthaus
-            - run: brew install scripthaus
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: ${{env.NODE_VERSION}}
-                  cache: "yarn"
-            - run: yarn --frozen-lockfile
-            - run: scripthaus run build-package
-            - uses: actions/upload-artifact@v4
-              with:
-                  name: waveterm-build-darwin-arm64
-                  path: out/make/zip/darwin/arm64/*.zip
-                  retention-days: 2
-    runbuild-linux:
-        name: "Build Linux x64"
+    upload:
+        name: "Upload Builds"
         runs-on: ubuntu-latest
-        needs: [runbuild-darwin-x64, runbuild-darwin-arm64]
+        needs: [runbuild]
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/checkout@v4
-              with:
-                  repository: scripthaus-dev/scripthaus
-                  path: scripthaus
-            - uses: actions/setup-go@v5
-              with:
-                  go-version: ${{env.GO_VERSION}}
-                  cache-dependency-path: |
-                      wavesrv/go.sum
-                      waveshell/go.sum
-                      scripthaus/go.sum
-            - run: |
-                  go work use ./scripthaus;
-                  cd scripthaus;
-                  go get ./...;
-                  CGO_ENABLED=1 go build -o scripthaus cmd/main.go
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: ${{env.NODE_VERSION}}
-                  cache: "yarn"
-            - run: yarn --frozen-lockfile
-            - run: ./scripthaus/scripthaus run build-package-linux
             - uses: actions/download-artifact@v4
               with:
-                  merge-multiple: true
+                  name: waveterm-build-darwin-x64
+                  path: buildtemp
+            - run: |
+                  mv out/make/zip/darwin/x64/Wave-darwin-x64-$WAVETERM_VERSION.zip buildtemp/waveterm-darwin-x64-v$WAVETERM_VERSION.zip
+            - uses: actions/download-artifact@v4
+              with:
+                  name: waveterm-build-darwin-arm64
+                  path: buildtemp
+            - run: |
+                  mv out/make/zip/darwin/arm64/Wave-darwin-arm64-$WAVETERM_VERSION.zip buildtemp/waveterm-darwin-arm64-v$WAVETERM_VERSION.zip
+            - uses: actions/download-artifact@v4
+              with:
+                  name: waveterm-build-linux
                   path: buildtemp
             - run: |
                   mv out/make/zip/linux/x64/Wave-linux-x64-$WAVETERM_VERSION.zip buildtemp/waveterm-linux-x64-v$WAVETERM_VERSION.zip
@@ -93,8 +69,3 @@ jobs:
                   AWS_ACCESS_KEY_ID: "${{ secrets.S3_USERID }}"
                   AWS_SECRET_ACCESS_KEY: "${{ secrets.S3_SECRETKEY }}"
                   AWS_DEFAULT_REGION: us-west-2
-            - uses: actions/upload-artifact@v4
-              with:
-                  name: waveterm-builds
-                  path: buildtemp
-                  retention-days: 2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,70 +12,69 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  schedule:
-    - cron: '36 5 * * 5'
+    push:
+        branches: ["main"]
+    pull_request:
+        branches: ["main"]
+    schedule:
+        - cron: "36 5 * * 5"
 
 jobs:
-  analyze:
-    name: Analyze
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners
-    # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
+    analyze:
+        name: Analyze
+        # Runner size impacts CodeQL analysis time. To learn more, please see:
+        #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+        #   - https://gh.io/supported-runners-and-hardware-resources
+        #   - https://gh.io/using-larger-runners
+        # Consider using larger runners for possible analysis time improvements.
+        runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+        timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'go', 'javascript-typescript' ]
-        # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
-        # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        strategy:
+            fail-fast: false
+            matrix:
+                language: ["go", "javascript-typescript"]
+                # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
+                # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
+                # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+                # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+            # Initializes the CodeQL tools for scanning.
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                  languages: ${{ matrix.language }}
+                  # If you wish to specify custom queries, you can do so here or in a config file.
+                  # By default, queries listed here will override any specified in a config file.
+                  # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+                  # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+                  # queries: security-extended,security-and-quality
 
+            # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+            # If this step fails, then you should remove it and run the build manually (see below)
+            - name: Autobuild
+              uses: github/codeql-action/autobuild@v3
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+            # ℹ️ Command-line programs to run using the OS shell.
+            # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+            #   If the Autobuild fails above, remove it and uncomment the following three lines.
+            #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+            # - run: |
+            #     echo "Run, Build Application using script"
+            #     ./location_of_script_within_repo/buildscript.sh
 
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v3
+              with:
+                  category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This converts the `build-helper.yml` file into a workflow matrix, meaning more of the logic can be reused and made generic. This helps ensure that future changes we make to our workflow only need to be defined once, reducing the chance that we miss something.