### PR TITLE
fix: use flex for .wave-button instead of block

### DIFF
--- a/src/app/common/elements/button.less
+++ b/src/app/common/elements/button.less
@@ -10,7 +10,6 @@
     border-radius: 6px;
     height: auto;
     line-height: 1.5;
-    display: block;
     white-space: nowrap;
     user-select: none;
 


### PR DESCRIPTION
Previously, .wave-button had `display: block;` overwriting the expected `display: flex;`. This resulted in buttons with an icon being aligned vertically instead of horizontally. This change removes the undesired `display: block;` so the buttons are formatted horizontally again.