### PR TITLE
Update to latest checkout action in CodeQL pipeline

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL


### PR DESCRIPTION
the checkout action needed to be updated to avoid a deprecation notice for Node16 runners