### PR TITLE
Replace the cloud tab icon with the non-sharp version

### DIFF
--- a/src/app/common/elements/tabicon.tsx
+++ b/src/app/common/elements/tabicon.tsx
@@ -11,6 +11,8 @@ class TabIcon extends React.Component<{ icon: string; color: string }> {
         let iconClass = "";
         if (icon === "default" || icon === "square") {
             iconClass = "fa-solid fa-square fa-fw";
+        } else if (icon === "cloud") {
+            iconClass = "fa-solid fa-cloud fa-fw";
         } else {
             iconClass = `fa-sharp fa-solid fa-${icon} fa-fw`;
         }

--- a/src/app/workspace/screen/tabs.less
+++ b/src/app/workspace/screen/tabs.less
@@ -106,7 +106,6 @@
             }
 
             &.is-active {
-                border-top: none;
                 opacity: 1;
                 font-weight: var(--screentabs-selected-font-weight);
                 border-top: 2px solid var(--tab-color);


### PR DESCRIPTION
Let's be honest, the sharp cloud icon is bad...