### PR TITLE
SSH Cleanup

### DIFF
--- a/src/app/common/elements/passwordfield.tsx
+++ b/src/app/common/elements/passwordfield.tsx
@@ -42,7 +42,7 @@ class PasswordField extends TextField {
     }
 
     render() {
-        const { decoration, className, placeholder, maxLength, label } = this.props;
+        const { decoration, className, placeholder, maxLength, label, autoFocus } = this.props;
         const { focused, internalValue, error, passwordVisible } = this.state;
         const inputValue = this.props.value ?? internalValue;
 
@@ -55,6 +55,7 @@ class PasswordField extends TextField {
             onChange: this.handleInputChange,
             onFocus: this.handleFocus,
             onBlur: this.handleBlur,
+            autoFocus: autoFocus,
             placeholder: placeholder,
             maxLength: maxLength,
         };

--- a/src/app/common/elements/passwordfield.tsx
+++ b/src/app/common/elements/passwordfield.tsx
@@ -55,6 +55,7 @@ class PasswordField extends TextField {
             onChange: this.handleInputChange,
             onFocus: this.handleFocus,
             onBlur: this.handleBlur,
+            onKeyDown: this.props.onKeyDown,
             autoFocus: autoFocus,
             placeholder: placeholder,
             maxLength: maxLength,

--- a/src/app/common/modals/userinput.tsx
+++ b/src/app/common/modals/userinput.tsx
@@ -40,7 +40,7 @@ export const UserInputModal = (userInputRequest: UserInputRequest) => {
         [userInputRequest]
     );
 
-    function handleTextKeyDown(e: any) {
+    function handleTextKeyDown(e: KeyboardEvent) {
         let waveEvent = adaptFromReactOrNativeKeyEvent(e);
         if (checkKeyPressed(waveEvent, "Enter")) {
             e.preventDefault();

--- a/src/app/common/modals/userinput.tsx
+++ b/src/app/common/modals/userinput.tsx
@@ -65,7 +65,12 @@ export const UserInputModal = (userInputRequest: UserInputRequest) => {
                 </div>
                 <Choose>
                     <When condition={userInputRequest.responsetype == "text"}>
-                        <PasswordField onChange={setResponseText} value={responseText} maxLength={400} />
+                        <PasswordField
+                            onChange={setResponseText}
+                            value={responseText}
+                            maxLength={400}
+                            autoFocus={true}
+                        />
                     </When>
                 </Choose>
             </div>

--- a/src/app/common/modals/userinput.tsx
+++ b/src/app/common/modals/userinput.tsx
@@ -55,7 +55,7 @@ export const UserInputModal = (userInputRequest: UserInputRequest) => {
 
     return (
         <Modal className="userinput-modal">
-            <Modal.Header onClose={closeModal} title={userInputRequest.title + ` (${countdown})`} />
+            <Modal.Header onClose={closeModal} title={userInputRequest.title + ` (${countdown}s)`} />
             <div className="wave-modal-body">
                 <div className="userinput-query">
                     <If condition={userInputRequest.markdown}>

--- a/src/app/common/modals/userinput.tsx
+++ b/src/app/common/modals/userinput.tsx
@@ -40,7 +40,7 @@ export const UserInputModal = (userInputRequest: UserInputRequest) => {
         [userInputRequest]
     );
 
-    function handleTextKeyDown(e: KeyboardEvent) {
+    function handleTextKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
         let waveEvent = adaptFromReactOrNativeKeyEvent(e);
         if (checkKeyPressed(waveEvent, "Enter")) {
             e.preventDefault();

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -1689,7 +1689,7 @@ func RemoteInstallCommand(ctx context.Context, pk *scpacket.FeCommandPacketType)
 		return nil, err
 	}
 	mshell := ids.Remote.MShell
-	go mshell.RunInstall()
+	go mshell.RunInstall(false)
 	return createRemoteViewRemoteIdUpdate(ids.Remote.RemotePtr.RemoteId), nil
 }
 

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -74,7 +74,14 @@ const PrintPingPacket = `printf "\n##N{\"type\": \"ping\"}\n"`
 
 const MShellServerCommandFmt = `
 PATH=$PATH:~/.mshell;
-mshell-[%VERSION%] --server 2> /dev/null || printf "\n##N{\"type\": \"init\", \"notfound\": true, \"uname\": \"%s | %s\"}\n" "$(uname -s)" "$(uname -m)"
+which mshell-[%VERSION%] > /dev/null;
+if [[ "$?" -ne 0 ]]
+then
+  printf "\n##N{\"type\": \"init\", \"notfound\": true, \"uname\": \"%s | %s\"}\n" "$(uname -s)" "$(uname -m)"
+else
+  [%PINGPACKET%]
+  mshell-[%VERSION%] --server
+fi
 `
 
 func MakeLocalMShellCommandStr(isSudo bool) (string, error) {

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -1526,13 +1526,13 @@ func (msh *MShellProc) createWaveshellSession(remoteCopy sstore.RemoteType) (she
 	if remoteCopy.SSHOpts.SSHHost == "" && remoteCopy.Local {
 		cmdStr, err := MakeLocalMShellCommandStr(remoteCopy.IsSudo())
 		if err != nil {
-			return nil, fmt.Errorf("cannot find local mshell binary: %v", err)
+			return nil, fmt.Errorf("cannot find local waveshell binary: %v", err)
 		}
 		ecmd := shexec.MakeLocalExecCmd(cmdStr, sapi)
 		var cmdPty *os.File
 		cmdPty, err = msh.addControllingTty(ecmd)
 		if err != nil {
-			return nil, fmt.Errorf("cannot attach controlling tty to mshell command: %v", err)
+			return nil, fmt.Errorf("cannot attach controlling tty to waveshell command: %v", err)
 		}
 		go msh.RunPtyReadLoop(cmdPty)
 		go msh.WaitAndSendPasswordNew(remoteCopy.SSHOpts.SSHPassword)

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -1082,31 +1082,6 @@ func (msh *MShellProc) WaitAndSendPasswordNew(pw string) {
 	requiresPassword := make(chan bool, 1)
 	ctx, cancelFn := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancelFn()
-	if pw != "" {
-		// do an extra check with the saved password if it is provided
-		go msh.CheckPasswordRequested(ctx, requiresPassword)
-		select {
-		case <-ctx.Done():
-			err := ctx.Err()
-			var errMsg error
-			if err == context.Canceled {
-				errMsg = fmt.Errorf("canceled by the user: %v", err)
-			} else {
-				errMsg = fmt.Errorf("timed out waiting for password prompt: %v", err)
-			}
-			msh.WriteToPtyBuffer("*error, %s\n", errMsg.Error())
-			msh.setErrorStatus(errMsg)
-			return
-		case required := <-requiresPassword:
-			if !required {
-				// we don't need user input in this case, so we exit early
-				return
-			}
-		}
-		msh.SendPassword(pw)
-	}
-
-	// ask for user input once
 	go msh.CheckPasswordRequested(ctx, requiresPassword)
 	select {
 	case <-ctx.Done():

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -1266,7 +1266,8 @@ func (msh *MShellProc) RunInstall(autoInstall bool) {
 		return
 	}
 	if msh.Client == nil {
-		client, err := ConnectToClient(remoteCopy.SSHOpts)
+		remoteDisplayName := fmt.Sprintf("%s [%s]", remoteCopy.RemoteAlias, remoteCopy.RemoteCanonicalName)
+		client, err := ConnectToClient(remoteCopy.SSHOpts, remoteDisplayName)
 		if err != nil {
 			statusErr := fmt.Errorf("ssh cannot connect to client: %w", err)
 			msh.setInstallErrorStatus(statusErr)
@@ -1501,7 +1502,8 @@ func (msh *MShellProc) createWaveshellSession(remoteCopy sstore.RemoteType) (she
 		go msh.WaitAndSendPasswordNew(remoteCopy.SSHOpts.SSHPassword)
 		wsSession = shexec.CmdWrap{Cmd: ecmd}
 	} else if msh.Client == nil {
-		client, err := ConnectToClient(remoteCopy.SSHOpts)
+		remoteDisplayName := fmt.Sprintf("%s [%s]", remoteCopy.RemoteAlias, remoteCopy.RemoteCanonicalName)
+		client, err := ConnectToClient(remoteCopy.SSHOpts, remoteDisplayName)
 		if err != nil {
 			return nil, fmt.Errorf("ssh cannot connect to client: %w", err)
 		}

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -74,14 +74,7 @@ const PrintPingPacket = `printf "\n##N{\"type\": \"ping\"}\n"`
 
 const MShellServerCommandFmt = `
 PATH=$PATH:~/.mshell;
-which mshell-[%VERSION%] > /dev/null;
-if [[ "$?" -ne 0 ]]
-then
-  printf "\n##N{\"type\": \"init\", \"notfound\": true, \"uname\": \"%s | %s\"}\n" "$(uname -s)" "$(uname -m)"
-else
-  [%PINGPACKET%]
-  mshell-[%VERSION%] --server
-fi
+mshell-[%VERSION%] --server 2> /dev/null || printf "\n##N{\"type\": \"init\", \"notfound\": true, \"uname\": \"%s | %s\"}\n" "$(uname -s)" "$(uname -m)"
 `
 
 func MakeLocalMShellCommandStr(isSudo bool) (string, error) {

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -1549,13 +1549,15 @@ func (msh *MShellProc) createWaveshellSession(remoteCopy sstore.RemoteType) (she
 		if err != nil {
 			return nil, fmt.Errorf("ssh cannot create session: %w", err)
 		}
-		wsSession = shexec.SessionWrap{Session: session, StartCmd: MakeServerCommandStr()}
+		cmd := fmt.Sprintf("%s -c %s", sapi.GetLocalShellPath(), shellescape.Quote(MakeServerCommandStr()))
+		wsSession = shexec.SessionWrap{Session: session, StartCmd: cmd}
 	} else {
 		session, err := msh.Client.NewSession()
 		if err != nil {
 			return nil, fmt.Errorf("ssh cannot create session: %w", err)
 		}
-		wsSession = shexec.SessionWrap{Session: session, StartCmd: MakeServerCommandStr()}
+		cmd := fmt.Sprintf(`%s -c %s`, sapi.GetLocalShellPath(), shellescape.Quote(MakeServerCommandStr()))
+		wsSession = shexec.SessionWrap{Session: session, StartCmd: cmd}
 	}
 	return wsSession, nil
 }

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -1220,13 +1220,7 @@ func (msh *MShellProc) RunInstall(autoInstall bool) {
 		msh.WriteToPtyBuffer("*error: cannot install on archived remote\n")
 		return
 	}
-	baseStatus := msh.GetStatus()
-	if baseStatus == StatusConnecting && !autoInstall {
-		msh.WriteToPtyBuffer("*error: cannot install on remote that is connected/connecting, disconnect to install\n")
-		return
-	}
-	if baseStatus == StatusConnecting {
-		//this is the auto-install case
+	if autoInstall {
 		request := &userinput.UserInputRequestType{
 			ResponseType: "confirm",
 			QueryText:    "Waveshell must be reinstalled on the connection to continue. Would you like to install it?",
@@ -1259,6 +1253,7 @@ func (msh *MShellProc) RunInstall(autoInstall bool) {
 			return
 		}
 	}
+	baseStatus := msh.GetStatus()
 	if baseStatus == StatusConnected {
 		request := &userinput.UserInputRequestType{
 			ResponseType: "confirm",

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -1633,7 +1633,7 @@ func (NewLauncher) Launch(msh *MShellProc, interactive bool) {
 		go msh.tryAutoInstall()
 		return
 	} else if err != nil {
-		msh.WriteToPtyBuffer("*error, %s\n", serr.Error())
+		msh.WriteToPtyBuffer("*error, %s\n", err.Error())
 		msh.setErrorStatus(err)
 		msh.WithLock(func() {
 			msh.Client = nil


### PR DESCRIPTION
Polishing the new SSH Code before the new release.  This includes:
- a bug fix that prevents a crash from an unrecoverable waveshell install
- lists the remote name when a password or kbd-interactive auth is requested
- allows using <enter> to submit a password in a user input modal
- allows using <esc> to close out a user input modal
- does not allow the root user to create or search local known_hosts files. that account must use the global files instead
- reads identity files early to avoid sending unnecessary dummy files to the server if a key cannot be parsed
- auto focus the user input modal text box for passwords
- remove auto password attempts for sudo remote
- add s to countdown timer for user input modal to denote seconds
- change auto installer behavior to pop up modals if necessary
- simplifies the command to run waveshell
- use the appropriate shell to launch the waveshell executable on the remote