### PR TITLE
Codeedit keybindings, enter key fix 

### DIFF
--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -652,7 +652,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
                 }
             }
         }
-        const isMainInputFocused = this.mainInputFocused.get();
+        const isMainInputFocused = inputModel.hasFocus() && this.mainInputFocused.get();
         const isHistoryFocused = this.historyFocused.get();
         return (
             <div


### PR DESCRIPTION
Fixed bug where enter is getting eaten by cmdinput layer by fixing the condition for when cmdinput keybindings are shown