### PR TITLE
User input keybindings fix

### DIFF
--- a/src/app/common/elements/modal.tsx
+++ b/src/app/common/elements/modal.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from "react";
+import * as mobx from "mobx";
 import { If } from "tsx-control-statements/components";
 import ReactDOM from "react-dom";
 import { Button } from "./button";
@@ -33,10 +34,9 @@ interface ModalFooterProps {
     cancelLabel?: string;
     okLabel?: string;
     keybindings?: boolean;
-    focusVal?: boolean;
 }
 
-class ModalKeybindings extends React.Component<{ onOk; onCancel; focusVal }, {}> {
+class ModalKeybindings extends React.Component<{ onOk; onCancel }, {}> {
     curId: string;
 
     @boundMethod
@@ -46,17 +46,13 @@ class ModalKeybindings extends React.Component<{ onOk; onCancel; focusVal }, {}>
         let keybindManager = GlobalModel.keybindManager;
         if (this.props.onOk) {
             keybindManager.registerKeybinding("modal", domain, "generic:confirm", (waveEvent) => {
-                if (this.props.focusVal || this.props.focusVal == undefined || this.props.focusVal == null) {
-                    this.props.onOk();
-                }
+                this.props.onOk();
                 return true;
             });
         }
         if (this.props.onCancel) {
             keybindManager.registerKeybinding("modal", domain, "generic:cancel", (waveEvent) => {
-                if (this.props.focusVal || this.props.focusVal == undefined || this.props.focusVal == null) {
-                    this.props.onCancel();
-                }
+                this.props.onCancel();
                 return true;
             });
         }
@@ -78,11 +74,10 @@ const ModalFooter: React.FC<ModalFooterProps> = ({
     cancelLabel = "Cancel",
     okLabel = "Ok",
     keybindings = true,
-    focusVal = true,
 }) => (
     <div className="wave-modal-footer">
         <If condition={keybindings}>
-            <ModalKeybindings onOk={onOk} onCancel={onCancel} focusVal={focusVal}></ModalKeybindings>
+            <ModalKeybindings onOk={onOk} onCancel={onCancel}></ModalKeybindings>
         </If>
         {onCancel && (
             <Button className="secondary" onClick={onCancel}>

--- a/src/app/common/elements/modal.tsx
+++ b/src/app/common/elements/modal.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from "react";
-import * as mobx from "mobx";
 import { If } from "tsx-control-statements/components";
 import ReactDOM from "react-dom";
 import { Button } from "./button";
@@ -34,9 +33,10 @@ interface ModalFooterProps {
     cancelLabel?: string;
     okLabel?: string;
     keybindings?: boolean;
+    focusVal?: boolean;
 }
 
-class ModalKeybindings extends React.Component<{ onOk; onCancel }, {}> {
+class ModalKeybindings extends React.Component<{ onOk; onCancel; focusVal }, {}> {
     curId: string;
 
     @boundMethod
@@ -46,13 +46,17 @@ class ModalKeybindings extends React.Component<{ onOk; onCancel }, {}> {
         let keybindManager = GlobalModel.keybindManager;
         if (this.props.onOk) {
             keybindManager.registerKeybinding("modal", domain, "generic:confirm", (waveEvent) => {
-                this.props.onOk();
+                if (this.props.focusVal || this.props.focusVal == undefined || this.props.focusVal == null) {
+                    this.props.onOk();
+                }
                 return true;
             });
         }
         if (this.props.onCancel) {
             keybindManager.registerKeybinding("modal", domain, "generic:cancel", (waveEvent) => {
-                this.props.onCancel();
+                if (this.props.focusVal || this.props.focusVal == undefined || this.props.focusVal == null) {
+                    this.props.onCancel();
+                }
                 return true;
             });
         }
@@ -74,10 +78,11 @@ const ModalFooter: React.FC<ModalFooterProps> = ({
     cancelLabel = "Cancel",
     okLabel = "Ok",
     keybindings = true,
+    focusVal = true,
 }) => (
     <div className="wave-modal-footer">
         <If condition={keybindings}>
-            <ModalKeybindings onOk={onOk} onCancel={onCancel}></ModalKeybindings>
+            <ModalKeybindings onOk={onOk} onCancel={onCancel} focusVal={focusVal}></ModalKeybindings>
         </If>
         {onCancel && (
             <Button className="secondary" onClick={onCancel}>

--- a/src/app/common/modals/userinput.tsx
+++ b/src/app/common/modals/userinput.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
-import * as mobx from "mobx";
 import { GlobalModel } from "@/models";
 import { Choose, When, If } from "tsx-control-statements/components";
 import { Modal, PasswordField, TextField, Markdown, Checkbox } from "@/elements";
-import { checkKeyPressed, adaptFromReactOrNativeKeyEvent, KeybindManager } from "@/util/keyutil";
 
 import "./userinput.less";
 

--- a/src/app/common/modals/userinput.tsx
+++ b/src/app/common/modals/userinput.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as mobx from "mobx";
 import { GlobalModel } from "@/models";
 import { Choose, When, If } from "tsx-control-statements/components";
 import { Modal, PasswordField, TextField, Markdown, Checkbox } from "@/elements";
@@ -44,22 +45,6 @@ export const UserInputModal = (userInputRequest: UserInputRequest) => {
         [userInputRequest]
     );
 
-    function handleTextFocus() {
-        let keybindManager = GlobalModel.keybindManager;
-        keybindManager.registerKeybinding("modal", "userinput", "generic:confirm", (waveEvent) => {
-            handleSendText();
-            return true;
-        });
-        keybindManager.registerKeybinding("modal", "userinput", "generic:cancel", (waveEvent) => {
-            handleSendCancel();
-            return true;
-        });
-    }
-
-    function handleTextBlur() {
-        GlobalModel.keybindManager.unregisterDomain("userinput");
-    }
-
     React.useEffect(() => {
         let timeout: ReturnType<typeof setTimeout>;
         if (countdown == 0) {
@@ -92,8 +77,6 @@ export const UserInputModal = (userInputRequest: UserInputRequest) => {
                                 value={responseText}
                                 maxLength={400}
                                 autoFocus={true}
-                                onFocus={() => handleTextFocus()}
-                                onBlur={() => handleTextBlur()}
                             />
                         </If>
                         <If condition={!userInputRequest.publictext}>
@@ -102,8 +85,6 @@ export const UserInputModal = (userInputRequest: UserInputRequest) => {
                                 value={responseText}
                                 maxLength={400}
                                 autoFocus={true}
-                                onFocus={() => handleTextFocus()}
-                                onBlur={() => handleTextBlur()}
                             />
                         </If>
                     </If>


### PR DESCRIPTION
Pretty straight forward, user input had keybindings but the Modal.Footer already has keybindings built in 

An argument could be made that the Modal.Footer keybindings are too magic, but in this case I think it would have been pretty hard to put the keybindings in the userInput, at least with my limited react knowledge