### PR TITLE
Bugfixes for ai chat code select

### DIFF
--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -250,11 +250,18 @@ class AIChat extends React.Component<{}, {}> {
         const textAreaPadding = 2 * 0.5 * termFontSize;
         let textAreaMaxHeight = textAreaLineHeight * textAreaMaxLines + textAreaPadding;
         let textAreaInnerHeight = this.textAreaNumLines.get() * textAreaLineHeight + textAreaPadding;
-        let isFocused = this.isFocused.get();
-
+        let renderKeybindings = mobx
+            .computed(() => {
+                return (
+                    this.isFocused.get() ||
+                    (GlobalModel.getActiveScreen().getFocusType() == "input" &&
+                        GlobalModel.activeMainView.get() == "session")
+                );
+            })
+            .get();
         return (
             <div className="cmd-aichat">
-                <If condition={isFocused}>
+                <If condition={renderKeybindings}>
                     <AIChatKeybindings AIChatObject={this}></AIChatKeybindings>
                 </If>
                 <div className="cmdinput-titlebar">

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -254,6 +254,7 @@ class AIChat extends React.Component<{}, {}> {
             .computed(() => {
                 return (
                     this.isFocused.get() ||
+                    GlobalModel.inputModel.hasFocus() ||
                     (GlobalModel.getActiveScreen().getFocusType() == "input" &&
                         GlobalModel.activeMainView.get() == "session")
                 );

--- a/src/models/input.ts
+++ b/src/models/input.ts
@@ -32,7 +32,11 @@ class InputModel {
     aiChatWindowRef: React.RefObject<HTMLDivElement>;
     codeSelectBlockRefArray: Array<React.RefObject<HTMLElement>>;
     codeSelectSelectedIndex: OV<number> = mobx.observable.box(-1);
+<<<<<<< Updated upstream
     codeSelectUuid: string;
+=======
+    inputPopUpType: OV<string> = mobx.observable.box("none");
+>>>>>>> Stashed changes
 
     AICmdInfoChatItems: mobx.IObservableArray<OpenAICmdInfoChatMessageType> = mobx.observable.array([], {
         name: "aicmdinfo-chat",
@@ -182,6 +186,10 @@ class InputModel {
         if (document.activeElement == historyInputElem) {
             return true;
         }
+        let aiChatInputElem = document.querySelector(".cmd-input chat-cmd-input");
+        if (document.activeElement == aiChatInputElem) {
+            return true;
+        }
         return false;
     }
 
@@ -226,6 +234,12 @@ class InputModel {
         })();
     }
 
+    setInputPopUpType(type: string) {
+        this.inputPopUpType = type;
+        this.aIChatShow.set(type == "aichat");
+        this.historyShow.set(type == "history");
+    }
+
     setOpenAICmdInfoChat(chat: OpenAICmdInfoChatMessageType[]): void {
         this.AICmdInfoChatItems.replace(chat);
         this.codeSelectBlockRefArray = [];
@@ -236,6 +250,11 @@ class InputModel {
             return;
         }
         mobx.action(() => {
+            if (show) {
+                this.setInputPopUpType("history");
+            } else {
+                this.setInputPopUpType("none");
+            }
             this.historyShow.set(show);
             if (this.hasFocus()) {
                 this.giveFocus();
@@ -648,6 +667,7 @@ class InputModel {
 
     openAIAssistantChat(): void {
         mobx.action(() => {
+            this.setInputPopUpType("aichat");
             this.aIChatShow.set(true);
             this.setAIChatFocus();
         })();
@@ -660,6 +680,7 @@ class InputModel {
             return;
         }
         mobx.action(() => {
+            this.setInputPopUpType("none");
             this.aIChatShow.set(false);
             if (giveFocus) {
                 this.giveFocus();

--- a/src/models/input.ts
+++ b/src/models/input.ts
@@ -32,6 +32,7 @@ class InputModel {
     aiChatWindowRef: React.RefObject<HTMLDivElement>;
     codeSelectBlockRefArray: Array<React.RefObject<HTMLElement>>;
     codeSelectSelectedIndex: OV<number> = mobx.observable.box(-1);
+    codeSelectUuid: string;
 
     AICmdInfoChatItems: mobx.IObservableArray<OpenAICmdInfoChatMessageType> = mobx.observable.array([], {
         name: "aicmdinfo-chat",
@@ -80,6 +81,7 @@ class InputModel {
             this.codeSelectSelectedIndex.set(-1);
             this.codeSelectBlockRefArray = [];
         })();
+        this.codeSelectUuid = "";
     }
 
     setInputMode(inputMode: null | "comment" | "global"): void {
@@ -522,6 +524,7 @@ class InputModel {
     }
 
     setAIChatFocus() {
+        console.log("setting ai chat focus");
         if (this.aiChatTextAreaRef?.current != null) {
             this.aiChatTextAreaRef.current.focus();
         }
@@ -540,8 +543,12 @@ class InputModel {
         }
     }
 
-    addCodeBlockToCodeSelect(blockRef: React.RefObject<HTMLElement>): number {
+    addCodeBlockToCodeSelect(blockRef: React.RefObject<HTMLElement>, uuid: string): number {
         let rtn = -1;
+        if (uuid != this.codeSelectUuid) {
+            this.codeSelectUuid = uuid;
+            this.codeSelectBlockRefArray = [];
+        }
         rtn = this.codeSelectBlockRefArray.length;
         this.codeSelectBlockRefArray.push(blockRef);
         return rtn;

--- a/src/models/input.ts
+++ b/src/models/input.ts
@@ -32,11 +32,8 @@ class InputModel {
     aiChatWindowRef: React.RefObject<HTMLDivElement>;
     codeSelectBlockRefArray: Array<React.RefObject<HTMLElement>>;
     codeSelectSelectedIndex: OV<number> = mobx.observable.box(-1);
-<<<<<<< Updated upstream
     codeSelectUuid: string;
-=======
     inputPopUpType: OV<string> = mobx.observable.box("none");
->>>>>>> Stashed changes
 
     AICmdInfoChatItems: mobx.IObservableArray<OpenAICmdInfoChatMessageType> = mobx.observable.array([], {
         name: "aicmdinfo-chat",

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -755,7 +755,6 @@ class Model {
     }
 
     onMetaArrowDown(): void {
-        console.log("meta arrow down?");
         GlobalCommandRunner.screenSelectLine("+1");
     }
 
@@ -768,7 +767,6 @@ class Model {
     }
 
     onSwitchSessionCmd(digit: number) {
-        console.log("switching to ", digit);
         GlobalCommandRunner.switchSession(String(digit));
     }
 


### PR DESCRIPTION
This pr fixes bugs related to ai chat code select. 

I have been struggling with bugs related to having duplicate data after a render for a while and I keep tracking them down but another unexpected re render creates issues. In this pr I attempt to fix the problem at the source. I created a uuid for the markdown renderer. If the input model sees a new uuid it knows a re render has happened and to clear its current data. 

This fixes a lot of the bugs that we have been seeing. I am still working on a bug where it takes 2 clicks to select a block by mouse. 

Also, I added more complex logic for when ai chat keybindings should exist, fixing the problem of keybinds not working when the user clicks on the chat region. 

There are still a lot of issues with the focus and scroll to work out. I think that we should definitely move this feature to red's side bar because the lack of vertical height feels very limiting. 