### PR TITLE
Add min-width to sidebar so it won't shrink when the window gets too small

### DIFF
--- a/src/app/common/elements/resizablesidebar.tsx
+++ b/src/app/common/elements/resizablesidebar.tsx
@@ -151,7 +151,7 @@ class ResizableSidebar extends React.Component<ResizableSidebarProps> {
         const isCollapsed = mainSidebarModel.getCollapsed();
 
         return (
-            <div className={cn("sidebar", className, { collapsed: isCollapsed })} style={{ width }}>
+            <div className={cn("sidebar", className, { collapsed: isCollapsed })} style={{ width, minWidth: width }}>
                 <div className="sidebar-content">{children(this.toggleCollapsed)}</div>
                 <div
                     className="sidebar-handle"

--- a/src/app/sidebar/sidebar.tsx
+++ b/src/app/sidebar/sidebar.tsx
@@ -266,8 +266,6 @@ class MainSideBar extends React.Component<MainSideBarProps, {}> {
     }
 
     render() {
-        const sidebarWidth = GlobalModel.mainSidebarModel.getWidth();
-
         return (
             <ResizableSidebar
                 className="main-sidebar"


### PR DESCRIPTION
This ensures that the sidebar will stay the same width, even when the window gets narrow. Without this, the sidebar will start to shrink as you make the window narrower.