### PR TITLE
fix: this prevents possible loops while connecting

### DIFF
--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -1733,6 +1733,7 @@ func (msh *MShellProc) Launch(interactive bool) {
 		msh.ServerProc = cproc
 		msh.Status = StatusConnected
 	})
+	msh.WriteToPtyBuffer("connected to %s\n", remoteCopy.RemoteCanonicalName)
 	go func() {
 		exitErr := cproc.Cmd.Wait()
 		exitCode := shexec.GetExitCode(exitErr)

--- a/wavesrv/pkg/remote/sshclient.go
+++ b/wavesrv/pkg/remote/sshclient.go
@@ -390,7 +390,7 @@ func createHostKeyCallback(opts *sstore.SSHOpts) (ssh.HostKeyCallback, error) {
 	// incorrectly. if a problem file is found, it is removed from our list
 	// and we try again
 	var basicCallback ssh.HostKeyCallback
-	for len(knownHostsFiles) > 0 {
+	for basicCallback == nil && len(knownHostsFiles) > 0 {
 		var err error
 		basicCallback, err = knownhosts.New(knownHostsFiles...)
 		if serr, ok := err.(*os.PathError); ok {
@@ -410,10 +410,6 @@ func createHostKeyCallback(opts *sstore.SSHOpts) (ssh.HostKeyCallback, error) {
 			// TODO handle obscure problems if possible
 			return nil, fmt.Errorf("known_hosts formatting error: %+v", err)
 		}
-	}
-
-	if basicCallback == nil {
-		basicCallback = func(hostname string, remote net.Addr, key ssh.PublicKey) error { return &knownhosts.KeyError{} }
 	}
 
 	waveHostKeyCallback := func(hostname string, remote net.Addr, key ssh.PublicKey) error {


### PR DESCRIPTION
A recent change made it possible to get stuck in a loop when connecting to a remote. This reverts the part of it that caused this while retaining the other behavior. This makes it possible to add to blank known_host files again. It also adds a printout to display when a connection is complete.