### PR TITLE
Code edit keybindings

### DIFF
--- a/src/plugins/code/code.tsx
+++ b/src/plugins/code/code.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from "react";
+import * as mobx from "mobx";
 import Editor, { Monaco } from "@monaco-editor/react";
 import type * as MonacoTypes from "monaco-editor/esm/vs/editor/editor.api";
 import cn from "classnames";
@@ -50,6 +51,18 @@ function renderCmdText(text: string): any {
 
 // there is a global monaco variable (TODO get the correct TS type)
 declare var monaco: any;
+
+class CodeKeybindings extends React.Component<{ codeObject: SourceCodeRenderer }, {}> {
+    componentDidMount(): void {
+        this.props.codeObject.registerKeybindings();
+    }
+    componentWillUnmount(): void {
+        this.props.codeObject.unregisterKeybindings();
+    }
+    render() {
+        return null;
+    }
+}
 
 class SourceCodeRenderer extends React.Component<
     {
@@ -207,14 +220,6 @@ class SourceCodeRenderer extends React.Component<
         GlobalModel.keybindManager.unregisterDomain(domain);
     }
 
-    handleFocus() {
-        this.registerKeybindings();
-    }
-
-    handleBlur() {
-        this.unregisterKeybindings();
-    }
-
     handleEditorDidMount = (editor: MonacoTypes.editor.IStandaloneCodeEditor, monaco: Monaco) => {
         this.monacoEditor = editor;
         this.setInitialLanguage(editor);
@@ -246,16 +251,13 @@ class SourceCodeRenderer extends React.Component<
         if (this.props.shouldFocus) {
             this.monacoEditor.focus();
             this.props.rendererApi.onFocusChanged(true);
-            this.handleFocus();
         }
         if (this.monacoEditor.onDidFocusEditorWidget) {
             this.monacoEditor.onDidFocusEditorWidget(() => {
                 this.props.rendererApi.onFocusChanged(true);
-                this.handleFocus();
             });
             this.monacoEditor.onDidBlurEditorWidget(() => {
                 this.props.rendererApi.onFocusChanged(false);
-                this.handleBlur();
             });
         }
         if (!this.getAllowEditing()) this.setState({ showReadonly: true });
@@ -542,8 +544,20 @@ class SourceCodeRenderer extends React.Component<
                 </div>
             );
         }
+        let { lineNum } = this.props.context;
+        let screen = GlobalModel.getActiveScreen();
+        let lineIsSelected = mobx.computed(
+            () => screen.getSelectedLine() == lineNum && screen.getFocusType() == "cmd",
+            {
+                name: "code-lineisselected",
+            }
+        );
+        console.log("lineis selected:", lineIsSelected.get());
         return (
             <div className="code-renderer">
+                <If condition={lineIsSelected.get()}>
+                    <CodeKeybindings codeObject={this}></CodeKeybindings>
+                </If>
                 <Split sizes={[editorFraction, 1 - editorFraction]} onSetSizes={this.setSizes}>
                     {this.getCodeEditor()}
                     {isPreviewerAvailable && showPreview && this.getPreviewer()}

--- a/src/plugins/code/code.tsx
+++ b/src/plugins/code/code.tsx
@@ -187,13 +187,11 @@ class SourceCodeRenderer extends React.Component<
         const { lineId } = this.props.context;
         let domain = "code-" + lineId;
         let keybindManager = GlobalModel.keybindManager;
-        console.log("registering keybindings");
         keybindManager.registerKeybinding("plugin", domain, "codeedit:save", (waveEvent) => {
             this.doSave();
             return true;
         });
         keybindManager.registerKeybinding("plugin", domain, "codeedit:close", (waveEvent) => {
-            console.log("closing");
             this.doClose();
             return true;
         });
@@ -206,7 +204,6 @@ class SourceCodeRenderer extends React.Component<
     unregisterKeybindings() {
         const { lineId } = this.props.context;
         let domain = "code-" + lineId;
-        console.log("unregistering keybindings?", domain);
         GlobalModel.keybindManager.unregisterDomain(domain);
     }
 
@@ -236,7 +233,6 @@ class SourceCodeRenderer extends React.Component<
                     "codeedit:togglePreview",
                 ])
             ) {
-                console.log("keydown??");
                 GlobalModel.keybindManager.processKeyEvent(e.browserEvent, waveEvent);
             }
         });
@@ -258,7 +254,6 @@ class SourceCodeRenderer extends React.Component<
                 this.handleFocus();
             });
             this.monacoEditor.onDidBlurEditorWidget(() => {
-                console.log("blur?");
                 this.props.rendererApi.onFocusChanged(false);
                 this.handleBlur();
             });

--- a/src/util/keyutil.ts
+++ b/src/util/keyutil.ts
@@ -29,6 +29,7 @@ type KeybindConfig = { command: string; keys: Array<string>; commandStr?: string
 
 const Callback = "callback";
 const Command = "command";
+const DumpLogs = true;
 
 type Keybind = {
     domain: string;
@@ -147,6 +148,9 @@ class KeybindManager {
         for (let index = keybindsArray.length - 1; index >= 0; index--) {
             let curKeybind = keybindsArray[index];
             if (this.checkKeyPressed(event, curKeybind.keybinding)) {
+                if (DumpLogs) {
+                    console.log("keybind found", curKeybind);
+                }
                 let shouldReturn = false;
                 let shouldRunCommand = true;
                 if (curKeybind.callback != null) {
@@ -184,6 +188,9 @@ class KeybindManager {
             }
             let systemLevel = this.levelMap.get("system");
             return this.processLevel(nativeEvent, event, systemLevel);
+        }
+        if (DumpLogs) {
+            console.log("levels:", this.levelMap, "event:", event);
         }
         for (let index = this.levelArray.length - 1; index >= 0; index--) {
             let curLevel = this.levelArray[index];

--- a/src/util/keyutil.ts
+++ b/src/util/keyutil.ts
@@ -29,7 +29,7 @@ type KeybindConfig = { command: string; keys: Array<string>; commandStr?: string
 
 const Callback = "callback";
 const Command = "command";
-const DumpLogs = true;
+const DumpLogs = false;
 
 type Keybind = {
     domain: string;


### PR DESCRIPTION
Added code edit keybindings

There was some complexity to this one 

I found that if you click off of codeedit to deselect it, then press Cmd+D, the keybindings for "deleteActiveLine" gets called, which deletes the code edit line, instead of closing it
This is expected behavior and what should happen, but makes me wonder if we should make it so that if the user clicks off of the line window, ie if the user clicks on the sidebar etc, that we make it so there is no active line selected 