### PR TITLE
Add pacman artifact and update product tagline

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -27,7 +27,7 @@ jobs:
               if: matrix.platform == 'linux'
               run: |
                   sudo apt-get update
-                  sudo apt-get install rpm
+                  sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm
             - uses: actions/setup-go@v5
               with:
                   go-version: ${{env.GO_VERSION}}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Wave Terminal
 
-An open-source, cross-platform, AI-integrated, modern terminal for seamless workflows.
+Wave is an open-source AI-native terminal built for seamless workflows.
 
 Wave isn't just another terminal emulator; it's a rethink on how terminals are built. Wave combines command line with the power of the open web to help veteran CLI users and new developers alike.
 
@@ -17,13 +17,14 @@ Wave isn't just another terminal emulator; it's a rethink on how terminals are b
 -   Persistent sessions that can restore state across network disconnections and reboots
 -   Searchable contextual command history across all remote sessions (saved locally)
 -   Workspaces, tabs, and command blocks to keep you organized
+-   CodeEdit, to edit local and remote files with a VSCode-like inline editor
 -   AI Integration with ChatGPT (or ChatGPT compatible APIs) to help write commands and get answers inline
 
 ![WaveTerm Screenshot](./assets/wave-screenshot.jpeg)
 
 ## Installation
 
-Wave Terminal works with MacOS and Linux (preliminary).
+Wave Terminal works with MacOS and Linux.
 
 Install Wave Terminal from: [www.waveterm.dev/download](https://www.waveterm.dev/download)
 
@@ -49,7 +50,7 @@ brew install --cask wave
 
 ## Contributing
 
-Wave uses Github Project for tracking issues.
+Wave uses Github Issues for issue tracking.
 
 Find more information in our [Contributions Guide](CONTRIBUTING.md), which includes:
 

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -73,7 +73,7 @@ const config = {
         executableName: pkg.productName,
         category: "TerminalEmulator",
         icon: "public/waveterm.icns",
-        target: ["zip", "deb", "rpm", "AppImage"],
+        target: ["zip", "deb", "rpm", "AppImage", "pacman"],
         synopsis: pkg.description,
         description: null,
         desktop: {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "email": "info@commandline.dev"
     },
     "productName": "Wave",
-    "description": "An open-source, cross-platform, AI-integrated, modern terminal for seamless workflows.",
+    "description": "An Open-Source, AI-Native, Terminal Built for Seamless Workflows",
     "version": "0.7.0",
     "main": "dist/emain.js",
     "license": "Apache-2.0",

--- a/src/app/common/modals/about.tsx
+++ b/src/app/common/modals/about.tsx
@@ -87,7 +87,7 @@ class AboutModal extends React.Component<{}, {}> {
                         <div className="text-wrapper">
                             <div>Wave Terminal</div>
                             <div className="text-standard">
-                                Open Source AI-Native Terminal
+                                Open-Source AI-Native Terminal
                                 <br />
                                 Built for Seamless Workflows
                             </div>

--- a/src/app/common/modals/about.tsx
+++ b/src/app/common/modals/about.tsx
@@ -75,6 +75,7 @@ class AboutModal extends React.Component<{}, {}> {
     }
 
     render() {
+        const currentDate = new Date();
         return (
             <Modal className="about-modal">
                 <Modal.Header onClose={this.closeModal} title="About" />
@@ -122,7 +123,9 @@ class AboutModal extends React.Component<{}, {}> {
                             Acknowledgements
                         </LinkButton>
                     </div>
-                    <div className="about-section text-standard">&copy; 2023 Command Line Inc.</div>
+                    <div className="about-section text-standard">
+                        &copy; {currentDate.getFullYear()} Command Line Inc.
+                    </div>
                 </div>
             </Modal>
         );

--- a/src/app/common/modals/about.tsx
+++ b/src/app/common/modals/about.tsx
@@ -86,9 +86,9 @@ class AboutModal extends React.Component<{}, {}> {
                         <div className="text-wrapper">
                             <div>Wave Terminal</div>
                             <div className="text-standard">
-                                Modern Terminal for
+                                Open Source AI-Native Terminal
                                 <br />
-                                Seamless Workflow
+                                Built for Seamless Workflows
                             </div>
                         </div>
                     </div>

--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -279,9 +279,6 @@ const menuTemplate: Electron.MenuItemConstructorOptions[] = [
     {
         role: "windowMenu",
     },
-    {
-        role: "help",
-    },
 ];
 
 const menu = electron.Menu.buildFromTemplate(menuTemplate);

--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -330,7 +330,10 @@ function createMainWindow(clientData: ClientDataType | null): Electron.BrowserWi
         height: bounds.height,
         minWidth: 800,
         minHeight: 600,
-        icon: unamePlatform == "linux" ? "public/logos/wave-logo-dark.png" : undefined,
+        icon:
+            unamePlatform == "linux"
+                ? path.join(getElectronAppBasePath(), "public/logos/wave-logo-dark.png")
+                : undefined,
         webPreferences: {
             preload: path.join(getElectronAppBasePath(), DistDir, "preload.js"),
         },


### PR DESCRIPTION
This adds support for Arch Linux via pacman. It also updates the product tagline in package.json and the "About" modal. It also removes the unused "Help" menu and updates the copyright year in About and fixes the window icon display on Linux.