### PR TITLE
Adding engineered query to chat command

### DIFF
--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -2625,7 +2625,7 @@ func getCmdInfoEngineeredPrompt(userQuery string, curLineStr string, shellType s
 		// Enclose the command in triple backticks to format it as a code block.
 		promptCurrentCommand = " The user is currently working with the command: ```\n" + curLineStr + "\n```\n\n"
 	}
-	promptFormattingInstruction := "Please ensure any command line suggestions or code snippets that are meant to be run by the user are enclosed in triple backquotes for easy copy and paste into the terminal."
+	promptFormattingInstruction := "Please ensure any command line suggestions or code snippets or scripts that are meant to be run by the user are enclosed in triple backquotes for easy copy and paste into the terminal."
 	promptQuestion := " The user's question is:\n\n" + userQuery + ""
 
 	return promptBase + promptCurrentCommand + promptFormattingInstruction + promptQuestion
@@ -2875,7 +2875,9 @@ func OpenAICommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (scbus
 		update := scbus.MakeUpdatePacket()
 		return update, nil
 	}
-	prompt := []packet.OpenAIPromptMessageType{{Role: sstore.OpenAIRoleUser, Content: promptStr}}
+	osType := GetOsTypeFromRuntime()
+	engineeredQuery := getCmdInfoEngineeredPrompt(promptStr, "", ids.Remote.ShellType, osType)
+	prompt := []packet.OpenAIPromptMessageType{{Role: sstore.OpenAIRoleUser, Content: engineeredQuery}}
 	if resolveBool(pk.Kwargs["cmdinfoclear"], false) {
 		update := sstore.UpdateWithClearOpenAICmdInfo(cmd.ScreenId)
 		if err != nil {

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -2625,7 +2625,7 @@ func getCmdInfoEngineeredPrompt(userQuery string, curLineStr string, shellType s
 		// Enclose the command in triple backticks to format it as a code block.
 		promptCurrentCommand = " The user is currently working with the command: ```\n" + curLineStr + "\n```\n\n"
 	}
-	promptFormattingInstruction := "Please ensure any command line suggestions or code snippets or scripts that are meant to be run by the user are enclosed in triple backquotes for easy copy and paste into the terminal."
+	promptFormattingInstruction := "Please ensure any command line suggestions or code snippets or scripts that are meant to be run by the user are enclosed in triple backquotes for easy copy and paste into the terminal.  Also note that any response you give will be rendered in markdown."
 	promptQuestion := " The user's question is:\n\n" + userQuery + ""
 
 	return promptBase + promptCurrentCommand + promptFormattingInstruction + promptQuestion


### PR DESCRIPTION
This simply adds the engineered query from the chat info window to the `/chat` command as well 