### PR TITLE
Get version for build-universal from the build-helper output, use package.json for all versioning

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -5,6 +5,8 @@ env:
     NODE_VERSION: "21.5.0"
 jobs:
     runbuild:
+        outputs:
+            WAVETERM_VERSION: ${{ steps.set-version.outputs.WAVETERM_VERSION }}
         strategy:
             matrix:
                 include:
@@ -43,7 +45,8 @@ jobs:
               with:
                   node-version: ${{env.NODE_VERSION}}
                   cache: "yarn"
-            - run: |
+            - id: set-version
+              run: |
                   VERSION=$(node -e 'console.log(require("./version.js"))')
                   echo "WAVETERM_VERSION=${VERSION:1}" >> "$GITHUB_ENV"
                   echo "WAVETERM_VERSION=${VERSION:1}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -46,6 +46,7 @@ jobs:
             - run: |
                   VERSION=$(node -e 'console.log(require("./version.js"))')
                   echo "WAVETERM_VERSION=${VERSION:1}" >> $GITHUB_ENV
+                  echo "WAVETERM_VERSION=${VERSION:1}" >> $GITHUB_OUTPUT
             - run: yarn --frozen-lockfile
             - run: ./scripthaus/scripthaus run ${{ matrix.scripthaus }}
             - uses: actions/upload-artifact@v4
@@ -62,6 +63,10 @@ jobs:
               with:
                   merge-multiple: true
                   path: buildtemp
+            - run: |
+                  echo "${WAVETERM_VERSION}" > buildtemp/version.txt
+              env:
+                  WAVETERM_VERSION: ${{ needs.runbuild.outputs.WAVETERM_VERSION }}
             - run: (cd buildtemp; zip ../waveterm-builds.zip *)
             - run: aws s3 cp waveterm-builds.zip s3://waveterm-github-artifacts/
               env:

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -45,8 +45,8 @@ jobs:
                   cache: "yarn"
             - run: |
                   VERSION=$(node -e 'console.log(require("./version.js"))')
-                  echo "WAVETERM_VERSION=${VERSION:1}" >> $GITHUB_ENV
-                  echo "WAVETERM_VERSION=${VERSION:1}" >> $GITHUB_OUTPUT
+                  echo "WAVETERM_VERSION=${VERSION:1}" >> "$GITHUB_ENV"
+                  echo "WAVETERM_VERSION=${VERSION:1}" >> "$GITHUB_OUTPUT"
             - run: yarn --frozen-lockfile
             - run: ./scripthaus/scripthaus run ${{ matrix.scripthaus }}
             - uses: actions/upload-artifact@v4
@@ -64,9 +64,7 @@ jobs:
                   merge-multiple: true
                   path: buildtemp
             - run: |
-                  echo "${WAVETERM_VERSION}" > buildtemp/version.txt
-              env:
-                  WAVETERM_VERSION: ${{ needs.runbuild.outputs.WAVETERM_VERSION }}
+                  echo "${{ needs.runbuild.outputs.WAVETERM_VERSION }}" > buildtemp/version.txt
             - run: (cd buildtemp; zip ../waveterm-builds.zip *)
             - run: aws s3 cp waveterm-builds.zip s3://waveterm-github-artifacts/
               env:

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -48,8 +48,7 @@ jobs:
             - id: set-version
               run: |
                   VERSION=$(node -e 'console.log(require("./version.js"))')
-                  echo "WAVETERM_VERSION=${VERSION:1}" >> "$GITHUB_ENV"
-                  echo "WAVETERM_VERSION=${VERSION:1}" >> "$GITHUB_OUTPUT"
+                  echo "WAVETERM_VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
             - run: yarn --frozen-lockfile
             - run: ./scripthaus/scripthaus run ${{ matrix.scripthaus }}
             - uses: actions/upload-artifact@v4

--- a/buildres/build-universal.sh
+++ b/buildres/build-universal.sh
@@ -100,5 +100,4 @@ echo "success, created $DMG_NAME"
 mv $DMG_NAME $BUILDS_DIR/
 spctl -a -vvv -t install $TEMP_WAVE_DIR_UNIVERSAL/
 
-
 rm -rf $TEMP_DIR $ZIP_DIR

--- a/buildres/build-universal.sh
+++ b/buildres/build-universal.sh
@@ -67,7 +67,7 @@ node $SCRIPT_DIR/osx-sign.js
 DEBUG=electron-notarize node $SCRIPT_DIR/osx-notarize.js
 echo "universal app creation success (build/sign/notarize)"
 
-UVERSION=$(node -e "console.log(require('${SCRIPT_DIR}/../version.js'))")
+UVERSION="$(cat $BUILDS_DIR/version.txt)"
 UPACKAGE_NAME="waveterm-macos-universal-${UVERSION}"
 
 echo "creating universal zip"

--- a/buildres/build-universal.sh
+++ b/buildres/build-universal.sh
@@ -67,7 +67,7 @@ node $SCRIPT_DIR/osx-sign.js
 DEBUG=electron-notarize node $SCRIPT_DIR/osx-notarize.js
 echo "universal app creation success (build/sign/notarize)"
 
