### PR TITLE
Open AI Timeout setting and alias for all settings

### DIFF
--- a/src/app/clientsettings/clientsettings.tsx
+++ b/src/app/clientsettings/clientsettings.tsx
@@ -159,6 +159,12 @@ class ClientSettingsView extends React.Component<{ model: RemotesModel }, { hove
     }
 
     @boundMethod
+    inlineUpdateOpenAITimeout(newTimeout: string): void {
+        const prtn = GlobalCommandRunner.setClientOpenAISettings({ timeout: newTimeout });
+        commandRtnHandler(prtn, this.errorMessage);
+    }
+
+    @boundMethod
     setErrorMessage(msg: string): void {
         mobx.action(() => {
             this.errorMessage.set(msg);
@@ -204,6 +210,7 @@ class ClientSettingsView extends React.Component<{ model: RemotesModel }, { hove
         const maxTokensStr = String(
             openAIOpts.maxtokens == null || openAIOpts.maxtokens == 0 ? 1000 : openAIOpts.maxtokens
         );
+        const aiTimeoutStr = String(openAIOpts.timeout == null || openAIOpts.timeout == 0 ? 10 : openAIOpts.timeout);
         const curFontSize = GlobalModel.getTermFontSize();
         const curFontFamily = GlobalModel.getTermFontFamily();
         const curTheme = GlobalModel.getThemeSource();
@@ -338,6 +345,19 @@ class ClientSettingsView extends React.Component<{ model: RemotesModel }, { hove
                                 text={maxTokensStr}
                                 value={maxTokensStr}
                                 onChange={this.inlineUpdateOpenAIMaxTokens}
+                                maxLength={10}
+                                showIcon={true}
+                            />
+                        </div>
+                    </div>
+                    <div className="settings-field">
+                        <div className="settings-label">AI Timeout (seconds)</div>
+                        <div className="settings-input">
+                            <InlineSettingsTextEdit
+                                placeholder=""
+                                text={aiTimeoutStr}
+                                value={aiTimeoutStr}
+                                onChange={this.inlineUpdateOpenAITimeout}
                                 maxLength={10}
                                 showIcon={true}
                             />

--- a/src/models/commandrunner.ts
+++ b/src/models/commandrunner.ts
@@ -413,6 +413,7 @@ class CommandRunner {
         apitoken?: string;
         maxtokens?: string;
         baseurl?: string;
+        timeout?: string;
     }): Promise<CommandRtnType> {
         let kwargs = {
             nohist: "1",
@@ -428,6 +429,9 @@ class CommandRunner {
         }
         if (opts.baseurl != null) {
             kwargs["openaibaseurl"] = opts.baseurl;
+        }
+        if (opts.timeout != null) {
+            kwargs["openaitimeout"] = opts.timeout;
         }
         return GlobalModel.submitCommand("client", "set", null, kwargs, false);
     }

--- a/src/types/custom.d.ts
+++ b/src/types/custom.d.ts
@@ -644,6 +644,7 @@ declare global {
         maxtokens?: number;
         maxchoices?: number;
         baseurl?: string;
+        timeout?: number;
     };
 
     type PlaybookType = {

--- a/wavesrv/pkg/sstore/sstore.go
+++ b/wavesrv/pkg/sstore/sstore.go
@@ -289,6 +289,8 @@ func (cdata *ClientData) Clean() *ClientData {
 			Model:      cdata.OpenAIOpts.Model,
 			MaxTokens:  cdata.OpenAIOpts.MaxTokens,
 			MaxChoices: cdata.OpenAIOpts.MaxChoices,
+			Timeout:    cdata.OpenAIOpts.Timeout,
+			BaseURL:    cdata.OpenAIOpts.BaseURL,
 			// omit API Token
 		}
 		if cdata.OpenAIOpts.APIToken != "" {
@@ -736,6 +738,7 @@ type OpenAIOptsType struct {
 	BaseURL    string `json:"baseurl,omitempty"`
 	MaxTokens  int    `json:"maxtokens,omitempty"`
 	MaxChoices int    `json:"maxchoices,omitempty"`
+	Timeout    int    `json:"timeout,omitempty"`
 }
 
 const (


### PR DESCRIPTION
Added a timeout setting for our ai and added aliases for all of the ai settings. 

Note that the timeout that can be set is the packet timeout, ie the timeout when waiting for a server response. The entire stream has a timeout of 5 minutes, I'm thinking we should up that timeout as well, perhaps to 10 minutes 

Or should I have a setting for that timeout as well? I think the packet response one is the one that we really should be setting, but not 100% sure 