### PR TITLE
Clean up the input model's auxiliary view logic

### DIFF
--- a/src/app/appconst.ts
+++ b/src/app/appconst.ts
@@ -65,6 +65,6 @@ export enum StatusIndicatorLevel {
 // matches packet.go
 export const ErrorCode_InvalidCwd = "ERRCWD";
 
-export const AuxView_History = "history";
-export const AuxView_Info = "info";
-export const AuxView_AIChat = "aichat";
+export const InputAuxView_History = "history";
+export const InputAuxView_Info = "info";
+export const InputAuxView_AIChat = "aichat";

--- a/src/app/appconst.ts
+++ b/src/app/appconst.ts
@@ -64,3 +64,7 @@ export enum StatusIndicatorLevel {
 
 // matches packet.go
 export const ErrorCode_InvalidCwd = "ERRCWD";
+
+export const AuxView_History = "history";
+export const AuxView_Info = "info";
+export const AuxView_AIChat = "aichat";

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -27,7 +27,7 @@ class AIChatKeybindings extends React.Component<{ AIChatObject: AIChat }, {}> {
             return true;
         });
         keybindManager.registerKeybinding("pane", "aichat", "generic:cancel", (waveEvent) => {
-            inputModel.closeAIAssistantChat(true);
+            inputModel.closeAuxView();
             return true;
         });
         keybindManager.registerKeybinding("pane", "aichat", "aichat:clearHistory", (waveEvent) => {
@@ -70,7 +70,7 @@ class AIChat extends React.Component<{}, {}> {
 
     componentDidMount() {
         const inputModel = GlobalModel.inputModel;
-        if (this.chatWindowScrollRef != null && this.chatWindowScrollRef.current != null) {
+        if (this.chatWindowScrollRef?.current != null) {
             this.chatWindowScrollRef.current.scrollTop = this.chatWindowScrollRef.current.scrollHeight;
         }
         if (this.textAreaRef.current != null) {
@@ -82,7 +82,7 @@ class AIChat extends React.Component<{}, {}> {
     }
 
     componentDidUpdate() {
-        if (this.chatWindowScrollRef != null && this.chatWindowScrollRef.current != null) {
+        if (this.chatWindowScrollRef?.current != null) {
             this.chatWindowScrollRef.current.scrollTop = this.chatWindowScrollRef.current.scrollHeight;
         }
     }
@@ -252,7 +252,7 @@ class AIChat extends React.Component<{}, {}> {
             <AuxiliaryCmdView
                 title="Wave AI"
                 className="cmd-aichat"
-                onClose={() => GlobalModel.inputModel.closeAIAssistantChat(true)}
+                onClose={() => GlobalModel.inputModel.closeAuxView()}
                 iconClass="fa-sharp fa-solid fa-sparkles"
             >
                 <If condition={renderKeybindings}>

--- a/src/app/workspace/cmdinput/cmdinput.less
+++ b/src/app/workspace/cmdinput/cmdinput.less
@@ -4,12 +4,11 @@
     max-height: max(300px, 40%);
     display: flex;
     flex-direction: column;
-    position: absolute;
-    bottom: 0;
     width: 100%;
     z-index: 100;
     border-top: 2px solid var(--app-border-color);
     background-color: var(--app-bg-color);
+    position: relative;
 
     // Apply a border between the base cmdinput and any views shown above it
     // TODO: use a generic selector for this

--- a/src/app/workspace/cmdinput/cmdinput.tsx
+++ b/src/app/workspace/cmdinput/cmdinput.tsx
@@ -63,7 +63,6 @@ class CmdInput extends React.Component<{}, {}> {
 
     @boundMethod
     baseCmdInputClick(e: React.MouseEvent): void {
-        console.log("baseCmdInputClick");
         if (this.promptRef.current != null) {
             if (this.promptRef.current.contains(e.target)) {
                 return;
@@ -182,7 +181,6 @@ class CmdInput extends React.Component<{}, {}> {
                 hidePrompt = true;
             }
         }
-        console.log(openView);
         return (
             <div ref={this.cmdInputRef} className={cn("cmd-input", hasOpenView, { active: focusVal })}>
                 <Choose>

--- a/src/app/workspace/cmdinput/cmdinput.tsx
+++ b/src/app/workspace/cmdinput/cmdinput.tsx
@@ -181,6 +181,7 @@ class CmdInput extends React.Component<{}, {}> {
                 hidePrompt = true;
             }
         }
+        console.log(openView);
         return (
             <div ref={this.cmdInputRef} className={cn("cmd-input", hasOpenView, { active: focusVal })}>
                 <Choose>

--- a/src/app/workspace/cmdinput/cmdinput.tsx
+++ b/src/app/workspace/cmdinput/cmdinput.tsx
@@ -81,7 +81,7 @@ class CmdInput extends React.Component<{}, {}> {
         e.preventDefault();
         e.stopPropagation();
         const inputModel = GlobalModel.inputModel;
-        if (inputModel.getActiveAuxView() === appconst.AuxView_AIChat) {
+        if (inputModel.getActiveAuxView() === appconst.InputAuxView_AIChat) {
             inputModel.setActiveAuxView(null);
         } else {
             inputModel.openAIAssistantChat();
@@ -94,7 +94,7 @@ class CmdInput extends React.Component<{}, {}> {
         e.stopPropagation();
 
         const inputModel = GlobalModel.inputModel;
-        if (inputModel.getActiveAuxView() === appconst.AuxView_History) {
+        if (inputModel.getActiveAuxView() === appconst.InputAuxView_History) {
             inputModel.resetHistory();
         } else {
             inputModel.openHistory();
@@ -185,15 +185,15 @@ class CmdInput extends React.Component<{}, {}> {
         return (
             <div ref={this.cmdInputRef} className={cn("cmd-input", hasOpenView, { active: focusVal })}>
                 <Choose>
-                    <When condition={openView === appconst.AuxView_History}>
+                    <When condition={openView === appconst.InputAuxView_History}>
                         <div className="cmd-input-grow-spacer"></div>
                         <HistoryInfo />
                     </When>
-                    <When condition={openView === appconst.AuxView_AIChat}>
+                    <When condition={openView === appconst.InputAuxView_AIChat}>
                         <div className="cmd-input-grow-spacer"></div>
                         <AIChat />
                     </When>
-                    <When condition={openView === appconst.AuxView_Info}>
+                    <When condition={openView === appconst.InputAuxView_Info}>
                         <InfoMsg key="infomsg" />
                     </When>
                 </Choose>

--- a/src/app/workspace/cmdinput/cmdinput.tsx
+++ b/src/app/workspace/cmdinput/cmdinput.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import * as mobxReact from "mobx-react";
 import * as mobx from "mobx";
 import { boundMethod } from "autobind-decorator";
-import { If } from "tsx-control-statements/components";
+import { Choose, If, When } from "tsx-control-statements/components";
 import cn from "classnames";
 import dayjs from "dayjs";
 import localizedFormat from "dayjs/plugin/localizedFormat";
@@ -18,6 +18,7 @@ import { Prompt } from "@/common/prompt/prompt";
 import { CenteredIcon, RotateIcon } from "@/common/icons/icons";
 import { AIChat } from "./aichat";
 import * as util from "@/util/util";
+import * as appconst from "@/app/appconst";
 
 import "./cmdinput.less";
 
@@ -71,7 +72,7 @@ class CmdInput extends React.Component<{}, {}> {
             e.stopPropagation();
             return;
         }
-        GlobalModel.inputModel.setHistoryFocus(false);
+        GlobalModel.inputModel.setAuxViewFocus(false);
         GlobalModel.inputModel.giveFocus();
     }
 
@@ -80,8 +81,8 @@ class CmdInput extends React.Component<{}, {}> {
         e.preventDefault();
         e.stopPropagation();
         const inputModel = GlobalModel.inputModel;
-        if (inputModel.aIChatShow.get()) {
-            inputModel.closeAIAssistantChat(true);
+        if (inputModel.getActiveAuxView() === appconst.AuxView_AIChat) {
+            inputModel.setActiveAuxView(null);
         } else {
             inputModel.openAIAssistantChat();
         }
@@ -93,7 +94,7 @@ class CmdInput extends React.Component<{}, {}> {
         e.stopPropagation();
 
         const inputModel = GlobalModel.inputModel;
-        if (inputModel.historyShow.get()) {
+        if (inputModel.getActiveAuxView() === appconst.AuxView_History) {
             inputModel.resetHistory();
         } else {
             inputModel.openHistory();
@@ -155,9 +156,6 @@ class CmdInput extends React.Component<{}, {}> {
             remote = GlobalModel.getRemote(rptr.remoteid);
         }
         feState = feState || {};
-        const infoShow = inputModel.infoShow.get();
-        const historyShow = !infoShow && inputModel.historyShow.get();
-        const aiChatShow = inputModel.aIChatShow.get();
         const focusVal = inputModel.physicalInputFocused.get();
         const inputMode: string = inputModel.inputMode.get();
         const textAreaInputKey = screen == null ? "null" : screen.screenId;
@@ -170,7 +168,7 @@ class CmdInput extends React.Component<{}, {}> {
         let shellInitMsg: string = null;
         let hidePrompt = false;
 
-        const openView = inputModel.getOpenView();
+        const openView = inputModel.getActiveAuxView();
         const hasOpenView = openView ? `has-${openView}` : null;
         if (ri == null) {
             let shellStr = "shell";
@@ -185,15 +183,19 @@ class CmdInput extends React.Component<{}, {}> {
         }
         return (
             <div ref={this.cmdInputRef} className={cn("cmd-input", hasOpenView, { active: focusVal })}>
-                <If condition={historyShow}>
-                    <div className="cmd-input-grow-spacer"></div>
-                    <HistoryInfo />
-                </If>
-                <If condition={aiChatShow}>
-                    <div className="cmd-input-grow-spacer"></div>
-                    <AIChat />
-                </If>
-                <InfoMsg key="infomsg" />
+                <Choose>
+                    <When condition={openView === appconst.AuxView_History}>
+                        <div className="cmd-input-grow-spacer"></div>
+                        <HistoryInfo />
+                    </When>
+                    <When condition={openView === appconst.AuxView_AIChat}>
+                        <div className="cmd-input-grow-spacer"></div>
+                        <AIChat />
+                    </When>
+                    <When condition={openView === appconst.AuxView_Info}>
+                        <InfoMsg key="infomsg" />
+                    </When>
+                </Choose>
                 <If condition={remote && remote.status != "connected"}>
                     <div className="remote-status-warning">
                         WARNING:&nbsp;

--- a/src/app/workspace/cmdinput/cmdinput.tsx
+++ b/src/app/workspace/cmdinput/cmdinput.tsx
@@ -63,6 +63,7 @@ class CmdInput extends React.Component<{}, {}> {
 
     @boundMethod
     baseCmdInputClick(e: React.MouseEvent): void {
+        console.log("baseCmdInputClick");
         if (this.promptRef.current != null) {
             if (this.promptRef.current.contains(e.target)) {
                 return;
@@ -82,7 +83,7 @@ class CmdInput extends React.Component<{}, {}> {
         e.stopPropagation();
         const inputModel = GlobalModel.inputModel;
         if (inputModel.getActiveAuxView() === appconst.InputAuxView_AIChat) {
-            inputModel.setActiveAuxView(null);
+            inputModel.closeAuxView();
         } else {
             inputModel.openAIAssistantChat();
         }

--- a/src/app/workspace/cmdinput/historyinfo.tsx
+++ b/src/app/workspace/cmdinput/historyinfo.tsx
@@ -167,7 +167,7 @@ class HistoryInfo extends React.Component<{}, {}> {
 
     @boundMethod
     handleClose() {
-        GlobalModel.inputModel.setActiveAuxView(null);
+        GlobalModel.inputModel.closeAuxView();
     }
 
     @boundMethod

--- a/src/app/workspace/cmdinput/historyinfo.tsx
+++ b/src/app/workspace/cmdinput/historyinfo.tsx
@@ -167,7 +167,7 @@ class HistoryInfo extends React.Component<{}, {}> {
 
     @boundMethod
     handleClose() {
-        GlobalModel.inputModel.toggleInfoMsg();
+        GlobalModel.inputModel.setActiveAuxView(null);
     }
 
     @boundMethod

--- a/src/app/workspace/cmdinput/historyinfo.tsx
+++ b/src/app/workspace/cmdinput/historyinfo.tsx
@@ -174,7 +174,7 @@ class HistoryInfo extends React.Component<{}, {}> {
     handleItemClick(hitem: HistoryItem) {
         const inputModel = GlobalModel.inputModel;
         const selItem = inputModel.getHistorySelectedItem();
-        inputModel.setHistoryFocus(true);
+        inputModel.setAuxViewFocus(false);
         if (this.lastClickHNum == hitem.historynum && selItem != null && selItem.historynum == hitem.historynum) {
             inputModel.grabSelectedHistoryItem();
             return;
@@ -194,14 +194,14 @@ class HistoryInfo extends React.Component<{}, {}> {
     @boundMethod
     handleClickType() {
         const inputModel = GlobalModel.inputModel;
-        inputModel.setHistoryFocus(true);
+        inputModel.setAuxViewFocus(true);
         inputModel.toggleHistoryType();
     }
 
     @boundMethod
     handleClickRemote() {
         const inputModel = GlobalModel.inputModel;
-        inputModel.setHistoryFocus(true);
+        inputModel.setAuxViewFocus(true);
         inputModel.toggleRemoteType();
     }
 

--- a/src/app/workspace/cmdinput/infomsg.tsx
+++ b/src/app/workspace/cmdinput/infomsg.tsx
@@ -45,7 +45,7 @@ class InfoMsg extends React.Component<{}, {}> {
     render() {
         const inputModel = GlobalModel.inputModel;
         const infoMsg: InfoType = inputModel.infoMsg.get();
-        const infoShow: boolean = inputModel.infoShow.get();
+        const infoShow: boolean = inputModel.getActiveAuxView() == appconst.AuxView_Info;
         let line: string = null;
         let istr: string = null;
         let idx: number = 0;

--- a/src/app/workspace/cmdinput/infomsg.tsx
+++ b/src/app/workspace/cmdinput/infomsg.tsx
@@ -43,6 +43,7 @@ class InfoMsg extends React.Component<{}, {}> {
     }
 
     render() {
+        console.log("rendering InfoMsg");
         const inputModel = GlobalModel.inputModel;
         const infoMsg: InfoType = inputModel.infoMsg.get();
         const infoShow: boolean = inputModel.getActiveAuxView() == appconst.AuxView_Info;

--- a/src/app/workspace/cmdinput/infomsg.tsx
+++ b/src/app/workspace/cmdinput/infomsg.tsx
@@ -43,7 +43,6 @@ class InfoMsg extends React.Component<{}, {}> {
     }
 
     render() {
-        console.log("rendering InfoMsg");
         const inputModel = GlobalModel.inputModel;
         const infoMsg: InfoType = inputModel.infoMsg.get();
         const infoShow = inputModel.getActiveAuxView() == appconst.InputAuxView_Info;

--- a/src/app/workspace/cmdinput/infomsg.tsx
+++ b/src/app/workspace/cmdinput/infomsg.tsx
@@ -46,7 +46,7 @@ class InfoMsg extends React.Component<{}, {}> {
         console.log("rendering InfoMsg");
         const inputModel = GlobalModel.inputModel;
         const infoMsg: InfoType = inputModel.infoMsg.get();
-        const infoShow: boolean = inputModel.getActiveAuxView() == appconst.InputAuxView_Info;
+        const infoShow = inputModel.getActiveAuxView() == appconst.InputAuxView_Info;
         let line: string = null;
         let istr: string = null;
         let idx: number = 0;

--- a/src/app/workspace/cmdinput/infomsg.tsx
+++ b/src/app/workspace/cmdinput/infomsg.tsx
@@ -46,7 +46,7 @@ class InfoMsg extends React.Component<{}, {}> {
         console.log("rendering InfoMsg");
         const inputModel = GlobalModel.inputModel;
         const infoMsg: InfoType = inputModel.infoMsg.get();
-        const infoShow: boolean = inputModel.getActiveAuxView() == appconst.AuxView_Info;
+        const infoShow: boolean = inputModel.getActiveAuxView() == appconst.InputAuxView_Info;
         let line: string = null;
         let istr: string = null;
         let idx: number = 0;

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -254,7 +254,6 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
     lastHeight: number = 0;
     lastSP: StrWithPos = { str: "", pos: appconst.NoStrPos };
     version: OV<number> = mobx.observable.box(0); // forces render updates
-    mainInputFocused: OV<boolean> = mobx.observable.box(true);
 
     incVersion(): void {
         const v = this.version.get();
@@ -553,9 +552,6 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
             return;
         }
         inputModel.setPhysicalInputFocused(true);
-        mobx.action(() => {
-            this.mainInputFocused.set(true);
-        })();
     }
 
     @boundMethod
@@ -564,9 +560,6 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
             return;
         }
         GlobalModel.inputModel.setPhysicalInputFocused(false);
-        mobx.action(() => {
-            this.mainInputFocused.set(false);
-        })();
     }
 
     @boundMethod

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -152,10 +152,7 @@ class CmdInputKeybindings extends React.Component<{ inputObject: TextAreaInput }
         });
         keybindManager.registerKeybinding("pane", "cmdinput", "generic:cancel", (waveEvent) => {
             GlobalModel.closeTabSettings();
-            if (inputModel.inputMode.get() != null) {
-                inputModel.resetInputMode();
-            }
-            inputModel.setActiveAuxView(null);
+            inputModel.closeAuxView();
             return true;
         });
         keybindManager.registerKeybinding("pane", "cmdinput", "cmdinput:expandInput", (waveEvent) => {
@@ -577,8 +574,10 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
             displayLines = 5;
         }
 
-        const disabled = inputModel.auxViewFocus.get();
-        if (disabled) {
+        const auxViewFocused = inputModel.getAuxViewFocus();
+        console.log("auxViewFocused", auxViewFocused);
+        if (auxViewFocused) {
+            console.log("aux view focused");
             displayLines = 1;
         }
         const activeScreen = GlobalModel.getActiveScreen();
@@ -607,15 +606,14 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
                 }
             }
         }
-        const isMainInputFocused = !inputModel.auxViewFocus.get();
-        const isHistoryFocused = !isMainInputFocused && inputModel.getActiveAuxView() == appconst.InputAuxView_History;
+        const isHistoryFocused = auxViewFocused && inputModel.getActiveAuxView() == appconst.InputAuxView_History;
         return (
             <div
                 className="textareainput-div control is-expanded"
                 ref={this.controlRef}
                 style={{ height: computedOuterHeight }}
             >
-                <If condition={isMainInputFocused}>
+                <If condition={!auxViewFocused}>
                     <CmdInputKeybindings inputObject={this}></CmdInputKeybindings>
                 </If>
                 <If condition={isHistoryFocused}>
@@ -640,7 +638,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
                     onChange={this.onChange}
                     onSelect={this.onSelect}
                     placeholder="Type here..."
-                    className={cn("textarea", { "display-disabled": disabled })}
+                    className={cn("textarea", { "display-disabled": auxViewFocused })}
                 ></textarea>
                 <input
                     key="history"

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -628,7 +628,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
             }
         }
         const isMainInputFocused = inputModel.auxViewFocus.get();
-        const isHistoryFocused = !isMainInputFocused && inputModel.getActiveAuxView() == appconst.AuxView_History;
+        const isHistoryFocused = !isMainInputFocused && inputModel.getActiveAuxView() == appconst.InputAuxView_History;
         return (
             <div
                 className="textareainput-div control is-expanded"

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -252,7 +252,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
     controlRef: React.RefObject<HTMLDivElement> = React.createRef();
     lastHeight: number = 0;
     lastSP: StrWithPos = { str: "", pos: appconst.NoStrPos };
-    version: OV<number> = mobx.observable.box(0); // forces render updates
+    version: OV<number> = mobx.observable.box(0, { name: "textAreaInput-version" }); // forces render updates
 
     incVersion(): void {
         const v = this.version.get();
@@ -541,16 +541,9 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
     }
 
     @boundMethod
-    handleMainFocus(e: any) {
-        const inputModel = GlobalModel.inputModel;
-        if (inputModel.auxViewFocus.get()) {
-            e.preventDefault();
-            if (this.historyInputRef.current != null) {
-                this.historyInputRef.current.focus();
-            }
-            return;
-        }
-        inputModel.setPhysicalInputFocused(true);
+    handleFocus(e: any) {
+        e.preventDefault();
+        GlobalModel.inputModel.giveFocus();
     }
 
     @boundMethod
@@ -559,19 +552,6 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
             return;
         }
         GlobalModel.inputModel.setPhysicalInputFocused(false);
-    }
-
-    @boundMethod
-    handleHistoryFocus(e: any) {
-        const inputModel = GlobalModel.inputModel;
-        if (!inputModel.auxViewFocus.get()) {
-            e.preventDefault();
-            if (this.mainInputRef.current != null) {
-                this.mainInputRef.current.focus();
-            }
-            return;
-        }
-        inputModel.setPhysicalInputFocused(true);
     }
 
     @boundMethod
@@ -627,7 +607,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
                 }
             }
         }
-        const isMainInputFocused = inputModel.auxViewFocus.get();
+        const isMainInputFocused = !inputModel.auxViewFocus.get();
         const isHistoryFocused = !isMainInputFocused && inputModel.getActiveAuxView() == appconst.InputAuxView_History;
         return (
             <div
@@ -652,7 +632,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
                     autoComplete="off"
                     autoCorrect="off"
                     id="main-cmd-input"
-                    onFocus={this.handleMainFocus}
+                    onFocus={this.handleFocus}
                     onBlur={this.handleMainBlur}
                     style={{ height: computedInnerHeight, minHeight: computedInnerHeight, fontSize: termFontSize }}
                     value={curLine}
@@ -670,7 +650,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
                     autoCorrect="off"
                     className="history-input"
                     type="text"
-                    onFocus={this.handleHistoryFocus}
+                    onFocus={this.handleFocus}
                     onBlur={this.handleHistoryBlur}
                     onKeyDown={this.onHistoryKeyDown}
                     onChange={this.handleHistoryInput}

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -152,7 +152,6 @@ class CmdInputKeybindings extends React.Component<{ inputObject: TextAreaInput }
         });
         keybindManager.registerKeybinding("pane", "cmdinput", "generic:cancel", (waveEvent) => {
             GlobalModel.closeTabSettings();
-            inputModel.toggleInfoMsg();
             if (inputModel.inputMode.get() != null) {
                 inputModel.resetInputMode();
             }
@@ -525,7 +524,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
             if (selStart > value.length || selEnd > value.length) {
                 return;
             }
-            const newValue = value.substr(0, selStart) + clipText + value.substr(selEnd);
+            const newValue = value.substring(0, selStart) + clipText + value.substring(selEnd);
             const cmdLineUpdate = { str: newValue, pos: selStart + clipText.length };
             GlobalModel.inputModel.updateCmdLine(cmdLineUpdate);
         });
@@ -598,7 +597,6 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
             displayLines = 5;
         }
 
-        // TODO: invert logic here. We should track focus on the main textarea and assume aux view is focused if not.
         const disabled = inputModel.auxViewFocus.get();
         if (disabled) {
             displayLines = 1;

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -575,9 +575,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
         }
 
         const auxViewFocused = inputModel.getAuxViewFocus();
-        console.log("auxViewFocused", auxViewFocused);
         if (auxViewFocused) {
-            console.log("aux view focused");
             displayLines = 1;
         }
         const activeScreen = GlobalModel.getActiveScreen();

--- a/src/app/workspace/workspaceview.tsx
+++ b/src/app/workspace/workspaceview.tsx
@@ -318,7 +318,6 @@ class WorkspaceView extends React.Component<{}, {}> {
                         session={session}
                         screen={activeScreen}
                     />
-                    <div className="cmdinput-height-placeholder" style={{ height: cmdInputHeight }}></div>
                     <If condition={activeScreen != null}>
                         <CmdInput key={"cmdinput-" + sessionId} />
                     </If>

--- a/src/models/input.ts
+++ b/src/models/input.ts
@@ -142,7 +142,6 @@ class InputModel {
     giveFocus(): void {
         // Override active view to the main input if aux view does not have focus
         const activeAuxView = this.getAuxViewFocus() ? this.getActiveAuxView() : null;
-        console.log("giveFocus", activeAuxView);
         mobx.action(() => {
             switch (activeAuxView) {
                 case appconst.InputAuxView_History: {

--- a/src/models/input.ts
+++ b/src/models/input.ts
@@ -712,7 +712,6 @@ class InputModel {
     }
 
     clearInfoMsg(setNull: boolean): void {
-        console.log("clearInfoMsg");
         this._clearInfoTimeout();
         mobx.action(() => {
             if (this.getActiveAuxView() == "info") {

--- a/src/models/input.ts
+++ b/src/models/input.ts
@@ -517,10 +517,12 @@ class InputModel {
                 this.activeAuxView.set(null);
             } else {
                 this.activeAuxView.set("info");
+                this.giveFocus();
             }
         })();
         if (info != null && timeoutMs) {
             this.infoTimeoutId = setTimeout(() => {
+                console.log("clearing info msg");
                 if (this.activeAuxView.get() != "info") {
                     return;
                 }
@@ -709,10 +711,12 @@ class InputModel {
     }
 
     clearInfoMsg(setNull: boolean): void {
+        console.log("clearInfoMsg");
         this._clearInfoTimeout();
         mobx.action(() => {
             if (this.getActiveAuxView() == "info") {
                 this.activeAuxView.set(null);
+                this.giveFocus();
             }
             if (setNull) {
                 this.infoMsg.set(null);
@@ -725,8 +729,10 @@ class InputModel {
         mobx.action(() => {
             if (this.activeAuxView.get() == "info") {
                 this.activeAuxView.set(null);
+                this.giveFocus();
             } else if (this.infoMsg.get() != null) {
                 this.activeAuxView.set("info");
+                this.giveFocus();
             }
         })();
     }

--- a/src/models/input.ts
+++ b/src/models/input.ts
@@ -455,16 +455,30 @@ class InputModel {
         })();
     }
 
+    // Gets the active auxiliary view, or null if none
     getActiveAuxView(): InputAuxViewType {
         return this.activeAuxView.get();
     }
 
+    // Closes the auxiliary view if it is open, focuses the main input
+    closeAuxView(): void {
+        if (this.activeAuxView.get() == null) {
+            return;
+        }
+        mobx.action(() => {
+            this.activeAuxView.set(null);
+            this.giveFocus();
+        })();
+    }
+
+    // Sets the active auxiliary view
     setActiveAuxView(view: InputAuxViewType): void {
         mobx.action(() => {
             this.activeAuxView.set(view);
         })();
     }
 
+    // Sets the focus state of the auxiliary view. If true, the view will get focus. Otherwise, the main input will get focus.
     setAuxViewFocus(focus: boolean): void {
         mobx.action(() => {
             this.auxViewFocus.set(focus);
@@ -662,18 +676,6 @@ class InputModel {
     openAIAssistantChat(): void {
         mobx.action(() => {
             this.activeAuxView.set("aichat");
-            this.giveFocus();
-        })();
-    }
-
-    // pass true to give focus to the input (e.g. if this is an 'active' close of the chat)
-    // when resetting the input (when switching screens, don't give focus)
-    closeAuxView(): void {
-        if (this.activeAuxView.get() == null) {
-            return;
-        }
-        mobx.action(() => {
-            this.activeAuxView.set(null);
             this.giveFocus();
         })();
     }

--- a/src/models/input.ts
+++ b/src/models/input.ts
@@ -471,10 +471,11 @@ class InputModel {
 
     // Sets the active auxiliary view
     setActiveAuxView(view: InputAuxViewType): void {
+        if (view == this.activeAuxView.get()) {
+            return;
+        }
         mobx.action(() => {
-            if (view != this.activeAuxView.get()) {
-                this.auxViewFocus.set(view != null);
-            }
+            this.auxViewFocus.set(view != null);
             this.activeAuxView.set(view);
         })();
         this.giveFocus();
@@ -491,9 +492,13 @@ class InputModel {
 
     // Sets the focus state of the auxiliary view. If true, the view will get focus. Otherwise, the main input will get focus.
     setAuxViewFocus(focus: boolean): void {
+        if (this.getAuxViewFocus() == focus) {
+            return;
+        }
         mobx.action(() => {
             this.auxViewFocus.set(focus);
         })();
+        this.giveFocus();
     }
 
     setHistoryIndex(hidx: number, force?: boolean): void {

--- a/src/models/input.ts
+++ b/src/models/input.ts
@@ -156,6 +156,7 @@ class InputModel {
                     if (elem != null) {
                         elem.focus();
                     }
+                    this.setPhysicalInputFocused(true);
                     return;
                 }
                 default: {

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1082,7 +1082,7 @@ class Model {
                 this.ws.watchScreen(newActiveSessionId, newActiveScreenId);
                 this.closeTabSettings();
                 const activeScreen = this.getActiveScreen();
-                if (activeScreen != null && activeScreen.getCurRemoteInstance() != null) {
+                if (activeScreen?.getCurRemoteInstance() != null) {
                     setTimeout(() => {
                         GlobalCommandRunner.syncShellState();
                     }, 100);

--- a/src/types/custom.d.ts
+++ b/src/types/custom.d.ts
@@ -539,7 +539,6 @@ declare global {
         initialize: (params: RendererModelInitializeParams) => void;
         dispose: () => void;
         reload: (delayMs: number) => void;
-
         giveFocus: () => void;
         updateOpts: (opts: RendererOptsUpdate) => void;
         setIsDone: () => void;

--- a/src/types/custom.d.ts
+++ b/src/types/custom.d.ts
@@ -539,6 +539,7 @@ declare global {
         initialize: (params: RendererModelInitializeParams) => void;
         dispose: () => void;
         reload: (delayMs: number) => void;
+
         giveFocus: () => void;
         updateOpts: (opts: RendererOptsUpdate) => void;
         setIsDone: () => void;

--- a/src/types/custom.d.ts
+++ b/src/types/custom.d.ts
@@ -15,6 +15,7 @@ declare global {
     type LineContainerStrs = "main" | "sidebar" | "history";
     type AppUpdateStatusType = "unavailable" | "ready";
     type NativeThemeSource = "system" | "light" | "dark";
+    type InputAuxViewType = null | "history" | "info" | "aichat";
 
     type OV<V> = mobx.IObservableValue<V>;
     type OArr<V> = mobx.IObservableArray<V>;


### PR DESCRIPTION
Removes separate obervable booleans for each of the auxiliary views and replaces them with a single variable. Setting this variable will result in the indicated auxiliary view being opened. Setting it to null will clear the view. This also establishes a focus variable. This can determine if the input is focused on the main input view or the open auxiliary view. 

Whenever a auxiliary view is opened, it will be automatically focused to. If you focus away back to the main input, the `auxViewFocus` variable will be updated. `giveFocus` is now called whenever the auxiliary view or the focus are updated. These new functions are the sources of truth for everything related to the auxiliary view logic. The fields should not be accessed directly.

This also removes the cmdinput-height-placeholder for cmdinput. This div was a legacy fix from before our UI was fully onboard with flexboxes. Now that it is, we can make cmdinput flow directly in the rest of the UI, rather than sitting as an absolute positioned div. This also fixes a bug where the placeholder height was not properly updating when the window was resized.