### PR TITLE
fix: inline text edit button use onMouseDown

### DIFF
--- a/src/app/common/elements/inlinesettingstextedit.tsx
+++ b/src/app/common/elements/inlinesettingstextedit.tsx
@@ -131,7 +131,7 @@ class InlineSettingsTextEdit extends React.Component<
                         </div>
                         <div className="control">
                             <div
-                                onClick={this.cancelChange}
+                                onMouseDown={this.cancelChange}
                                 title="Cancel (Esc)"
                                 className="button is-prompt-danger is-outlined is-small"
                             >
@@ -142,7 +142,7 @@ class InlineSettingsTextEdit extends React.Component<
                         </div>
                         <div className="control">
                             <div
-                                onClick={this.confirmChange}
+                                onMouseDown={this.confirmChange}
                                 title="Confirm (Enter)"
                                 className="button is-wave-green is-outlined is-small"
                             >


### PR DESCRIPTION
This PR fix a issue that after edit text in `InlineSettingsTextEdit` click `Confirm` button is not work.

<img width="446" alt="截屏2024-04-17 22 52 03" src="https://github.com/wavetermdev/waveterm/assets/21140084/e62779e9-2d3a-40f1-994a-97584bf77267">

Because of `onBlur` has high priority than `onClick` when click `Confirm` button always execute `handleBlur` first, so edit will be canceled. `onMouseDown` has high priority than `onBlur`, can fix this issue.