### PR TITLE
Other key bind bug fixes

### DIFF
--- a/src/app/workspace/workspaceview.tsx
+++ b/src/app/workspace/workspaceview.tsx
@@ -54,33 +54,34 @@ class SessionKeybindings extends React.Component<{}, {}> {
             GlobalModel.onBracketCmd(1);
             return true;
         });
-        keybindManager.registerKeybinding("pane", "session", "app:selectLineAbove", (waveEvent) => {
+        keybindManager.registerKeybinding("pane", "screen", "app:selectLineAbove", (waveEvent) => {
             GlobalModel.onMetaArrowUp();
             return true;
         });
-        keybindManager.registerKeybinding("pane", "session", "app:selectLineBelow", (waveEvent) => {
+        keybindManager.registerKeybinding("pane", "screen", "app:selectLineBelow", (waveEvent) => {
             GlobalModel.onMetaArrowDown();
             return true;
         });
-        keybindManager.registerKeybinding("pane", "session", "app:restartCommand", (waveEvent) => {
+        keybindManager.registerKeybinding("pane", "screen", "app:restartCommand", (waveEvent) => {
             GlobalModel.onRestartCommand();
             return true;
         });
-        keybindManager.registerKeybinding("pane", "session", "app:restartLastCommand", (waveEvent) => {
+        keybindManager.registerKeybinding("pane", "screen", "app:restartLastCommand", (waveEvent) => {
             GlobalModel.onRestartLastCommand();
             return true;
         });
-        keybindManager.registerKeybinding("pane", "session", "app:focusSelectedLine", (waveEvent) => {
+        keybindManager.registerKeybinding("pane", "screen", "app:focusSelectedLine", (waveEvent) => {
             GlobalModel.onFocusSelectedLine();
             return true;
         });
-        keybindManager.registerKeybinding("pane", "session", "app:deleteActiveLine", (waveEvent) => {
+        keybindManager.registerKeybinding("pane", "screen", "app:deleteActiveLine", (waveEvent) => {
             return GlobalModel.handleDeleteActiveLine();
         });
     }
 
     componentWillUnmount() {
         GlobalModel.keybindManager.unregisterDomain("session");
+        GlobalModel.keybindManager.unregisterDomain("screen");
     }
 
     render() {
@@ -201,7 +202,7 @@ class WorkspaceView extends React.Component<{}, {}> {
         }
         const isHidden = GlobalModel.activeMainView.get() != "session";
         const mainSidebarModel = GlobalModel.mainSidebarModel;
-        const showTabSettings = GlobalModel.tabSettingsOpen.get();
+        const showTabSettings = GlobalModel.tabSettingsOpen.get() && !isHidden;
         return (
             <div
                 className={cn("mainview", "session-view", { "is-hidden": isHidden })}

--- a/src/app/workspace/workspaceview.tsx
+++ b/src/app/workspace/workspaceview.tsx
@@ -202,7 +202,7 @@ class WorkspaceView extends React.Component<{}, {}> {
         }
         const isHidden = GlobalModel.activeMainView.get() != "session";
         const mainSidebarModel = GlobalModel.mainSidebarModel;
-        const showTabSettings = GlobalModel.tabSettingsOpen.get() && !isHidden;
+        const showTabSettings = GlobalModel.tabSettingsOpen.get();
         return (
             <div
                 className={cn("mainview", "session-view", { "is-hidden": isHidden })}
@@ -221,7 +221,7 @@ class WorkspaceView extends React.Component<{}, {}> {
                             <i className="fa-solid fa-sharp fa-xmark-large" />
                         </div>
                         <TabSettings key={activeScreen.screenId} screen={activeScreen} />
-                        <If condition={showTabSettings}>
+                        <If condition={showTabSettings && !isHidden}>
                             <TabSettingsPulldownKeybindings />
                         </If>
                     </div>


### PR DESCRIPTION
Fixed tabsettings bug, changed pane:session to pane:screen 

Modals now only process the last registered modal domain 

Something to think about related to the tab settings bug
Seems like it's really easy to make mistakes like this with this system
because we are kind of doing our own focus calculations, and there are a lot of factors that we might not think about 

In the future can we make this system less thinking for the programmer? 
I guess to some extent it would be just as hard even without the current keybinding system and there would still be all of these edge cases 