### PR TITLE
add initial testdriver config

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -24,16 +24,3 @@ jobs:
             3. type 'ls' into the input
             4. press return
             5. validate Wave shows the result of 'ls'
-      # - name: Send custom JSON data to Slack workflow
-      #   id: slack
-      #   if: ${{ always() }}
-      #   uses: slackapi/slack-github-action@v1.25.0
-      #   with:
-      #     # This data can be any valid JSON from a previous step in the GitHub Action
-      #     payload: |
-      #       {
-      #         "link": "${{ steps.testdriver.outputs.link }}",
-      #         "summary": ${{ toJSON(steps.testdriver.outputs.summary)}}
-      #       }
-      #   env:
-      #     SLACK_WEBHOOK_URL: "https://hooks.slack.com/triggers/xxx"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,39 @@
+name: TestDriver.ai Regression Testing
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 21 * * *" # every day at 9pm
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: "TestDriver"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dashcamio/testdriver@main
+        id: testdriver
+        # note that .testdriver/prerun.sh runs before this, so the app has launched already
+        with:
+          prompt: |
+            2. click "Continue"
+            2. focus the Wave input with the keyboard shorcut Command + I
+            3. type 'ls' into the input
+            4. press return
+            5. validate Wave shows the result of 'ls'
+      # - name: Send custom JSON data to Slack workflow
+      #   id: slack
+      #   if: ${{ always() }}
+      #   uses: slackapi/slack-github-action@v1.25.0
+      #   with:
+      #     # This data can be any valid JSON from a previous step in the GitHub Action
+      #     payload: |
+      #       {
+      #         "link": "${{ steps.testdriver.outputs.link }}",
+      #         "summary": ${{ toJSON(steps.testdriver.outputs.summary)}}
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: "https://hooks.slack.com/triggers/xxx"

--- a/.testdriver/prerun.sh
+++ b/.testdriver/prerun.sh
@@ -1,0 +1,20 @@
+rm ~/Desktop/WITH-LOVE-FROM-AMERICA.txt
+brew install go
+brew tap scripthaus-dev/scripthaus
+brew install scripthaus
+npm install -g yarn
+mkdir ~/build
+cd ~/build
+git clone https://github.com/wavetermdev/waveterm.git
+cd waveterm
+scripthaus run build-backend
+echo "Yarn"
+yarn
+echo "Rebuild"
+scripthaus run electron-rebuild
+echo "Webpack"
+scripthaus run webpack-build
+echo "Starting Electron"
+scripthaus run electron 1>/dev/null 2>&1 &
+echo "Electron Done"
+exit


### PR DESCRIPTION
As we spoke about, this will run build WaveTerminal and run [TesterDiver.ai](https://TesterDiver.ai) tests within our VMs.

These tests will run:
- run at 9pm every day
- on PR that matches `main`
- on push to `main`

Here is an example test:
[![TestDriver.ai Test Result](https://replayable-api-production.herokuapp.com/replay/65de5498ec8637006713e194/screenshot?shareKey=4SOkeYPlfsmzHv2uPRw)](https://app.dashcam.io/replay/65de5498ec8637006713e194?share=4SOkeYPlfsmzHv2uPRw)

Watch [TestDriver.ai Test Result](https://app.dashcam.io/replay/65de5498ec8637006713e194?share=4SOkeYPlfsmzHv2uPRw) on Dashcam

# Todo:

- [ ] Currently, this action doesn't seem to run because we're making this PR from a fork. You may wish to enable running actions from forks here:
![image](https://github.com/wavetermdev/waveterm/assets/318295/30c5dfd3-856f-4800-96cd-41b16d4695c9)