### PR TITLE
Small UI tweaks

### DIFF
--- a/public/themes/default.css
+++ b/public/themes/default.css
@@ -51,7 +51,7 @@
     /* global colors */
     --app-bg-color: black;
     --app-accent-color: rgb(88, 193, 66);
-    --app-accent-bg-color: rgba(88, 193, 66, 0.2);
+    --app-accent-bg-color: rgba(87, 193, 66, 0.25);
     --app-error-color: rgb(229, 77, 46);
     --app-warning-color: rgb(224, 185, 86);
     --app-success-color: rgb(78, 154, 6);
@@ -222,5 +222,5 @@
     --modal-bg-color: var(--app-bg-color);
     --modal-header-bottom-border-color: rgba(241, 246, 243, 0.15);
 
-    --logo-button-hover-bg-color: #1e1e1e;
+    --logo-button-hover-bg-color: var(--app-accent-bg-color);
 }

--- a/public/themes/default.css
+++ b/public/themes/default.css
@@ -51,7 +51,7 @@
     /* global colors */
     --app-bg-color: black;
     --app-accent-color: rgb(88, 193, 66);
-    --app-accent-bg-color: rgba(87, 193, 66, 0.25);
+    --app-accent-bg-color: rgba(88, 193, 66, 0.25);
     --app-error-color: rgb(229, 77, 46);
     --app-warning-color: rgb(224, 185, 86);
     --app-success-color: rgb(78, 154, 6);

--- a/public/themes/light.css
+++ b/public/themes/light.css
@@ -23,6 +23,7 @@
 
     /* tab color */
     --tab-white: rgb(0, 0, 0, 0.6);
+    --tab-mint: rgb(70, 235, 156);
 
     /* button colors */
     --button-text-color: rgb(50, 50, 50); /* Dark gray for light theme */

--- a/public/themes/light.css
+++ b/public/themes/light.css
@@ -54,7 +54,7 @@
     --markdown-bg-color: rgb(0, 0, 0, 0.1);
 
     /* modal colors */
-    --modal-header-bottom-border-color: rgba(0, 0, 0, 0.3);
+    --modal-header-bottom-border-color: var(--app-border-color);
 
     /* cmd input */
     --cmdinput-textarea-bg-color: rgba(0, 0, 0, 0.1);
@@ -72,6 +72,4 @@
 
     /* toggle colors */
     --toggle-thumb-color: var(--app-bg-color);
-
-    --logo-button-hover-bg-color: #f0f0f0;
 }

--- a/public/themes/light.css
+++ b/public/themes/light.css
@@ -55,7 +55,7 @@
     --markdown-bg-color: rgb(0, 0, 0, 0.1);
 
     /* modal colors */
-    --modal-header-bottom-border-color: var(--app-border-color);
+    --modal-header-bottom-border-color: rgba(0, 0, 0, 0.3);
 
     /* cmd input */
     --cmdinput-textarea-bg-color: rgba(0, 0, 0, 0.1);

--- a/src/app/common/elements/mainview.less
+++ b/src/app/common/elements/mainview.less
@@ -9,6 +9,10 @@
         display: none;
     }
 
+    .header-container {
+        border-bottom: 1px solid var(--app-border-color);
+    }
+
     .header {
         -webkit-app-region: drag;
         display: flex;
@@ -18,7 +22,6 @@
         vertical-align: middle;
         padding: 0 10px 0 10px;
         margin: 0;
-        border-bottom: 1px solid var(--app-border-color);
 
         .title {
             font-size: var(--title-font-size);
@@ -42,10 +45,10 @@
 
 // This ensures the tab bar does not collide with the floating logo. The floating logo sits above the sidebar when it is not collapsed, so no additional margin is needed in that case.
 // More margin is given on macOS to account for the traffic light buttons
-#main.platform-darwin.mainsidebar-collapsed .header {
-    margin-left: var(--floating-logo-width-darwin);
+#main.platform-darwin.mainsidebar-collapsed .header-container {
+    padding-left: var(--floating-logo-width-darwin);
 }
 
-#main:not(.platform-darwin).mainsidebar-collapsed .header {
-    margin-left: var(--floating-logo-width);
+#main:not(.platform-darwin).mainsidebar-collapsed .header-container {
+    padding-left: var(--floating-logo-width);
 }

--- a/src/app/common/elements/mainview.tsx
+++ b/src/app/common/elements/mainview.tsx
@@ -23,7 +23,7 @@ class MainView extends React.Component<{
                 className={cn("mainview", this.props.className)}
                 style={{ maxWidth: `calc(100vw - ${maxWidthSubtractor}px)` }}
             >
-                <div className="header-container bottom-border">
+                <div className="header-container">
                     <header className="header">
                         <div className="title text-primary">{this.props.title}</div>
                         <div className="close-div hoverEffect" title="Close (Escape)" onClick={this.props.onClose}>


### PR DESCRIPTION
Extends the bottom border for the mainview header underneath the window controls, updates the accent bg color for dark mode to be a little brighter, and makes the accent bg color the background for the sidebar logo button when it is hovered over.
<img width="342" alt="image" src="https://github.com/wavetermdev/waveterm/assets/16651283/899f6711-e1e0-42e5-a934-91b9feb774ec">
<img width="340" alt="image" src="https://github.com/wavetermdev/waveterm/assets/16651283/93e68e24-6806-4c96-b7e2-3b39db605af0">

Also tones down the mint color in light mode, as it was appearing too bright:
<img width="182" alt="image" src="https://github.com/wavetermdev/waveterm/assets/16651283/101dccb7-75ca-4c05-8d24-bcc1ac3dde5a">
<img width="182" alt="image" src="https://github.com/wavetermdev/waveterm/assets/16651283/e6cb9cb3-4f22-40c3-b368-b8ec2dbf93ef">
