### PR TITLE
fix: ignore computer sleep for telemetry clock

### DIFF
--- a/wavesrv/cmd/main-server.go
+++ b/wavesrv/cmd/main-server.go
@@ -930,12 +930,11 @@ func checkNewReleaseWrapper() {
 }
 
 func telemetryLoop() {
-	var lastSent time.Time
+	var nextSend int64
 	time.Sleep(InitialTelemetryWait)
 	for {
-		dur := time.Since(lastSent)
-		if lastSent.IsZero() || dur >= TelemetryInterval {
-			lastSent = time.Now()
+		if time.Now().Unix() > nextSend {
+			nextSend = time.Now().Add(TelemetryInterval).Unix()
 			sendTelemetryWrapper()
 			checkNewReleaseWrapper()
 		}


### PR DESCRIPTION
This uses unix time with regular integer comparisons to prevent the telemetry clock from needing to wait for 8 hours of the program running. Now, it only needs to wait 8 real-time hours instead.