### PR TITLE
Combine S3 upload step in build-helper into build job

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -5,8 +5,6 @@ env:
     NODE_VERSION: "21.5.0"
 jobs:
     runbuild:
-        outputs:
-            WAVETERM_VERSION: ${{ steps.set-version.outputs.WAVETERM_VERSION }}
         strategy:
             matrix:
                 include:
@@ -63,25 +61,8 @@ jobs:
                   APPLE_ID: ${{ matrix.platform == 'darwin' && secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
                   APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'darwin' && secrets.PROD_MACOS_NOTARIZATION_PWD }}
                   APPLE_TEAM_ID: ${{ matrix.platform == 'darwin' && secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
-            - uses: actions/upload-artifact@v4
-              with:
-                  name: waveterm-build-${{ matrix.platform }}
-                  path: make/*.* # only upload files from the make directory, not subdirectories
-                  retention-days: 2
-    upload:
-        name: "Upload Builds"
-        runs-on: ubuntu-latest
-        needs: [runbuild]
-        steps:
-            - uses: actions/download-artifact@v4
-              with:
-                  merge-multiple: true
-                  path: buildtemp
-            - name: Set `version.txt`
-              run: |
-                  echo "${{ needs.runbuild.outputs.WAVETERM_VERSION }}" >> buildtemp/version.txt
-            - name: Upload to S3
-              run: aws s3 cp buildtemp/ s3://waveterm-github-artifacts/staging/${{ needs.runbuild.outputs.WAVETERM_VERSION }}/ --recursive --exclude "builder-*.yml"
+            - name: Upload to S3 staging
+              run: aws s3 cp make/ s3://waveterm-github-artifacts/staging/${{ steps.set-version.outputs.WAVETERM_VERSION }}/ --recursive --exclude "*/*" --exclude "builder-*.yml"
               env:
                   AWS_ACCESS_KEY_ID: "${{ secrets.S3_USERID }}"
                   AWS_SECRET_ACCESS_KEY: "${{ secrets.S3_SECRETKEY }}"


### PR DESCRIPTION
Now that we aren't uploading a zip of the build artifacts but instead staging them in a bucket, we can upload them separately once the build job completes and save the work of uploading a GitHub artifact.