### PR TITLE
fix: add a new line when writing to knownhosts

### DIFF
--- a/wavesrv/pkg/remote/sshclient.go
+++ b/wavesrv/pkg/remote/sshclient.go
@@ -292,7 +292,7 @@ func writeToKnownHosts(knownHostsFile string, newLine string, getUserVerificatio
 		return UserInputCancelError{Err: fmt.Errorf("canceled by the user")}
 	}
 
-	_, err = f.WriteString(newLine)
+	_, err = f.WriteString(newLine + "\n")
 	if err != nil {
 		f.Close()
 		return err


### PR DESCRIPTION
This fixes issue #476 by ensuring that when waveterm writes to a knownhosts file, a newline character is appended at the end.