### PR TITLE
Fixed separator code in config path

### DIFF
--- a/wavesrv/cmd/main-server.go
+++ b/wavesrv/cmd/main-server.go
@@ -1180,12 +1180,7 @@ func main() {
 	gr.HandleFunc("/api/log-active-state", AuthKeyWrap(HandleLogActiveState))
 	gr.HandleFunc("/api/read-file", AuthKeyWrapAllowHmac(HandleReadFile))
 	gr.HandleFunc("/api/write-file", AuthKeyWrap(HandleWriteFile)).Methods("POST")
-	fileSep, err := strconv.Unquote(strconv.QuoteRune(filepath.Separator))
-	if err != nil {
-		log.Printf("file separator err: %v\n", fileSep)
-		fileSep = "/"
-	}
-	configPath := filepath.Join(scbase.GetWaveHomeDir(), "config") + fileSep
+	configPath := filepath.Join(scbase.GetWaveHomeDir(), "config") + string(filepath.Separator)
 	log.Printf("[wave] config path: %q\n", configPath)
 	isFileHandler := http.StripPrefix("/config/", http.FileServer(http.Dir(configPath)))
 	isDirHandler := http.HandlerFunc(configDirHandler)

--- a/wavesrv/cmd/main-server.go
+++ b/wavesrv/cmd/main-server.go
@@ -1180,7 +1180,12 @@ func main() {
 	gr.HandleFunc("/api/log-active-state", AuthKeyWrap(HandleLogActiveState))
 	gr.HandleFunc("/api/read-file", AuthKeyWrapAllowHmac(HandleReadFile))
 	gr.HandleFunc("/api/write-file", AuthKeyWrap(HandleWriteFile)).Methods("POST")
-	configPath := filepath.Join(scbase.GetWaveHomeDir(), "config") + strconv.QuoteRune(filepath.Separator)
+	fileSep, err := strconv.Unquote(strconv.QuoteRune(filepath.Separator))
+	if err != nil {
+		log.Printf("file separator err: %v\n", fileSep)
+		fileSep = "/"
+	}
+	configPath := filepath.Join(scbase.GetWaveHomeDir(), "config") + fileSep
 	log.Printf("[wave] config path: %q\n", configPath)
 	isFileHandler := http.StripPrefix("/config/", http.FileServer(http.Dir(configPath)))
 	isDirHandler := http.HandlerFunc(configDirHandler)


### PR DESCRIPTION
I found that the strconv quoteRune function was returning a string with quotes in the string, like `"\'/\'"`. Not sure why the strconv api was made that way, but I added a function to remove those quotes and a default value if something goes wrong