### PR TITLE
Attempt 2 to resolve security warning

### DIFF
--- a/wavesrv/cmd/main-server.go
+++ b/wavesrv/cmd/main-server.go
@@ -797,7 +797,8 @@ func HandleRunEphemeralCommand(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func CheckIsDir(dirHandler http.Handler, fileHandler http.Handler) http.Handler {
+// Checks if the /config request is for a specific file or a directory. Passes the request to the appropriate handler.
+func ConfigHandlerCheckIsDir(dirHandler http.Handler, fileHandler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		configPath := r.URL.Path
 		configBaseDir, err := filepath.Abs(filepath.Join(scbase.GetWaveHomeDir(), "config"))
@@ -1188,7 +1189,7 @@ func main() {
 	log.Printf("[wave] config path: %q\n", configPath)
 	isFileHandler := http.StripPrefix("/config/", http.FileServer(http.Dir(configPath)+"/"))
 	isDirHandler := http.HandlerFunc(configDirHandler)
-	gr.PathPrefix("/config/").Handler(CheckIsDir(isDirHandler, isFileHandler))
+	gr.PathPrefix("/config/").Handler(ConfigHandlerCheckIsDir(isDirHandler, isFileHandler))
 
 	serverAddr := MainServerAddr
 	if scbase.IsDevMode() {

--- a/wavesrv/cmd/main-server.go
+++ b/wavesrv/cmd/main-server.go
@@ -810,7 +810,7 @@ func CheckIsDir(dirHandler http.Handler, fileHandler http.Handler) http.Handler 
 		fstat, err := os.Stat(configFullPath)
 		if errors.Is(err, fs.ErrNotExist) {
 			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(fmt.Sprintf("file not found: %v", configPath)))
+			w.Write([]byte(fmt.Sprintf("file not found: %v", err)))
 			return
 		} else if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/wavesrv/cmd/main-server.go
+++ b/wavesrv/cmd/main-server.go
@@ -857,7 +857,7 @@ func AuthKeyWrapAllowHmac(fn WebFnType) WebFnType {
 			hmacOk, err := waveenc.ValidateUrlHmac([]byte(scbase.WaveAuthKey), r.URL.Path, qvals)
 			if err != nil || !hmacOk {
 				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(fmt.Sprintf("error validating hmac")))
+				w.Write([]byte("error validating hmac"))
 				return
 			}
 			// fallthrough (hmac is valid)

--- a/wavesrv/cmd/main-server.go
+++ b/wavesrv/cmd/main-server.go
@@ -800,7 +800,12 @@ func HandleRunEphemeralCommand(w http.ResponseWriter, r *http.Request) {
 func CheckIsDir(dirHandler http.Handler, fileHandler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		configPath := r.URL.Path
-		configBaseDir := filepath.Join(scbase.GetWaveHomeDir(), "config")
+		configBaseDir, err := filepath.Abs(filepath.Join(scbase.GetWaveHomeDir(), "config"))
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("error: cannot get config base dir"))
+			return
+		}
 		configFullPath, err := filepath.Abs(filepath.Join(scbase.GetWaveHomeDir(), configPath))
 		if err != nil || !strings.HasPrefix(configFullPath, configBaseDir) {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/wavesrv/cmd/main-server.go
+++ b/wavesrv/cmd/main-server.go
@@ -801,12 +801,7 @@ func HandleRunEphemeralCommand(w http.ResponseWriter, r *http.Request) {
 func ConfigHandlerCheckIsDir(dirHandler http.Handler, fileHandler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		configPath := r.URL.Path
-		configBaseDir, err := filepath.Abs(filepath.Join(scbase.GetWaveHomeDir(), "config"))
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("error: cannot get config base dir"))
-			return
-		}
+		configBaseDir := filepath.Join(scbase.GetWaveHomeDir(), "config")
 		configFullPath, err := filepath.Abs(filepath.Join(scbase.GetWaveHomeDir(), configPath))
 		if err != nil || !strings.HasPrefix(configFullPath, configBaseDir) {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/wavesrv/pkg/scbase/scbase.go
+++ b/wavesrv/pkg/scbase/scbase.go
@@ -12,7 +12,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -64,9 +64,9 @@ func GetWaveHomeDir() string {
 		}
 		pdev := os.Getenv(WaveDevVarName)
 		if pdev != "" {
-			scHome = path.Join(homeVar, WaveDevDirName)
+			scHome = filepath.Join(homeVar, WaveDevDirName)
 		} else {
-			scHome = path.Join(homeVar, WaveDirName)
+			scHome = filepath.Join(homeVar, WaveDirName)
 		}
 
 	}
@@ -78,7 +78,7 @@ func MShellBinaryDir() string {
 	if appPath == "" {
 		appPath = "."
 	}
-	return path.Join(appPath, "bin", "mshell")
+	return filepath.Join(appPath, "bin", "mshell")
 }
 
 func MShellBinaryPath(version string, goos string, goarch string) (string, error) {
@@ -91,7 +91,7 @@ func MShellBinaryPath(version string, goos string, goarch string) (string, error
 		return "", fmt.Errorf("invalid mshell version: %q", version)
 	}
 	fileName := fmt.Sprintf("mshell-%s-%s.%s", versionStr, goos, goarch)
-	fullFileName := path.Join(binaryDir, fileName)
+	fullFileName := filepath.Join(binaryDir, fileName)
 	return fullFileName, nil
 }
 
@@ -134,7 +134,7 @@ func InitializeWaveAuthKey() error {
 	if err != nil {
 		return fmt.Errorf("cannot find/create WAVETERM_HOME directory %q", homeDir)
 	}
-	fileName := path.Join(homeDir, WaveAuthKeyFileName)
+	fileName := filepath.Join(homeDir, WaveAuthKeyFileName)
 	fd, err := os.Open(fileName)
 	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		return createWaveAuthKeyFile(fileName)
@@ -162,7 +162,7 @@ func AcquireWaveLock() (*os.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot find/create WAVETERM_HOME directory %q", homeDir)
 	}
-	lockFileName := path.Join(homeDir, WaveLockFile)
+	lockFileName := filepath.Join(homeDir, WaveLockFile)
 	log.Printf("[base] acquiring lock on %s\n", lockFileName)
 	fd, err := os.OpenFile(lockFileName, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
@@ -188,7 +188,7 @@ func EnsureSessionDir(sessionId string) (string, error) {
 		return sdir, nil
 	}
 	scHome := GetWaveHomeDir()
-	sdir = path.Join(scHome, SessionsDirBaseName, sessionId)
+	sdir = filepath.Join(scHome, SessionsDirBaseName, sessionId)
 	err := ensureDir(sdir)
 	if err != nil {
 		return "", err
@@ -202,7 +202,7 @@ func EnsureSessionDir(sessionId string) (string, error) {
 // deprecated (v0.1.8)
 func GetSessionsDir() string {
 	waveHome := GetWaveHomeDir()
-	sdir := path.Join(waveHome, SessionsDirBaseName)
+	sdir := filepath.Join(waveHome, SessionsDirBaseName)
 	return sdir
 }
 
@@ -217,7 +217,7 @@ func EnsureScreenDir(screenId string) (string, error) {
 		return sdir, nil
 	}
 	scHome := GetWaveHomeDir()
-	sdir = path.Join(scHome, ScreensDirBaseName, screenId)
+	sdir = filepath.Join(scHome, ScreensDirBaseName, screenId)
 	err := ensureDir(sdir)
 	if err != nil {
 		return "", err
@@ -230,18 +230,18 @@ func EnsureScreenDir(screenId string) (string, error) {
 
 func GetScreensDir() string {
 	waveHome := GetWaveHomeDir()
-	sdir := path.Join(waveHome, ScreensDirBaseName)
+	sdir := filepath.Join(waveHome, ScreensDirBaseName)
 	return sdir
 }
 
 func EnsureConfigDirs() (string, error) {
 	scHome := GetWaveHomeDir()
-	configDir := path.Join(scHome, "config")
+	configDir := filepath.Join(scHome, "config")
 	err := ensureDir(configDir)
 	if err != nil {
 		return "", err
 	}
-	keybindingsFile := path.Join(configDir, "keybindings.json")
+	keybindingsFile := filepath.Join(configDir, "keybindings.json")
 	keybindingsFileObj, err := ensureFile(keybindingsFile)
 	if err != nil {
 		return "", err
@@ -250,7 +250,7 @@ func EnsureConfigDirs() (string, error) {
 		keybindingsFileObj.WriteString("[]\n")
 		keybindingsFileObj.Close()
 	}
-	terminalThemesDir := path.Join(configDir, "terminal-themes")
+	terminalThemesDir := filepath.Join(configDir, "terminal-themes")
 	err = ensureDir(terminalThemesDir)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This is the second attempt to resolve the "Uncontrolled data in path expression" warning. I am also using this opportunity to replace `path` with `filepath` in the `main-server.go` file.