### PR TITLE
undo text cursor on prompt area

### DIFF
--- a/src/app/workspace/cmdinput/cmdinput.less
+++ b/src/app/workspace/cmdinput/cmdinput.less
@@ -49,7 +49,6 @@
 
     .base-cmdinput {
         position: relative;
-        cursor: text;
         // Rather than apply the padding to the whole container, we will apply it to the inner contents directly.
         // This is more fragile, but allows us to capture a larger target area for the individual components.
         --padding-top: var(--termpad);


### PR DESCRIPTION
I decided that I actually didn't like having the prompt area in a text cursor, because you couldn't type in the prompt area