### PR TITLE
Remove redundant default.css import

### DIFF
--- a/public/themes/light.css
+++ b/public/themes/light.css
@@ -1,9 +1,8 @@
 /* Copyright 2024, Command Line Inc.
    SPDX-License-Identifier: Apache-2.0 */
 
-@import "./default.css";
-@import "./term-default.css";
-@import "./term-light.css";
+@import url("./term-default.css");
+@import url("./term-light.css");
 
 :root {
     --app-bg-color: #fefefe;


### PR DESCRIPTION
themequery.css already imports default.css so importing it in light.css is redundant.