### PR TITLE
Set build version programmatically in build-helper, fix broken build-universal script

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -44,6 +44,9 @@ jobs:
               with:
                   node-version: ${{env.NODE_VERSION}}
                   cache: "yarn"
+            - run: |
+                  VERSION=$(node -e 'console.log(require("./version.js"))')
+                  echo "WAVETERM_VERSION=${VERSION:1}" >> $GITHUB_ENV
             - run: yarn --frozen-lockfile
             - run: ./scripthaus/scripthaus run ${{ matrix.scripthaus }}
             - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -1,7 +1,6 @@
 name: "Build Helper"
 on: workflow_dispatch
 env:
-    WAVETERM_VERSION: 0.6.1
     GO_VERSION: "1.21.5"
     NODE_VERSION: "21.5.0"
 jobs:

--- a/buildres/build-universal.js
+++ b/buildres/build-universal.js
@@ -1,9 +1,9 @@
 const eu = require("@electron/universal");
 const path = require("path");
 
-let x64Path = path.resolve(__dirname, "temp", "x64", "Wave.app")
-let arm64Path = path.resolve(__dirname, "temp", "arm64", "Wave.app")
-let outPath = path.resolve(__dirname, "temp", "Wave.app")
+const x64Path = path.resolve(__dirname, "temp", "x64", "Wave.app");
+const arm64Path = path.resolve(__dirname, "temp", "arm64", "Wave.app");
+const outPath = path.resolve(__dirname, "temp", "Wave.app");
 
 console.log("building universal package");
 console.log("x64 path", x64Path);

--- a/buildres/build-universal.sh
+++ b/buildres/build-universal.sh
@@ -64,10 +64,10 @@ node $SCRIPT_DIR/build-universal.js
 rm -rf $TEMP_WAVE_DIR_UNIVERSAL/Contents/Resources/app
 mv $TEMP_DIR/app $TEMP_WAVE_DIR_UNIVERSAL/Contents/Resources/app
 node $SCRIPT_DIR/osx-sign.js
-DEBUG=electron-notarize node osx-notarize.js
+DEBUG=electron-notarize node $SCRIPT_DIR/osx-notarize.js
 echo "universal app creation success (build/sign/notarize)"
 
-UVERSION=$(node -e 'console.log(require("../version.js"))')
+UVERSION=$(node -e "console.log(require('${SCRIPT_DIR}/../version.js'))")
 UPACKAGE_NAME="waveterm-macos-universal-${UVERSION}"
 
 echo "creating universal zip"

--- a/buildres/build-universal.sh
+++ b/buildres/build-universal.sh
@@ -56,8 +56,8 @@ TEMP_WAVE_DIR_X64=$TEMP_DIR/arm64/Wave.app
 TEMP_WAVE_DIR_UNIVERSAL=$TEMP_DIR/Wave.app
 lipo -create -output $TEMP_DIR/wavesrv $TEMP_WAVE_DIR_X64/Contents/Resources/app/bin/wavesrv $TEMP_WAVE_DIR_ARM/Contents/Resources/app/bin/wavesrv
 rm -rf $TEMP_WAVE_DIR_ARM/Contents/Resources/app
-mv $TEMP_WAVE_DIR_X64/Contents/Resources/app temp/
-cp $TEMP_DIR/wavesrv temp/app/bin/wavesrv
+mv $TEMP_WAVE_DIR_X64/Contents/Resources/app $TEMP_DIR
+cp $TEMP_DIR/wavesrv $TEMP_DIR/app/bin/wavesrv
 mkdir $TEMP_WAVE_DIR_ARM/Contents/Resources/app
 mkdir $TEMP_WAVE_DIR_X64/Contents/Resources/app
 node $SCRIPT_DIR/build-universal.js

--- a/buildres/osx-notarize.js
+++ b/buildres/osx-notarize.js
@@ -1,4 +1,5 @@
 const { notarize } = require("@electron/notarize");
+const path = require("path");
 
 console.log("running osx-notarize");
 const waveAppPath = path.resolve(__dirname, "temp", "Wave.app");

--- a/buildres/osx-notarize.js
+++ b/buildres/osx-notarize.js
@@ -1,14 +1,17 @@
-const { notarize } = require('@electron/notarize');
-// DEBUG=electron-notarize
+const { notarize } = require("@electron/notarize");
 
 console.log("running osx-notarize");
+const waveAppPath = path.resolve(__dirname, "temp", "Wave.app");
+
 notarize({
-    appPath: "temp/Wave.app",
+    appPath: waveAppPath,
     tool: "notarytool",
     keychainProfile: "notarytool-creds",
-}).then(() => {
-    console.log("notarize success");
-}).catch((e) => {
-    console.log("notarize error", e);
-    process.exit(1);
-});
+})
+    .then(() => {
+        console.log("notarize success");
+    })
+    .catch((e) => {
+        console.log("notarize error", e);
+        process.exit(1);
+    });

--- a/buildres/osx-sign.js
+++ b/buildres/osx-sign.js
@@ -1,10 +1,9 @@
 const { signAsync } = require("@electron/osx-sign");
-// DEBUG="electron-osx-sign*"
 
 console.log("running osx-sign");
-let waveAppPath = "temp/Wave.app";
+const waveAppPath = path.resolve(__dirname, "temp", "Wave.app");
 signAsync({
-    app: "temp/Wave.app",
+    app: waveAppPath,
     binaries: [
         waveAppPath + "/Contents/Resources/app/bin/wavesrv",
         waveAppPath + "/Contents/Resources/app/bin/mshell/mshell-v0.4-linux.amd64",
@@ -12,9 +11,11 @@ signAsync({
         waveAppPath + "/Contents/Resources/app/bin/mshell/mshell-v0.4-darwin.amd64",
         waveAppPath + "/Contents/Resources/app/bin/mshell/mshell-v0.4-darwin.arm64",
     ],
-}).then(() => {
-    console.log("signing success");
-}).catch((e) => {
-    console.log("signing error", e);
-    process.exit(1);
-});
+})
+    .then(() => {
+        console.log("signing success");
+    })
+    .catch((e) => {
+        console.log("signing error", e);
+        process.exit(1);
+    });

--- a/buildres/osx-sign.js
+++ b/buildres/osx-sign.js
@@ -1,4 +1,5 @@
 const { signAsync } = require("@electron/osx-sign");
+const path = require("path");
 
 console.log("running osx-sign");
 const waveAppPath = path.resolve(__dirname, "temp", "Wave.app");


### PR DESCRIPTION
This removes the need to set the build version in the `build-helper.yml` file, instead reading it from `version.js`. It also fixes some paths that I forgot to make relative to the script locations with my last PR.