### PR TITLE
Add support for svg images to imageview command

### DIFF
--- a/src/plugins/image/image.tsx
+++ b/src/plugins/image/image.tsx
@@ -53,6 +53,9 @@ class SimpleImageRenderer extends React.Component<
                 </div>
             );
         }
+        if (dataBlob.name.endsWith(".svg")) {
+            dataBlob = new Blob([dataBlob], { type: "image/svg+xml" }) as ExtBlob;
+        }
         if (this.objUrl == null) {
             this.objUrl = URL.createObjectURL(dataBlob);
         }


### PR DESCRIPTION
I've addressed issue #67!
Please take a look :)

### Description
I've modified the code to ensure that the MIME type is set to "image/svg+xml" exclusively for SVG files.
Below is how an SVG file appears when displayed using the imageview command.
<img width="511" alt="image" src="https://github.com/wavetermdev/waveterm/assets/72508905/acb17974-86c1-4ea3-9319-8659d1b40b35">
