### PR TITLE
Sudo Caching

### DIFF
--- a/waveshell/pkg/packet/packet.go
+++ b/waveshell/pkg/packet/packet.go
@@ -989,6 +989,7 @@ type SudoRequestPacketType struct {
 	CK          base.CommandKey `json:"ck"`
 	ShellPubKey []byte          `json:"shellpubkey"`
 	SudoStatus  string          `json:"sudostatus"`
+	ErrStr      string          `json:"errstr"`
 }
 
 func (*SudoRequestPacketType) GetType() string {

--- a/waveshell/pkg/packet/packet.go
+++ b/waveshell/pkg/packet/packet.go
@@ -65,6 +65,8 @@ const (
 	LogPacketStr            = "log" // logging packet (sent from waveshell back to server)
 	ShellStatePacketStr     = "shellstate"
 	RpcInputPacketStr       = "rpcinput" // rpc-followup
+	SudoRequestPacketStr    = "sudorequest"
+	SudoResponsePacketStr   = "sudoresponse"
 
 	OpenAIPacketStr   = "openai" // other
 	OpenAICloudReqStr = "openai-cloudreq"
@@ -120,6 +122,8 @@ func init() {
 	TypeStrToFactory[ShellStatePacketStr] = reflect.TypeOf(ShellStatePacketType{})
 	TypeStrToFactory[FileStatPacketStr] = reflect.TypeOf(FileStatPacketType{})
 	TypeStrToFactory[RpcInputPacketStr] = reflect.TypeOf(RpcInputPacketType{})
+	TypeStrToFactory[SudoRequestPacketStr] = reflect.TypeOf(SudoRequestPacketType{})
+	TypeStrToFactory[SudoResponsePacketStr] = reflect.TypeOf(SudoResponsePacketType{})
 
 	var _ RpcPacketType = (*RunPacketType)(nil)
 	var _ RpcPacketType = (*GetCmdPacketType)(nil)
@@ -146,6 +150,7 @@ func init() {
 	var _ CommandPacketType = (*CmdDonePacketType)(nil)
 	var _ CommandPacketType = (*SpecialInputPacketType)(nil)
 	var _ CommandPacketType = (*CmdFinalPacketType)(nil)
+	var _ CommandPacketType = (*SudoResponsePacketType)(nil)
 }
 
 func RegisterPacketType(typeStr string, rtype reflect.Type) {
@@ -826,6 +831,7 @@ type RunPacketType struct {
 	RunData       []RunDataType   `json:"rundata,omitempty"`
 	Detached      bool            `json:"detached,omitempty"`
 	ReturnState   bool            `json:"returnstate,omitempty"`
+	IsSudo        bool            `json:"issudo,omitempty"`
 }
 
 func (*RunPacketType) GetType() string {
@@ -975,6 +981,54 @@ func (*OpenAICloudReqPacketType) GetType() string {
 func MakeOpenAICloudReqPacket() *OpenAICloudReqPacketType {
 	return &OpenAICloudReqPacketType{
 		Type: OpenAICloudReqStr,
+	}
+}
+
+type SudoRequestPacketType struct {
+	Type        string          `json:"type"`
+	CK          base.CommandKey `json:"ck"`
+	ShellPubKey []byte          `json:"shellpubkey"`
+	SudoStatus  string          `json:"sudostatus"`
+}
+
+func (*SudoRequestPacketType) GetType() string {
+	return SudoRequestPacketStr
+}
+
+func (p *SudoRequestPacketType) GetCK() base.CommandKey {
+	return p.CK
+}
+
+func MakeSudoRequestPacket(ck base.CommandKey, pubKey []byte, sudoStatus string) *SudoRequestPacketType {
+	return &SudoRequestPacketType{
+		Type:        SudoRequestPacketStr,
+		CK:          ck,
+		ShellPubKey: pubKey,
+		SudoStatus:  sudoStatus,
+	}
+}
+
+type SudoResponsePacketType struct {
+	Type      string          `json:"type"`
+	CK        base.CommandKey `json:"ck"`
+	Secret    []byte          `json:"secret"`
+	SrvPubKey []byte          `json:"srvpubkey"`
+}
+
+func (*SudoResponsePacketType) GetType() string {
+	return SudoResponsePacketStr
+}
+
+func (p *SudoResponsePacketType) GetCK() base.CommandKey {
+	return p.CK
+}
+
+func MakeSudoResponsePacket(ck base.CommandKey, secret []byte, srvPubKey []byte) *SudoResponsePacketType {
+	return &SudoResponsePacketType{
+		Type:      SudoResponsePacketStr,
+		CK:        ck,
+		Secret:    secret,
+		SrvPubKey: srvPubKey,
 	}
 }
 

--- a/waveshell/pkg/shexec/shexec.go
+++ b/waveshell/pkg/shexec/shexec.go
@@ -957,7 +957,7 @@ func RunCommandSimple(pk *packet.RunPacketType, sender *packet.PacketSender, fro
 	if pk.IsSudo {
 		sudoKey = uuid.New()
 		sudoErrKey = uuid.New()
-		pk.Command = fmt.Sprintf("sudo -p \"%s\" -S true 2>&7 <&6; if [ $? != 0 ]; then echo %s >&7 && exit; fi; exec 6>&-; exec 7>&-; %s", sudoKey, sudoErrKey, pk.Command)
+		fullCmdStr = fmt.Sprintf("sudo -p \"%s\" -S true 2>&7 <&6; if [ $? != 0 ]; then echo %s >&7 && exit; fi; exec 6>&-; exec 7>&-; %s", sudoKey, sudoErrKey, fullCmdStr)
 	}
 
 	cmd.Cmd = sapi.MakeShExecCommand(fullCmdStr, rcFileName, pk.UsePty)

--- a/waveshell/pkg/shexec/shexec.go
+++ b/waveshell/pkg/shexec/shexec.go
@@ -37,7 +37,7 @@ import (
 	"github.com/wavetermdev/waveterm/waveshell/pkg/shellutil"
 	"github.com/wavetermdev/waveterm/waveshell/pkg/utilfn"
 	"github.com/wavetermdev/waveterm/waveshell/pkg/wlog"
-	"github.com/wavetermdev/waveterm/wavesrv/pkg/promptenc"
+	"github.com/wavetermdev/waveterm/wavesrv/pkg/waveenc"
 	"golang.org/x/mod/semver"
 	"golang.org/x/sys/unix"
 )
@@ -199,7 +199,7 @@ func (s *ShExecType) processSpecialInputPacket(pk *packet.SpecialInputPacketType
 }
 
 func (s ShExecUPR) processSudoResponsePacket(sudoPacket *packet.SudoResponsePacketType) error {
-	encryptor, err := promptenc.MakeEncryptorEcdh(s.ShExec.ShellPrivKey, sudoPacket.SrvPubKey)
+	encryptor, err := waveenc.MakeEncryptorEcdh(s.ShExec.ShellPrivKey, sudoPacket.SrvPubKey)
 	if err != nil {
 		return err
 	}

--- a/wavesrv/cmd/main-server.go
+++ b/wavesrv/cmd/main-server.go
@@ -39,7 +39,6 @@ import (
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/cmdrunner"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/ephemeral"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/pcloud"
-	"github.com/wavetermdev/waveterm/wavesrv/pkg/promptenc"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/releasechecker"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/remote"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/rtnstate"
@@ -49,6 +48,7 @@ import (
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/scws"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/sstore"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/telemetry"
+	"github.com/wavetermdev/waveterm/wavesrv/pkg/waveenc"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/wsshell"
 )
 
@@ -830,7 +830,7 @@ func AuthKeyWrapAllowHmac(fn WebFnType) WebFnType {
 				w.Write([]byte("no x-authkey header"))
 				return
 			}
-			hmacOk, err := promptenc.ValidateUrlHmac([]byte(scbase.WaveAuthKey), r.URL.Path, qvals)
+			hmacOk, err := waveenc.ValidateUrlHmac([]byte(scbase.WaveAuthKey), r.URL.Path, qvals)
 			if err != nil || !hmacOk {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte(fmt.Sprintf("error validating hmac")))

--- a/wavesrv/pkg/bufferedpipe/bufferedpipe.go
+++ b/wavesrv/pkg/bufferedpipe/bufferedpipe.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/wavetermdev/waveterm/wavesrv/pkg/promptenc"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/scbase"
+	"github.com/wavetermdev/waveterm/wavesrv/pkg/waveenc"
 )
 
 const (
@@ -54,7 +54,7 @@ func (pipe *BufferedPipe) GetOutputUrl() (string, error) {
 	qvals := make(url.Values)
 	qvals.Set("key", pipe.Key)
 	qvals.Set("nonce", uuid.New().String())
-	hmacStr, err := promptenc.ComputeUrlHmac([]byte(scbase.WaveAuthKey), BufferedPipeGetterUrl, qvals)
+	hmacStr, err := waveenc.ComputeUrlHmac([]byte(scbase.WaveAuthKey), BufferedPipeGetterUrl, qvals)
 	if err != nil {
 		return "", err
 	}

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -610,7 +610,6 @@ func RunCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (scbus.Up
 	if err != nil {
 		return nil, fmt.Errorf("/run error, invalid lang: %w", err)
 	}
-	sudoArg := resolveBool(pk.Kwargs[KwArgSudo], false)
 
 	cmdStr := firstArg(pk)
 	expandedCmdStr, err := doCmdHistoryExpansion(ctx, ids, cmdStr)
@@ -643,7 +642,11 @@ func RunCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (scbus.Up
 	}
 	runPacket.Command = strings.TrimSpace(cmdStr)
 	runPacket.ReturnState = resolveBool(pk.Kwargs["rtnstate"], isRtnStateCmd)
-	runPacket.IsSudo = sudoArg || IsSudoCommand(cmdStr)
+	if sudoArg, ok := pk.Kwargs[KwArgSudo]; ok {
+		runPacket.IsSudo = resolveBool(sudoArg, false)
+	} else {
+		runPacket.IsSudo = IsSudoCommand(cmdStr)
+	}
 	rcOpts := remote.RunCommandOpts{
 		SessionId:     ids.SessionId,
 		ScreenId:      ids.ScreenId,

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -593,17 +593,6 @@ func getLangArg(pk *scpacket.FeCommandPacketType) (string, error) {
 	return pk.Kwargs[KwArgLang], nil
 }
 
-func getSudoArg(pk *scpacket.FeCommandPacketType) (bool, error) {
-	// TODO better error checking
-	if len(pk.Kwargs[KwArgSudo]) > 50 {
-		return false, nil // TODO return error, don't fail silently
-	}
-	if pk.Kwargs[KwArgSudo] == "" {
-		return false, nil
-	}
-	return strconv.ParseBool(pk.Kwargs[KwArgSudo])
-}
-
 func RunCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (scbus.UpdatePacket, error) {
 	ids, err := resolveUiIds(ctx, pk, R_Session|R_Screen|R_RemoteConnected)
 	if err != nil {
@@ -621,10 +610,8 @@ func RunCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (scbus.Up
 	if err != nil {
 		return nil, fmt.Errorf("/run error, invalid lang: %w", err)
 	}
-	sudoArg, err := getSudoArg(pk)
-	if err != nil {
-		return nil, fmt.Errorf("/run error, invalid sudo: %w", err)
-	}
+	sudoArg := resolveBool(pk.Kwargs[KwArgSudo], false)
+
 	cmdStr := firstArg(pk)
 	expandedCmdStr, err := doCmdHistoryExpansion(ctx, ids, cmdStr)
 	if err != nil {

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -3931,7 +3931,7 @@ func ClearSudoCache(ctx context.Context, pk *scpacket.FeCommandPacketType) (rtnU
 
 	clearAll := resolveBool(pk.Kwargs["all"], false)
 	if clearAll {
-		for _, proc := range remote.GlobalStore.Map {
+		for _, proc := range remote.GetRemoteMap() {
 			proc.ClearCachedSudoPw()
 		}
 		pluralize = "s"

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -40,7 +40,6 @@ import (
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/ephemeral"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/history"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/pcloud"
-	"github.com/wavetermdev/waveterm/wavesrv/pkg/promptenc"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/releasechecker"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/remote"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/remote/openai"
@@ -50,6 +49,7 @@ import (
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/scpacket"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/sstore"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/telemetry"
+	"github.com/wavetermdev/waveterm/wavesrv/pkg/waveenc"
 	"golang.org/x/mod/semver"
 )
 
@@ -5255,7 +5255,7 @@ func MakeReadFileUrl(screenId string, lineId string, filePath string) (string, e
 	qvals.Set("lineid", lineId)
 	qvals.Set("path", filePath)
 	qvals.Set("nonce", uuid.New().String())
-	hmacStr, err := promptenc.ComputeUrlHmac([]byte(scbase.WaveAuthKey), "/api/read-file", qvals)
+	hmacStr, err := waveenc.ComputeUrlHmac([]byte(scbase.WaveAuthKey), "/api/read-file", qvals)
 	if err != nil {
 		return "", fmt.Errorf("error computing hmac-url: %v", err)
 	}

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -639,6 +639,7 @@ func RunCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (scbus.Up
 	}
 	runPacket.Command = strings.TrimSpace(cmdStr)
 	runPacket.ReturnState = resolveBool(pk.Kwargs["rtnstate"], isRtnStateCmd)
+	runPacket.IsSudo = IsSudoCommand(cmdStr)
 	rcOpts := remote.RunCommandOpts{
 		SessionId:     ids.SessionId,
 		ScreenId:      ids.ScreenId,

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -295,6 +295,8 @@ func init() {
 	registerCmdFn("csvview", CSVViewCommand)
 
 	registerCmdFn("_debug:ri", DebugRemoteInstanceCommand)
+
+	registerCmdFn("sudo:clear", ClearSudoCache)
 }
 
 func getValidCommands() []string {
@@ -3912,6 +3914,20 @@ func DebugRemoteInstanceCommand(ctx context.Context, pk *scpacket.FeCommandPacke
 	update.AddUpdate(sstore.InfoMsgType{
 		InfoTitle: "remote instance",
 		InfoLines: outputLines,
+	})
+	return update, nil
+}
+
+func ClearSudoCache(ctx context.Context, pk *scpacket.FeCommandPacketType) (rtnUpdate scbus.UpdatePacket, rtnErr error) {
+	ids, err := resolveUiIds(ctx, pk, R_Session|R_Screen|R_Remote)
+	if err != nil {
+		return nil, err
+	}
+	ids.Remote.MShell.ClearCachedSudoPw()
+	update := scbus.MakeUpdatePacket()
+	update.AddUpdate(sstore.InfoMsgType{
+		InfoMsg:   "sudo password cleared",
+		TimeoutMs: 2000,
 	})
 	return update, nil
 }

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -88,7 +88,6 @@ const OpenAIPacketTimeout = 10 * time.Second
 const OpenAIStreamTimeout = 5 * time.Minute
 const OpenAICloudCompletionTelemetryOffErrorMsg = "To ensure responsible usage and prevent misuse, Wave AI requires telemetry to be enabled when using its free AI features.\n\nIf you prefer not to enable telemetry, you can still access Wave AI's features by providing your own OpenAI API key in the Settings menu. Please note that when using your personal API key, requests will be sent directly to the OpenAI API without being proxied through Wave's servers.\n\nIf you wish to continue using Wave AI's free features, you can easily enable telemetry by running the '/telemetry:on' command in the terminal. This will allow you to access the free AI features while helping to protect the platform from abuse."
 
-
 const (
 	KwArgRenderer = "renderer"
 	KwArgView     = "view"
@@ -639,7 +638,7 @@ func RunCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (scbus.Up
 	}
 	runPacket.Command = strings.TrimSpace(cmdStr)
 	runPacket.ReturnState = resolveBool(pk.Kwargs["rtnstate"], isRtnStateCmd)
-	runPacket.IsSudo = IsSudoCommand(cmdStr)
+	runPacket.IsSudo = IsSudoCommand(cmdStr) && scbase.IsDevMode() // only use sudo caching in dev mode (for now)
 	rcOpts := remote.RunCommandOpts{
 		SessionId:     ids.SessionId,
 		ScreenId:      ids.ScreenId,

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -3927,17 +3927,19 @@ func ClearSudoCache(ctx context.Context, pk *scpacket.FeCommandPacketType) (rtnU
 		return nil, err
 	}
 	ids.Remote.MShell.ClearCachedSudoPw()
+	pluralize := ""
 
 	clearAll := resolveBool(pk.Kwargs["all"], false)
 	if clearAll {
 		for _, proc := range remote.GlobalStore.Map {
 			proc.ClearCachedSudoPw()
 		}
+		pluralize = "s"
 	}
 
 	update := scbus.MakeUpdatePacket()
 	update.AddUpdate(sstore.InfoMsgType{
-		InfoMsg:   "sudo password cleared",
+		InfoMsg:   fmt.Sprintf("sudo password%s cleared", pluralize),
 		TimeoutMs: 2000,
 	})
 	return update, nil

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -3927,6 +3927,14 @@ func ClearSudoCache(ctx context.Context, pk *scpacket.FeCommandPacketType) (rtnU
 		return nil, err
 	}
 	ids.Remote.MShell.ClearCachedSudoPw()
+
+	clearAll := resolveBool(pk.Kwargs["all"], false)
+	if clearAll {
+		for _, proc := range remote.GlobalStore.Map {
+			proc.ClearCachedSudoPw()
+		}
+	}
+
 	update := scbus.MakeUpdatePacket()
 	update.AddUpdate(sstore.InfoMsgType{
 		InfoMsg:   "sudo password cleared",

--- a/wavesrv/pkg/cmdrunner/cmdrunner.go
+++ b/wavesrv/pkg/cmdrunner/cmdrunner.go
@@ -643,7 +643,7 @@ func RunCommand(ctx context.Context, pk *scpacket.FeCommandPacketType) (scbus.Up
 	}
 	runPacket.Command = strings.TrimSpace(cmdStr)
 	runPacket.ReturnState = resolveBool(pk.Kwargs["rtnstate"], isRtnStateCmd)
-	runPacket.IsSudo = (sudoArg || IsSudoCommand(cmdStr)) && scbase.IsDevMode() // only use sudo caching in dev mode (for now)
+	runPacket.IsSudo = sudoArg || IsSudoCommand(cmdStr)
 	rcOpts := remote.RunCommandOpts{
 		SessionId:     ids.SessionId,
 		ScreenId:      ids.ScreenId,

--- a/wavesrv/pkg/cmdrunner/shparse.go
+++ b/wavesrv/pkg/cmdrunner/shparse.go
@@ -311,6 +311,55 @@ func IsReturnStateCommand(cmdStr string) bool {
 	return false
 }
 
+func checkSimpleSudoCmd(cmdStr string) bool {
+	cmdStr = strings.TrimSpace(cmdStr)
+	return strings.HasPrefix(cmdStr, "sudo ")
+}
+
+func isSudoCmd(cmd syntax.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	if _, ok := cmd.(*syntax.FuncDecl); ok {
+		return false
+	}
+	if blockExpr, ok := cmd.(*syntax.Block); ok {
+		for _, stmt := range blockExpr.Stmts {
+			if isSudoCmd(stmt.Cmd) {
+				return true
+			}
+		}
+		return false
+	}
+	if binExpr, ok := cmd.(*syntax.BinaryCmd); ok {
+		if isSudoCmd(binExpr.X.Cmd) || isSudoCmd(binExpr.Y.Cmd) {
+			return true
+		}
+	} else if callExpr, ok := cmd.(*syntax.CallExpr); ok {
+		arg0 := getCallExprLitArg(callExpr, 0)
+		if arg0 != "" && utilfn.ContainsStr([]string{"sudo"}, arg0) {
+			return true
+		}
+	}
+	return false
+
+}
+
+func IsSudoCommand(cmdStr string) bool {
+	cmdReader := strings.NewReader(cmdStr)
+	parser := syntax.NewParser(syntax.Variant(syntax.LangBash))
+	file, err := parser.Parse(cmdReader, "sudo")
+	if err != nil {
+		return checkSimpleSudoCmd(cmdStr)
+	}
+	for _, stmt := range file.Stmts {
+		if isSudoCmd(stmt.Cmd) {
+			return true
+		}
+	}
+	return false
+}
+
 func EvalBracketArgs(origCmdStr string) (map[string]string, string, error) {
 	rtn := make(map[string]string)
 	if strings.HasPrefix(origCmdStr, " ") {

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -2763,6 +2763,7 @@ func (msh *MShellProc) processSinglePacket(pk packet.PacketType) {
 func (msh *MShellProc) ClearCachedSudoPw() {
 	msh.WithLock(func() {
 		msh.sudoPw = nil
+		msh.sudoClearDeadline = 0
 	})
 }
 

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -38,13 +38,13 @@ import (
 	"github.com/wavetermdev/waveterm/waveshell/pkg/statediff"
 	"github.com/wavetermdev/waveterm/waveshell/pkg/utilfn"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/ephemeral"
-	"github.com/wavetermdev/waveterm/wavesrv/pkg/promptenc"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/scbase"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/scbus"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/scpacket"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/sstore"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/telemetry"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/userinput"
+	"github.com/wavetermdev/waveterm/wavesrv/pkg/waveenc"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/mod/semver"
@@ -2689,7 +2689,7 @@ func (msh *MShellProc) sendSudoPassword(sudoPk *packet.SudoRequestPacketType) er
 	if err != nil {
 		return fmt.Errorf("generate ecdh: %e", err)
 	}
-	encryptor, err := promptenc.MakeEncryptorEcdh(srvPrivKey, sudoPk.ShellPubKey)
+	encryptor, err := waveenc.MakeEncryptorEcdh(srvPrivKey, sudoPk.ShellPubKey)
 	if err != nil {
 		return err
 	}

--- a/wavesrv/pkg/remote/remote.go
+++ b/wavesrv/pkg/remote/remote.go
@@ -2777,6 +2777,12 @@ func (msh *MShellProc) processSinglePacket(pk packet.PacketType) {
 	msh.WriteToPtyBuffer("*[remote %s] unhandled packet %s\n", msh.GetRemoteName(), packet.AsString(pk))
 }
 
+func (msh *MShellProc) ClearCachedSudoPw() {
+	msh.WithLock(func() {
+		msh.sudoPw = nil
+	})
+}
+
 func (msh *MShellProc) ProcessPackets() {
 	defer msh.WithLock(func() {
 		if msh.Status == StatusConnected {

--- a/wavesrv/pkg/userinput/userinput.go
+++ b/wavesrv/pkg/userinput/userinput.go
@@ -13,6 +13,8 @@ import (
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/scbus"
 )
 
+const UserInputRequestStr = "userinputrequest"
+
 // An RpcPacket for requesting user input from the client
 type UserInputRequestType struct {
 	RequestId    string `json:"requestid"`
@@ -26,7 +28,7 @@ type UserInputRequestType struct {
 }
 
 func (*UserInputRequestType) GetType() string {
-	return "userinputrequest"
+	return UserInputRequestStr
 }
 
 func (req *UserInputRequestType) SetReqId(reqId string) {

--- a/wavesrv/pkg/waveenc/hmac.go
+++ b/wavesrv/pkg/waveenc/hmac.go
@@ -1,7 +1,7 @@
 // Copyright 2024, Command Line Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package promptenc
+package waveenc
 
 import (
 	"crypto/hmac"

--- a/wavesrv/pkg/waveenc/waveenc.go
+++ b/wavesrv/pkg/waveenc/waveenc.go
@@ -1,7 +1,7 @@
 // Copyright 2023, Command Line Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package promptenc
+package waveenc
 
 import (
 	"crypto/cipher"


### PR DESCRIPTION
This change allows waveterm to cache your sudo password for use across multiple ptys. This prevents the user from needing to enter it for every command where it's required.