### PR TITLE
Send NumRunningCommands updates via the main bus, regardless of where other updates are being sent

### DIFF
--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -2939,7 +2939,7 @@ func OpenAICommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (scbus
 		return nil, fmt.Errorf("openai error, prompt string is blank")
 	}
 	update := scbus.MakeUpdatePacket()
-	sstore.IncrementNumRunningCmds_Update(update, cmd.ScreenId, 1)
+	go sstore.IncrementNumRunningCmds(cmd.ScreenId, 1)
 	line, err := sstore.AddOpenAILine(ctx, ids.ScreenId, DefaultUserId, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("cannot add new line: %v", err)
@@ -3148,7 +3148,7 @@ func addLineForCmd(ctx context.Context, metaCmd string, shouldFocus bool, ids re
 	sstore.AddLineUpdate(update, rtnLine, cmd)
 	update.AddUpdate(*screen)
 	if cmd.Status == sstore.CmdStatusRunning {
-		sstore.IncrementNumRunningCmds_Update(update, cmd.ScreenId, 1)
+		go sstore.IncrementNumRunningCmds(cmd.ScreenId, 1)
 	}
 	updateHistoryContext(ctx, rtnLine, cmd, cmd.FeState)
 	return update, nil

--- a/wavesrv/pkg/sstore/dbops.go
+++ b/wavesrv/pkg/sstore/dbops.go
@@ -789,7 +789,7 @@ func UpdateCmdDoneInfo(ctx context.Context, update *scbus.ModelUpdatePacketType,
 		// This is not a fatal error, so just log it
 		log.Printf("error setting status indicator level after done packet: %v\n", err)
 	}
-	IncrementNumRunningCmds_Update(update, screenId, -1)
+	go IncrementNumRunningCmds(screenId, -1)
 	return nil
 }
 


### PR DESCRIPTION
IncrementNumRunningCommands_Update was occasionally getting set in Screen-specific update busses, rather than the Main bus. When creating a lot of workspaces or tabs, this could cause the active screen to change before the initialization command completed, meaning the frontend would miss the update that turns off the running commands spinner. By sending these updates over the main bus always, we ensure that it will never be missed.