### PR TITLE
Quick fix to turn off mouse clicking functionality for code blocks

### DIFF
--- a/src/app/common/elements/markdown.tsx
+++ b/src/app/common/elements/markdown.tsx
@@ -39,18 +39,9 @@ class CodeBlockMarkdown extends React.Component<{ children: React.ReactNode; cod
     }
 
     render() {
-        let clickHandler: (e: React.MouseEvent<HTMLElement>, blockIndex: number) => void;
-        let inputModel = GlobalModel.inputModel;
-        clickHandler = (e: React.MouseEvent<HTMLElement>, blockIndex: number) => {
-            inputModel.setCodeSelectSelectedCodeBlock(blockIndex);
-        };
         let selected = this.blockIndex == this.props.codeSelectSelectedIndex;
         return (
-            <pre
-                ref={this.blockRef}
-                className={cn({ selected: selected })}
-                onClick={(event) => clickHandler(event, this.blockIndex)}
-            >
+            <pre ref={this.blockRef} className={cn({ selected: selected })}>
                 {this.props.children}
             </pre>
         );


### PR DESCRIPTION
This turns off the buggy mouse click code block functionality. I posted this in case mike wants to put this in before the release, if not I will close it