### PR TITLE
Control keybindings

### DIFF
--- a/assets/default-keybindings.json
+++ b/assets/default-keybindings.json
@@ -24,12 +24,68 @@
       "keys": ["Backspace", "Delete"]
     },
     {
+      "command": "generic:space",
+      "keys": ["Space"]
+    },
+    {
+      "command": "generic:tab",
+      "keys": ["Tab"]
+    },
+    {
+      "command": "generic:numpad-0",
+      "keys": ["0"]
+    },
+    {
+      "command": "generic:numpad-1",
+      "keys": ["1"]
+    },
+    {
+      "command": "generic:numpad-2",
+      "keys": ["2"]
+    },
+    {
+      "command": "generic:numpad-3",
+      "keys": ["3"]
+    },
+    {
+      "command": "generic:numpad-4",
+      "keys": ["4"]
+    },
+    {
+      "command": "generic:numpad-5",
+      "keys": ["5"]
+    },
+    {
+      "command": "generic:numpad-6",
+      "keys": ["6"]
+    },
+    {
+      "command": "generic:numpad-7",
+      "keys": ["7"]
+    },
+    {
+      "command": "generic:numpad-8",
+      "keys": ["8"]
+    },
+    {
+      "command": "generic:numpad-9",
+      "keys": ["9"]
+    },
+    {
       "command": "generic:selectAbove",
       "keys": ["ArrowUp"]
     },
     {
       "command": "generic:selectBelow",
       "keys": ["ArrowDown"]
+    },
+    {
+      "command": "generic:selectLeft",
+      "keys": ["ArrowLeft"]
+    },
+    {
+      "command": "generic:selectRight",
+      "keys": ["ArrowRight"]
     },
     {
       "command": "generic:selectPageAbove",

--- a/src/app/common/elements/datepicker.tsx
+++ b/src/app/common/elements/datepicker.tsx
@@ -280,6 +280,11 @@ const DatePicker: React.FC<DatePickerProps> = ({ selectedDate, format = "MM/DD/Y
         setShowYearAccordion(false);
     };
 
+    const closeModal = () => {
+        setIsOpen(false);
+        setShowYearAccordion(false);
+    };
+
     const dayPickerModal = isOpen
         ? ReactDOM.createPortal(
               <div ref={modalRef} className="day-picker-modal" style={calculatePosition()}>
@@ -348,6 +353,14 @@ const DatePicker: React.FC<DatePickerProps> = ({ selectedDate, format = "MM/DD/Y
         });
         keybindManager.registerKeybinding("control", domain, "generic:space", (waveEvent) => {
             toggleModal();
+            return true;
+        });
+        keybindManager.registerKeybinding("control", domain, "generic:confirm", (waveEvent) => {
+            toggleModal();
+            return true;
+        });
+        keybindManager.registerKeybinding("control", domain, "generic:cancel", (waveEvent) => {
+            closeModal();
             return true;
         });
         keybindManager.registerKeybinding("control", domain, "generic:tab", (waveEvent) => {

--- a/src/app/common/elements/datepicker.tsx
+++ b/src/app/common/elements/datepicker.tsx
@@ -40,6 +40,9 @@ const DatePicker: React.FC<DatePickerProps> = ({ selectedDate, format = "MM/DD/Y
         DD: selDate.format("DD"),
     });
     let curUuid = uuidv4();
+    let keybindsRegistered = mobx.observable.box(false, {
+        name: "datepicker-keybinds-registered",
+    });
 
     useEffect(() => {
         inputRefs.current = {
@@ -327,6 +330,12 @@ const DatePicker: React.FC<DatePickerProps> = ({ selectedDate, format = "MM/DD/Y
     };
 
     const registerKeybindings = (event: any, part: string) => {
+        if (keybindsRegistered.get() == true) {
+            return;
+        }
+        mobx.action(() => {
+            keybindsRegistered.set(true);
+        })();
         let keybindManager = GlobalModel.keybindManager;
         let domain = "datepicker-" + curUuid + "-" + part;
         keybindManager.registerKeybinding("control", domain, "generic:selectLeft", (waveEvent) => {
@@ -378,6 +387,9 @@ const DatePicker: React.FC<DatePickerProps> = ({ selectedDate, format = "MM/DD/Y
     };
 
     const unregisterKeybindings = (part) => {
+        mobx.action(() => {
+            keybindsRegistered.set(false);
+        })();
         let domain = "datepicker-" + curUuid + "-" + part;
         GlobalModel.keybindManager.unregisterDomain(domain);
     };

--- a/src/app/common/elements/dropdown.tsx
+++ b/src/app/common/elements/dropdown.tsx
@@ -110,8 +110,6 @@ class Dropdown extends React.Component<DropdownProps, DropdownState> {
     }
 
     registerKeybindings() {
-        const { options } = this.props;
-        const { isOpen } = this.state;
         let keybindManager = GlobalModel.keybindManager;
         let domain = "dropdown-" + this.curUuid;
         keybindManager.registerKeybinding("control", domain, "generic:confirm", (waveEvent) => {
@@ -127,6 +125,8 @@ class Dropdown extends React.Component<DropdownProps, DropdownState> {
             return true;
         });
         keybindManager.registerKeybinding("control", domain, "generic:selectAbove", (waveEvent) => {
+            const { isOpen } = this.state;
+            const { options } = this.props;
             if (isOpen) {
                 this.setState((prevState) => ({
                     highlightedIndex:
@@ -136,6 +136,8 @@ class Dropdown extends React.Component<DropdownProps, DropdownState> {
             return true;
         });
         keybindManager.registerKeybinding("control", domain, "generic:selectBelow", (waveEvent) => {
+            const { isOpen } = this.state;
+            const { options } = this.props;
             if (isOpen) {
                 this.setState((prevState) => ({
                     highlightedIndex:

--- a/src/app/common/elements/inlinesettingstextedit.tsx
+++ b/src/app/common/elements/inlinesettingstextedit.tsx
@@ -78,11 +78,11 @@ class InlineSettingsTextEdit extends React.Component<
     registerKeybindings() {
         let keybindManager = GlobalModel.keybindManager;
         let domain = "inline-settings" + this.curId;
-        keybindManager.registerKeybinding("mainview", domain, "generic:confirm", (waveEvent) => {
+        keybindManager.registerKeybinding("control", domain, "generic:confirm", (waveEvent) => {
             this.confirmChange();
             return true;
         });
-        keybindManager.registerKeybinding("mainview", domain, "generic:cancel", (waveEvent) => {
+        keybindManager.registerKeybinding("control", domain, "generic:cancel", (waveEvent) => {
             this.cancelChange();
             return true;
         });

--- a/src/util/keyutil.ts
+++ b/src/util/keyutil.ts
@@ -38,7 +38,7 @@ type Keybind = {
     commandStr: string;
 };
 
-const KeybindLevels = ["system", "modal", "app", "mainview", "pane", "plugin"];
+const KeybindLevels = ["system", "modal", "app", "mainview", "pane", "plugin", "control"];
 
 class KeybindManager {
     domainCallbacks: Map<string, KeybindCallback>;
@@ -178,7 +178,12 @@ class KeybindManager {
         if (modalLevel.length != 0) {
             // console.log("processing modal");
             // special case when modal keybindings are present
-            let shouldReturn = this.processLevel(nativeEvent, event, modalLevel);
+            let controlLevel = this.levelMap.get("control");
+            let shouldReturn = this.processLevel(nativeEvent, event, controlLevel);
+            if (shouldReturn) {
+                return true;
+            }
+            shouldReturn = this.processLevel(nativeEvent, event, modalLevel);
             if (shouldReturn) {
                 return true;
             }


### PR DESCRIPTION
Keybindings for the control level, which is basically all of the smaller things that could be on modals or on settings pages, etc

Tested and confirmed that inline settings  text edit works correctly on both the screen settings modal and the client settings main view page

Also, small thing that I found - the dropdown arrow keys don't scroll the dropdown. If you select an option that's scrolled out of reach, the selected item seems to disappear, unless you scroll with your mouse. 
it had been like that before I made these changes. I'm not exactly sure how to fix it, there wasn't a simple `scrollDropdown` lol, it seemed like it might involve some html stuff beyond my current knowledge. I can look into fixing it, but if anyone knows a simple way to do it feel free to let me know or push a commit