### PR TITLE
fix: split the apple locale on the region for LANG

### DIFF
--- a/wavesrv/pkg/scbase/scbase.go
+++ b/wavesrv/pkg/scbase/scbase.go
@@ -393,7 +393,9 @@ func determineLang() string {
 			log.Printf("error executing 'defaults read -g AppleLocale': %v\n", err)
 			return ""
 		}
-		return strings.TrimSpace(string(out)) + ".UTF-8"
+		strOut := string(out)
+		truncOut := strings.Split(strOut, "@")[0]
+		return strings.TrimSpace(truncOut) + ".UTF-8"
 	} else {
 		// this is specifically to get the wavesrv LANG so waveshell
 		// on a remote uses the same LANG


### PR DESCRIPTION
We use AppleLocale to get the desired language when running on macos. Unfortunately, if a region is set, the locale is not equivalent to the LANG environment variable. It appends an extra region field that we did not previously filter out. This change ensures that it will be filtered out when present.