### PR TITLE
SSH Quick Fixes

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1,9 +1,9 @@
 github.com/aws/aws-sdk-go-v2/service/s3 v1.27.11 h1:3/gm/JTX9bX8CpzTgIlrtYpB3EVBDxyg/GY/QdcIEZw=
 github.com/google/go-github/v57 v57.0.0 h1:L+Y3UPTY8ALM8x+TV0lg+IEBI+upibemtBD8Q9u7zHs=
-github.com/google/go-github/v60 v60.0.0 h1:oLG98PsLauFvvu4D/YPxq374jhSxFYdzQGNCyONLfn8=
-github.com/google/go-github/v60 v60.0.0/go.mod h1:ByhX2dP9XT9o/ll2yXAu2VD8l5eNVg8hD4Cr0S/LmQk=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
+github.com/wavetermdev/ssh_config v0.0.0-20240306041034-17e2087ebde2 h1:onqZrJVap1sm15AiIGTfWzdr6cEF0KdtddeuuOVhzyY=
+github.com/wavetermdev/ssh_config v0.0.0-20240306041034-17e2087ebde2/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/public/themes/default.css
+++ b/public/themes/default.css
@@ -17,7 +17,7 @@
     */
 
     /* base fonts */
-    --base-font: normal 15px "Lato", sans-serif;
+    --base-font: normal 15px / normal "Lato", sans-serif;
 
     --title-font-size: 18px;
     --input-bg-color: #171717;

--- a/src/app/common/modals/userinput.less
+++ b/src/app/common/modals/userinput.less
@@ -11,3 +11,9 @@
         }
     }
 }
+
+.markdown {
+    font-family: var(--base-font);
+    font-size: 15px;
+    line-height: 1.5;
+}

--- a/src/app/common/modals/userinput.less
+++ b/src/app/common/modals/userinput.less
@@ -13,7 +13,5 @@
 }
 
 .markdown {
-    font-family: var(--base-font);
-    font-size: 15px;
-    line-height: 1.5;
+    font: var(--base-font);
 }

--- a/wavesrv/go.mod
+++ b/wavesrv/go.mod
@@ -34,4 +34,4 @@ require (
 
 replace github.com/wavetermdev/waveterm/waveshell => ../waveshell
 
-replace github.com/kevinburke/ssh_config => github.com/wavetermdev/ssh_config v0.0.0-20240109090616-36c8da3d7376
+replace github.com/kevinburke/ssh_config => github.com/wavetermdev/ssh_config v0.0.0-20240306041034-17e2087ebde2

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -124,7 +124,7 @@ var SetVarScopes = []SetVarScope{
 	{ScopeName: "remote", VarNames: []string{}},
 }
 
-var userHostRe = regexp.MustCompile(`^(sudo@)?([a-z][a-z0-9._@\\-]*)@([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$`)
+var userHostRe = regexp.MustCompile(`^(sudo@)?([a-zA-Z0-9][a-zA-Z0-9._@\\-]*)@([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$`)
 var remoteAliasRe = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 var genericNameRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_ .()<>,/\"'\\[\\]{}=+$@!*-]*$")
 var rendererRe = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_.:-]*$")

--- a/wavesrv/pkg/remote/sshclient.go
+++ b/wavesrv/pkg/remote/sshclient.go
@@ -612,8 +612,14 @@ func combineSshKeywords(opts *sstore.SSHOpts, configKeywords *SshKeywords) (*Ssh
 		sshKeywords.Port = "22"
 	}
 
-	sshKeywords.IdentityFile = []string{opts.SSHIdentity}
-	sshKeywords.IdentityFile = append(sshKeywords.IdentityFile, configKeywords.IdentityFile...)
+	// this is more complicated than it needs to be since we are already storing the identity
+	// file for remotes, even if they come from the ssh config. it should be simplified with
+	// future rework to the connection user interface
+	if opts.SSHIdentity == "" || (len(configKeywords.IdentityFile) > 0 && configKeywords.IdentityFile[0] == opts.SSHIdentity) {
+		sshKeywords.IdentityFile = configKeywords.IdentityFile
+	} else {
+		sshKeywords.IdentityFile = []string{opts.SSHIdentity}
+	}
 
 	// these are not officially supported in the waveterm frontend but can be configured
 	// in ssh config files


### PR DESCRIPTION
This updates a couple small things for the new release
- allows ssh usernames to start with numbers/capital letters and allows the use of capital letters in them in general
- use the ssh2 default identity file names
- allow a custom identity file to overwrite the config identity files instead of appending to them
- updates the styles of the user input modals so markdown requests look identical to non-markdown requests in terms of font styling