-UVERSION="$(cat $BUILDS_DIR/version.txt)"
+UVERSION=$(cat $BUILDS_DIR/version.txt)
 UPACKAGE_NAME="waveterm-macos-universal-${UVERSION}"
 
 echo "creating universal zip"

--- a/buildres/build-universal.sh
+++ b/buildres/build-universal.sh
@@ -50,11 +50,6 @@ unzip -q $X64_ZIP -d $TEMP_DIR/x64
 unzip -q $ARM64_ZIP -d $TEMP_DIR/arm64
 rm $ARM64_ZIP $X64_ZIP
 
-# Rename any non-darwin builds to waveterm
-for f in $BUILDS_DIR/*[!.txt]; do
-    mv "$f" "$(echo "$f" | sed "s/Wave/waveterm/")";
-done
-
 # Create universal app and sign and notarize it
 TEMP_WAVE_DIR_ARM=$TEMP_DIR/x64/Wave.app
 TEMP_WAVE_DIR_X64=$TEMP_DIR/arm64/Wave.app
@@ -73,7 +68,7 @@ DEBUG=electron-notarize node $SCRIPT_DIR/osx-notarize.js
 echo "universal app creation success (build/sign/notarize)"
 
 UVERSION=$(cat $BUILDS_DIR/version.txt)
-UPACKAGE_NAME="waveterm-macos-universal-${UVERSION}"
+UPACKAGE_NAME="Wave-macos-universal-${UVERSION}"
 
 echo "creating universal zip"
 ditto $TEMP_WAVE_DIR_UNIVERSAL $ZIP_DIR/Wave.app

--- a/buildres/build-universal.sh
+++ b/buildres/build-universal.sh
@@ -50,6 +50,11 @@ unzip -q $X64_ZIP -d $TEMP_DIR/x64
 unzip -q $ARM64_ZIP -d $TEMP_DIR/arm64
 rm $ARM64_ZIP $X64_ZIP
 
+# Rename any non-darwin builds to waveterm
+for f in $BUILDS_DIR/*[!.txt]; do
+    mv "$f" "$(echo "$f" | sed "s/Wave/waveterm/")";
+done
+
 # Create universal app and sign and notarize it
 TEMP_WAVE_DIR_ARM=$TEMP_DIR/x64/Wave.app
 TEMP_WAVE_DIR_X64=$TEMP_DIR/arm64/Wave.app
@@ -94,5 +99,6 @@ $SCRIPT_DIR/../../create-dmg/create-dmg \
 echo "success, created $DMG_NAME"
 mv $DMG_NAME $BUILDS_DIR/
 spctl -a -vvv -t install $TEMP_WAVE_DIR_UNIVERSAL/
+
 
 rm -rf $TEMP_DIR $ZIP_DIR

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "waveterm",
     "author": "Command Line Inc",
     "productName": "Wave",
-    "version": "0.6.1",
+    "version": "v0.6.1",
     "main": "dist/emain.js",
     "license": "Apache-2.0",
     "dependencies": {

--- a/scripthaus.md
+++ b/scripthaus.md
@@ -43,12 +43,13 @@ rm -rf dist/
 rm -rf bin/
 rm -rf build/
 node_modules/.bin/webpack --env prod
+WAVESRV_VERSION=$(node -e 'console.log(require("./version.js"))')
 GO_LDFLAGS="-s -w -X main.BuildTime=$(date +'%Y%m%d%H%M')"
 (cd waveshell; CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="$GO_LDFLAGS" -o ../bin/mshell/mshell-v0.4-darwin.amd64 main-waveshell.go)
 (cd waveshell; CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="$GO_LDFLAGS" -o ../bin/mshell/mshell-v0.4-darwin.arm64 main-waveshell.go)
 (cd waveshell; CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="$GO_LDFLAGS" -o ../bin/mshell/mshell-v0.4-linux.amd64 main-waveshell.go)
 (cd waveshell; CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="$GO_LDFLAGS" -o ../bin/mshell/mshell-v0.4-linux.arm64 main-waveshell.go)
-(cd wavesrv; CGO_ENABLED=1 go build -tags "osusergo,netgo,sqlite_omit_load_extension" -ldflags "-X main.BuildTime=$(date +'%Y%m%d%H%M')" -o ../bin/wavesrv ./cmd)
+(cd wavesrv; CGO_ENABLED=1 go build -tags "osusergo,netgo,sqlite_omit_load_extension" -ldflags "-X main.BuildTime=$(date +'%Y%m%d%H%M') -X main.WaveVersion=$WAVESRV_VERSION" -o ../bin/wavesrv ./cmd)
 node_modules/.bin/electron-forge make
 ```
 
@@ -59,13 +60,14 @@ rm -rf dist/
 rm -rf bin/
 rm -rf build/
 node_modules/.bin/webpack --env prod
+WAVESRV_VERSION=$(node -e 'console.log(require("./version.js"))')
 GO_LDFLAGS="-s -w -X main.BuildTime=$(date +'%Y%m%d%H%M')"
 (cd waveshell; CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="$GO_LDFLAGS" -o ../bin/mshell/mshell-v0.4-darwin.amd64 main-waveshell.go)
 (cd waveshell; CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="$GO_LDFLAGS" -o ../bin/mshell/mshell-v0.4-darwin.arm64 main-waveshell.go)
 (cd waveshell; CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="$GO_LDFLAGS" -o ../bin/mshell/mshell-v0.4-linux.amd64 main-waveshell.go)
 (cd waveshell; CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="$GO_LDFLAGS" -o ../bin/mshell/mshell-v0.4-linux.arm64 main-waveshell.go)
 # adds -extldflags=-static, *only* on linux (macos does not support fully static binaries) to avoid a glibc dependency
-(cd wavesrv; CGO_ENABLED=1 go build -tags "osusergo,netgo,sqlite_omit_load_extension" -ldflags "-linkmode 'external' -extldflags=-static $GO_LDFLAGS" -o ../bin/wavesrv ./cmd)
+(cd wavesrv; CGO_ENABLED=1 go build -tags "osusergo,netgo,sqlite_omit_load_extension" -ldflags "-linkmode 'external' -extldflags=-static $GO_LDFLAGS -X main.WaveVersion=$WAVESRV_VERSION" -o ../bin/wavesrv ./cmd)
 node_modules/.bin/electron-forge make
 ```
 
@@ -77,8 +79,9 @@ open out/Wave-darwin-x64/Wave.app
 
 ```bash
 # @scripthaus command build-wavesrv
+WAVESRV_VERSION=$(node -e 'console.log(require("./version.js"))')
 cd wavesrv
-CGO_ENABLED=1 go build -tags "osusergo,netgo,sqlite_omit_load_extension" -ldflags "-X main.BuildTime=$(date +'%Y%m%d%H%M')" -o ../bin/wavesrv ./cmd
+CGO_ENABLED=1 go build -tags "osusergo,netgo,sqlite_omit_load_extension" -ldflags "-X main.BuildTime=$(date +'%Y%m%d%H%M') -X main.WaveVersion=$WAVESRV_VERSION" -o ../bin/wavesrv ./cmd
 ```
 
 ```bash

--- a/version.js
+++ b/version.js
@@ -1,5 +1,5 @@
 const path = require("path");
 const packageJson = require(path.resolve(__dirname, "package.json"));
 
-const VERSION = `v${packageJson.version}`;
+const VERSION = `${packageJson.version}`;
 module.exports = VERSION;

--- a/wavesrv/cmd/main-server.go
+++ b/wavesrv/cmd/main-server.go
@@ -66,10 +66,13 @@ const TelemetryInterval = 8 * time.Hour
 
 const MaxWriteFileMemSize = 20 * (1024 * 1024) // 20M
 
+// these are set at build time
+var WaveVersion = "v0.0.0"
+var BuildTime = "0"
+
 var GlobalLock = &sync.Mutex{}
 var WSStateMap = make(map[string]*scws.WSState) // clientid -> WsState
 var GlobalAuthKey string
-var BuildTime = "0"
 var shutdownOnce sync.Once
 var ContentTypeHeaderValidRe = regexp.MustCompile(`^\w+/[\w.+-]+$`)
 
@@ -804,6 +807,7 @@ func doShutdown(reason string) {
 
 func main() {
 	scbase.BuildTime = BuildTime
+	scbase.WaveVersion = WaveVersion
 	base.ProcessType = base.ProcessType_WaveSrv
 	wlog.GlobalSubsystem = base.ProcessType_WaveSrv
 	wlog.LogConsumer = wlog.LogWithLogger

--- a/wavesrv/pkg/scbase/scbase.go
+++ b/wavesrv/pkg/scbase/scbase.go
@@ -35,14 +35,16 @@ const WaveLockFile = "waveterm.lock"
 const WaveDirName = ".waveterm"        // must match emain.ts
 const WaveDevDirName = ".waveterm-dev" // must match emain.ts
 const WaveAppPathVarName = "WAVETERM_APP_PATH"
-const WaveVersion = "v0.6.1"
 const WaveAuthKeyFileName = "waveterm.authkey"
 const MShellVersion = "v0.4.0"
 
 var SessionDirCache = make(map[string]string)
 var ScreenDirCache = make(map[string]string)
 var BaseLock = &sync.Mutex{}
+
+// these are set by the main-server using build-time variables
 var BuildTime = "-"
+var WaveVersion = "-"
 
 func IsDevMode() bool {
 	pdev := os.Getenv(WaveDevVarName)


### PR DESCRIPTION
This sets a version.txt file in the build-helper pipeline for the version to use for the currently-building binary. The build-universal script will then honor that version when packaging up the universal binary.

This also removes the static version from the Go code, so now all version definitions originate from the package.json file.

This also renames all zip files in build-universal from Wave-* to waveterm-* for consistency