### PR TITLE
Break out non-autocomplete changes from autocomplete PR

### DIFF
--- a/public/themes/light.css
+++ b/public/themes/light.css
@@ -9,8 +9,8 @@
     --app-accent-color: rgb(75, 166, 57);
     --app-accent-bg-color: rgba(75, 166, 57, 0.2);
     --app-text-color: rgb(0, 0, 0);
-    --app-text-primary-color: rgb(0, 0, 0, 0.9);
-    --app-text-secondary-color: rgb(0, 0, 0, 0.7);
+    --app-text-primary-color: rgb(23, 23, 23);
+    --app-text-secondary-color: rgb(76, 76, 76);
     --app-border-color: rgb(139 145 138);
     --app-panel-bg-color: rgb(224, 224, 224);
     --app-panel-bg-color-dev: rgb(224, 224, 224);

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -103,16 +103,21 @@ class AIChat extends React.Component<{}, {}> {
         return { numLines, linePos };
     }
 
+    @mobx.action
+    @boundMethod
     onTextAreaFocused(e: any) {
         GlobalModel.inputModel.setAuxViewFocus(true);
         this.onTextAreaChange(e);
     }
 
+    @mobx.action
+    @boundMethod
     onTextAreaBlur(e: any) {
         GlobalModel.inputModel.setAuxViewFocus(false);
     }
 
     // Adjust the height of the textarea to fit the text
+    @boundMethod
     onTextAreaChange(e: any) {
         // Calculate the bounding height of the text area
         const textAreaMaxLines = 4;
@@ -141,8 +146,10 @@ class AIChat extends React.Component<{}, {}> {
             this.submitChatMessage(messageStr);
             currentRef.value = "";
         } else {
-            inputModel.grabCodeSelectSelection();
-            inputModel.setAuxViewFocus(false);
+            mobx.action(() => {
+                inputModel.grabCodeSelectSelection();
+                inputModel.setAuxViewFocus(false);
+            })();
         }
     }
 
@@ -183,7 +190,6 @@ class AIChat extends React.Component<{}, {}> {
         return true;
     }
 
-    @mobx.action
     @boundMethod
     onKeyDown(e: any) {}
 
@@ -255,9 +261,9 @@ class AIChat extends React.Component<{}, {}> {
                         autoComplete="off"
                         autoCorrect="off"
                         id="chat-cmd-input"
-                        onFocus={this.onTextAreaFocused.bind(this)}
-                        onBlur={this.onTextAreaBlur.bind(this)}
-                        onChange={this.onTextAreaChange.bind(this)}
+                        onFocus={this.onTextAreaFocused}
+                        onBlur={this.onTextAreaBlur}
+                        onChange={this.onTextAreaChange}
                         onKeyDown={this.onKeyDown}
                         style={{ fontSize: this.termFontSize }}
                         className="chat-textarea"

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -88,7 +88,7 @@ class AIChat extends React.Component<{}, {}> {
     }
 
     submitChatMessage(messageStr: string) {
-        const curLine = GlobalModel.inputModel.getCurLine();
+        const curLine = GlobalModel.inputModel.curLine;
         const prtn = GlobalModel.submitChatInfoCommand(messageStr, curLine, false);
         prtn.then((rtn) => {
             if (!rtn.success) {
@@ -105,6 +105,7 @@ class AIChat extends React.Component<{}, {}> {
 
     onTextAreaFocused(e: any) {
         GlobalModel.inputModel.setAuxViewFocus(true);
+        this.onTextAreaChange(e);
     }
 
     onTextAreaBlur(e: any) {

--- a/src/app/workspace/cmdinput/aichat.tsx
+++ b/src/app/workspace/cmdinput/aichat.tsx
@@ -103,15 +103,13 @@ class AIChat extends React.Component<{}, {}> {
         return { numLines, linePos };
     }
 
-    @mobx.action
-    @boundMethod
+    @mobx.action.bound
     onTextAreaFocused(e: any) {
         GlobalModel.inputModel.setAuxViewFocus(true);
         this.onTextAreaChange(e);
     }
 
-    @mobx.action
-    @boundMethod
+    @mobx.action.bound
     onTextAreaBlur(e: any) {
         GlobalModel.inputModel.setAuxViewFocus(false);
     }

--- a/src/app/workspace/cmdinput/cmdinput.less
+++ b/src/app/workspace/cmdinput/cmdinput.less
@@ -193,8 +193,8 @@
                 }
 
                 // This aligns the icons with the prompt field.
-                // We don't need right padding because the whole input field is already padded.
-                padding: 2px 0 0 12px;
+                // We don't need right margin because the whole input field is already padded.
+                margin: 2px 0 0 12px;
                 cursor: pointer;
             }
 

--- a/src/app/workspace/cmdinput/cmdinput.tsx
+++ b/src/app/workspace/cmdinput/cmdinput.tsx
@@ -56,8 +56,7 @@ class CmdInput extends React.Component<{}, {}> {
         this.updateCmdInputHeight();
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     clickFocusInputHint(): void {
         GlobalModel.inputModel.giveFocus();
     }
@@ -76,8 +75,7 @@ class CmdInput extends React.Component<{}, {}> {
         GlobalModel.inputModel.setAuxViewFocus(false);
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     clickAIAction(e: any): void {
         e.preventDefault();
         e.stopPropagation();
@@ -89,8 +87,7 @@ class CmdInput extends React.Component<{}, {}> {
         }
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     clickHistoryAction(e: any): void {
         e.preventDefault();
         e.stopPropagation();
@@ -108,8 +105,7 @@ class CmdInput extends React.Component<{}, {}> {
         GlobalCommandRunner.connectRemote(remoteId);
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     toggleFilter(screen: Screen) {
         screen.filterRunning.set(!screen.filterRunning.get());
     }

--- a/src/app/workspace/cmdinput/cmdinput.tsx
+++ b/src/app/workspace/cmdinput/cmdinput.tsx
@@ -57,6 +57,7 @@ class CmdInput extends React.Component<{}, {}> {
     }
 
     @boundMethod
+    @mobx.action
     clickFocusInputHint(): void {
         GlobalModel.inputModel.giveFocus();
     }
@@ -76,6 +77,7 @@ class CmdInput extends React.Component<{}, {}> {
     }
 
     @boundMethod
+    @mobx.action
     clickAIAction(e: any): void {
         e.preventDefault();
         e.stopPropagation();
@@ -88,6 +90,7 @@ class CmdInput extends React.Component<{}, {}> {
     }
 
     @boundMethod
+    @mobx.action
     clickHistoryAction(e: any): void {
         e.preventDefault();
         e.stopPropagation();
@@ -106,10 +109,9 @@ class CmdInput extends React.Component<{}, {}> {
     }
 
     @boundMethod
+    @mobx.action
     toggleFilter(screen: Screen) {
-        mobx.action(() => {
-            screen.filterRunning.set(!screen.filterRunning.get());
-        })();
+        screen.filterRunning.set(!screen.filterRunning.get());
     }
 
     @boundMethod

--- a/src/app/workspace/cmdinput/historyinfo.less
+++ b/src/app/workspace/cmdinput/historyinfo.less
@@ -22,6 +22,7 @@
         color: var(--app-text-color);
         display: flex;
         flex-direction: column-reverse;
+        min-height: 100%;
 
         .history-item {
             cursor: pointer;

--- a/src/app/workspace/cmdinput/historyinfo.tsx
+++ b/src/app/workspace/cmdinput/historyinfo.tsx
@@ -170,11 +170,13 @@ class HistoryInfo extends React.Component<{}, {}> {
     }
 
     @boundMethod
+    @mobx.action
     handleClose() {
         GlobalModel.inputModel.closeAuxView();
     }
 
     @boundMethod
+    @mobx.action
     handleItemClick(hitem: HistoryItem) {
         const inputModel = GlobalModel.inputModel;
         const selItem = inputModel.getHistorySelectedItem();
@@ -196,6 +198,7 @@ class HistoryInfo extends React.Component<{}, {}> {
     }
 
     @boundMethod
+    @mobx.action
     handleClickType() {
         const inputModel = GlobalModel.inputModel;
         inputModel.setAuxViewFocus(true);
@@ -203,6 +206,7 @@ class HistoryInfo extends React.Component<{}, {}> {
     }
 
     @boundMethod
+    @mobx.action
     handleClickRemote() {
         const inputModel = GlobalModel.inputModel;
         inputModel.setAuxViewFocus(true);

--- a/src/app/workspace/cmdinput/historyinfo.tsx
+++ b/src/app/workspace/cmdinput/historyinfo.tsx
@@ -229,7 +229,7 @@ class HistoryInfo extends React.Component<{}, {}> {
     render() {
         const inputModel = GlobalModel.inputModel;
         const selItem = inputModel.getHistorySelectedItem();
-        const hitems = inputModel.getFilteredHistoryItems();
+        const hitems = inputModel.filteredHistoryItems;
         const opts = inputModel.historyQueryOpts.get();
         let hitem: HistoryItem = null;
         let snames: Record<string, string> = {};

--- a/src/app/workspace/cmdinput/historyinfo.tsx
+++ b/src/app/workspace/cmdinput/historyinfo.tsx
@@ -169,14 +169,12 @@ class HistoryInfo extends React.Component<{}, {}> {
         }
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     handleClose() {
         GlobalModel.inputModel.closeAuxView();
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     handleItemClick(hitem: HistoryItem) {
         const inputModel = GlobalModel.inputModel;
         const selItem = inputModel.getHistorySelectedItem();
@@ -197,16 +195,14 @@ class HistoryInfo extends React.Component<{}, {}> {
         }, 3000);
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     handleClickType() {
         const inputModel = GlobalModel.inputModel;
         inputModel.setAuxViewFocus(true);
         inputModel.toggleHistoryType();
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     handleClickRemote() {
         const inputModel = GlobalModel.inputModel;
         inputModel.setAuxViewFocus(true);

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -117,7 +117,7 @@ class CmdInputKeybindings extends React.Component<{ inputObject: TextAreaInput }
             const lastTab = this.lastTab;
             this.lastTab = true;
             this.curPress = "tab";
-            const curLine = inputModel.getCurLine();
+            const curLine = inputModel.curLine;
             if (lastTab) {
                 GlobalModel.submitCommand(
                     "_compgen",
@@ -250,9 +250,10 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
     lastSP: StrWithPos = { str: "", pos: appconst.NoStrPos };
     version: OV<number> = mobx.observable.box(0, { name: "textAreaInput-version" }); // forces render updates
 
+    @mobx.action
     incVersion(): void {
         const v = this.version.get();
-        mobx.action(() => this.version.set(v + 1))();
+        this.version.set(v + 1);
     }
 
     getCurSP(): StrWithPos {
@@ -278,6 +279,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
         GlobalModel.sendCmdInputText(this.props.screen.screenId, curSP);
     }
 
+    @mobx.action
     setFocus(): void {
         GlobalModel.inputModel.giveFocus();
     }
@@ -324,6 +326,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
         this.updateSP();
     }
 
+    @mobx.action
     componentDidUpdate() {
         const activeScreen = GlobalModel.getActiveScreen();
         if (activeScreen != null) {
@@ -340,7 +343,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
                 this.mainInputRef.current.selectionStart = fcpos;
                 this.mainInputRef.current.selectionEnd = fcpos;
             }
-            mobx.action(() => inputModel.forceCursorPos.set(null))();
+            inputModel.forceCursorPos.set(null);
         }
         if (inputModel.forceInputFocus) {
             inputModel.forceInputFocus = false;
@@ -414,21 +417,20 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
             return;
         }
         currentRef.setRangeText("\n", currentRef.selectionStart, currentRef.selectionEnd, "end");
-        GlobalModel.inputModel.setCurLine(currentRef.value);
+        GlobalModel.inputModel.curLine = currentRef.value;
     }
 
-    @mobx.action
     @boundMethod
     onKeyDown(e: any) {}
 
     @boundMethod
+    @mobx.action
     onChange(e: any) {
-        mobx.action(() => {
-            GlobalModel.inputModel.setCurLine(e.target.value);
-        })();
+        GlobalModel.inputModel.curLine = e.target.value;
     }
 
     @boundMethod
+    @mobx.action
     onSelect(e: any) {
         this.incVersion();
     }
@@ -454,6 +456,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
     }
 
     @boundMethod
+    @mobx.action
     controlP() {
         const inputModel = GlobalModel.inputModel;
         if (!inputModel.isHistoryLoaded()) {
@@ -466,6 +469,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
     }
 
     @boundMethod
+    @mobx.action
     controlN() {
         const inputModel = GlobalModel.inputModel;
         inputModel.moveHistorySelection(-1);
@@ -527,16 +531,16 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
     }
 
     @boundMethod
+    @mobx.action
     handleHistoryInput(e: any) {
         const inputModel = GlobalModel.inputModel;
-        mobx.action(() => {
-            const opts = mobx.toJS(inputModel.historyQueryOpts.get());
-            opts.queryStr = e.target.value;
-            inputModel.setHistoryQueryOpts(opts);
-        })();
+        const opts = mobx.toJS(inputModel.historyQueryOpts.get());
+        opts.queryStr = e.target.value;
+        inputModel.setHistoryQueryOpts(opts);
     }
 
     @boundMethod
+    @mobx.action
     handleFocus(e: any) {
         e.preventDefault();
         GlobalModel.inputModel.giveFocus();
@@ -561,7 +565,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
     render() {
         const model = GlobalModel;
         const inputModel = model.inputModel;
-        const curLine = inputModel.getCurLine();
+        const curLine = inputModel.curLine;
         let displayLines = 1;
         const numLines = curLine.split("\n").length;
         const maxCols = this.getTextAreaMaxCols();

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -313,6 +313,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
         }
     }
 
+    @mobx.action
     componentDidMount() {
         const activeScreen = GlobalModel.getActiveScreen();
         if (activeScreen != null) {

--- a/src/app/workspace/cmdinput/textareainput.tsx
+++ b/src/app/workspace/cmdinput/textareainput.tsx
@@ -424,14 +424,12 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
     @boundMethod
     onKeyDown(e: any) {}
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     onChange(e: any) {
         GlobalModel.inputModel.curLine = e.target.value;
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     onSelect(e: any) {
         this.incVersion();
     }
@@ -456,8 +454,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
         GlobalModel.inputModel.updateCmdLine(cmdLineUpdate);
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     controlP() {
         const inputModel = GlobalModel.inputModel;
         if (!inputModel.isHistoryLoaded()) {
@@ -469,8 +466,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
         this.lastHistoryUpDown = true;
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     controlN() {
         const inputModel = GlobalModel.inputModel;
         inputModel.moveHistorySelection(-1);
@@ -531,8 +527,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
         });
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     handleHistoryInput(e: any) {
         const inputModel = GlobalModel.inputModel;
         const opts = mobx.toJS(inputModel.historyQueryOpts.get());
@@ -540,8 +535,7 @@ class TextAreaInput extends React.Component<{ screen: Screen; onHeightChange: ()
         inputModel.setHistoryQueryOpts(opts);
     }
 
-    @boundMethod
-    @mobx.action
+    @mobx.action.bound
     handleFocus(e: any) {
         e.preventDefault();
         GlobalModel.inputModel.giveFocus();

--- a/src/models/input.ts
+++ b/src/models/input.ts
@@ -74,7 +74,6 @@ class InputModel {
     lastCurLine: string = "";
 
     constructor(globalModel: Model) {
-        mobx.makeAutoObservable(this);
         this.globalModel = globalModel;
         mobx.action(() => {
             this.codeSelectSelectedIndex.set(-1);
@@ -83,12 +82,12 @@ class InputModel {
         this.codeSelectUuid = "";
     }
 
+    @mobx.action
     setInputMode(inputMode: null | "comment" | "global"): void {
-        mobx.action(() => {
-            this.inputMode.set(inputMode);
-        })();
+        this.inputMode.set(inputMode);
     }
 
+    @mobx.action
     toggleHistoryType(): void {
         const opts = mobx.toJS(this.historyQueryOpts.get());
         let htype = opts.queryType;
@@ -102,6 +101,7 @@ class InputModel {
         this.setHistoryType(htype);
     }
 
+    @mobx.action
     toggleRemoteType(): void {
         const opts = mobx.toJS(this.historyQueryOpts.get());
         if (opts.limitRemote) {
@@ -114,67 +114,63 @@ class InputModel {
         this.setHistoryQueryOpts(opts);
     }
 
+    @mobx.action
     onInputFocus(isFocused: boolean): void {
-        mobx.action(() => {
-            if (isFocused) {
-                this.inputFocused.set(true);
-                this.lineFocused.set(false);
-            } else if (this.inputFocused.get()) {
-                this.inputFocused.set(false);
-            }
-        })();
+        if (isFocused) {
+            this.inputFocused.set(true);
+            this.lineFocused.set(false);
+        } else if (this.inputFocused.get()) {
+            this.inputFocused.set(false);
+        }
     }
 
+    @mobx.action
     onLineFocus(isFocused: boolean): void {
-        mobx.action(() => {
-            if (isFocused) {
-                this.inputFocused.set(false);
-                this.lineFocused.set(true);
-            } else if (this.lineFocused.get()) {
-                this.lineFocused.set(false);
-            }
-        })();
+        if (isFocused) {
+            this.inputFocused.set(false);
+            this.lineFocused.set(true);
+        } else if (this.lineFocused.get()) {
+            this.lineFocused.set(false);
+        }
     }
 
     // Focuses the main input or the auxiliary view, depending on the active auxiliary view
+    @mobx.action
     giveFocus(): void {
         // Override active view to the main input if aux view does not have focus
         const activeAuxView = this.getAuxViewFocus() ? this.getActiveAuxView() : null;
-        mobx.action(() => {
-            switch (activeAuxView) {
-                case appconst.InputAuxView_History: {
-                    const elem: HTMLElement = document.querySelector(".cmd-input input.history-input");
-                    if (elem != null) {
-                        elem.focus();
-                    }
-                    break;
+        switch (activeAuxView) {
+            case appconst.InputAuxView_History: {
+                const elem: HTMLElement = document.querySelector(".cmd-input input.history-input");
+                if (elem != null) {
+                    elem.focus();
                 }
-                case appconst.InputAuxView_AIChat:
-                    this.setAIChatFocus();
-                    break;
-                case null: {
-                    const elem = document.getElementById("main-cmd-input");
-                    if (elem != null) {
-                        elem.focus();
-                    }
-                    this.setPhysicalInputFocused(true);
-                    break;
-                }
-                default: {
-                    const elem: HTMLElement = document.querySelector(".cmd-input .auxview");
-                    if (elem != null) {
-                        elem.focus();
-                    }
-                    break;
-                }
+                break;
             }
-        })();
+            case appconst.InputAuxView_AIChat:
+                this.setAIChatFocus();
+                break;
+            case null: {
+                const elem = document.getElementById("main-cmd-input");
+                if (elem != null) {
+                    elem.focus();
+                }
+                this.setPhysicalInputFocused(true);
+                break;
+            }
+            default: {
+                const elem: HTMLElement = document.querySelector(".cmd-input .auxview");
+                if (elem != null) {
+                    elem.focus();
+                }
+                break;
+            }
+        }
     }
 
+    @mobx.action
     setPhysicalInputFocused(isFocused: boolean): void {
-        mobx.action(() => {
-            this.physicalInputFocused.set(isFocused);
-        })();
+        this.physicalInputFocused.set(isFocused);
         if (isFocused) {
             const screen = this.globalModel.getActiveScreen();
             if (screen != null) {
@@ -201,6 +197,7 @@ class InputModel {
         return false;
     }
 
+    @mobx.action
     setHistoryType(htype: HistoryTypeStrs): void {
         if (this.historyQueryOpts.get().queryType == htype) {
             return;
@@ -232,15 +229,15 @@ class InputModel {
         return bestIdx + 1;
     }
 
+    @mobx.action
     setHistoryQueryOpts(opts: HistoryQueryOpts): void {
-        mobx.action(() => {
-            const oldItem = this.getHistorySelectedItem();
-            this.historyQueryOpts.set(opts);
-            const bestIndex = this.findBestNewIndex(oldItem);
-            setTimeout(() => this.setHistoryIndex(bestIndex, true), 10);
-        })();
+        const oldItem = this.getHistorySelectedItem();
+        this.historyQueryOpts.set(opts);
+        const bestIndex = this.findBestNewIndex(oldItem);
+        setTimeout(() => this.setHistoryIndex(bestIndex, true), 10);
     }
 
+    @mobx.action
     setOpenAICmdInfoChat(chat: OpenAICmdInfoChatMessageType[]): void {
         this.AICmdInfoChatItems.replace(chat);
         this.codeSelectBlockRefArray = [];
@@ -254,6 +251,7 @@ class InputModel {
         return hitems != null;
     }
 
+    @mobx.action
     loadHistory(show: boolean, afterLoadIndex: number, htype: HistoryTypeStrs) {
         if (this.historyLoading.get()) {
             return;
@@ -264,12 +262,11 @@ class InputModel {
             }
         }
         this.historyAfterLoadIndex = afterLoadIndex;
-        mobx.action(() => {
-            this.historyLoading.set(true);
-        })();
+        this.historyLoading.set(true);
         GlobalCommandRunner.loadHistory(show, htype);
     }
 
+    @mobx.action
     openHistory(): void {
         if (this.historyLoading.get()) {
             return;
@@ -285,13 +282,12 @@ class InputModel {
         }
     }
 
+    @mobx.action
     updateCmdLine(cmdLine: StrWithPos): void {
-        mobx.action(() => {
-            this.setCurLine(cmdLine.str);
-            if (cmdLine.pos != appconst.NoStrPos) {
-                this.forceCursorPos.set(cmdLine.pos);
-            }
-        })();
+        this.curLine = cmdLine.str;
+        if (cmdLine.pos != appconst.NoStrPos) {
+            this.forceCursorPos.set(cmdLine.pos);
+        }
     }
 
     getHistorySelectedItem(): HistoryItem {
@@ -314,6 +310,7 @@ class InputModel {
         return hitems[0];
     }
 
+    @mobx.action
     setHistorySelectionNum(hnum: string): void {
         const hitems = this.filteredHistoryItems;
         for (const [i, hitem] of hitems.entries()) {
@@ -324,30 +321,29 @@ class InputModel {
         }
     }
 
+    @mobx.action
     setHistoryInfo(hinfo: HistoryInfoType): void {
-        mobx.action(() => {
-            const oldItem = this.getHistorySelectedItem();
-            const hitems: HistoryItem[] = hinfo.items ?? [];
-            this.historyItems.set(hitems);
-            this.historyLoading.set(false);
-            this.historyQueryOpts.get().queryType = hinfo.historytype;
-            if (hinfo.historytype == "session" || hinfo.historytype == "global") {
-                this.historyQueryOpts.get().limitRemote = false;
-                this.historyQueryOpts.get().limitRemoteInstance = false;
+        const oldItem = this.getHistorySelectedItem();
+        const hitems: HistoryItem[] = hinfo.items ?? [];
+        this.historyItems.set(hitems);
+        this.historyLoading.set(false);
+        this.historyQueryOpts.get().queryType = hinfo.historytype;
+        if (hinfo.historytype == "session" || hinfo.historytype == "global") {
+            this.historyQueryOpts.get().limitRemote = false;
+            this.historyQueryOpts.get().limitRemoteInstance = false;
+        }
+        if (this.historyAfterLoadIndex == -1) {
+            const bestIndex = this.findBestNewIndex(oldItem);
+            setTimeout(() => this.setHistoryIndex(bestIndex, true), 100);
+        } else if (this.historyAfterLoadIndex) {
+            if (hitems.length >= this.historyAfterLoadIndex) {
+                this.setHistoryIndex(this.historyAfterLoadIndex);
             }
-            if (this.historyAfterLoadIndex == -1) {
-                const bestIndex = this.findBestNewIndex(oldItem);
-                setTimeout(() => this.setHistoryIndex(bestIndex, true), 100);
-            } else if (this.historyAfterLoadIndex) {
-                if (hitems.length >= this.historyAfterLoadIndex) {
-                    this.setHistoryIndex(this.historyAfterLoadIndex);
-                }
-            }
-            this.historyAfterLoadIndex = 0;
-            if (hinfo.show) {
-                this.openHistory();
-            }
-        })();
+        }
+        this.historyAfterLoadIndex = 0;
+        if (hinfo.show) {
+            this.openHistory();
+        }
     }
 
     @mobx.computed
@@ -411,16 +407,15 @@ class InputModel {
         elem.scrollIntoView({ block: "nearest" });
     }
 
+    @mobx.action
     grabSelectedHistoryItem(): void {
         const hitem = this.getHistorySelectedItem();
         if (hitem == null) {
             this.resetHistory();
             return;
         }
-        mobx.action(() => {
-            this.resetInput();
-            this.setCurLine(hitem.cmdstr);
-        })();
+        this.resetInput();
+        this.curLine = hitem.cmdstr;
     }
 
     // Closes the auxiliary view if it is open, focuses the main input
@@ -444,8 +439,8 @@ class InputModel {
         mobx.action(() => {
             this.auxViewFocus.set(view != null);
             this.activeAuxView.set(view);
+            this.giveFocus();
         })();
-        this.giveFocus();
     }
 
     // Gets the focus state of the auxiliary view. If true, the view will get focus. Otherwise, the main input will get focus.
@@ -458,39 +453,33 @@ class InputModel {
     }
 
     // Sets the focus state of the auxiliary view. If true, the view will get focus. Otherwise, the main input will get focus.
+    @mobx.action
     setAuxViewFocus(focus: boolean): void {
-        mobx.action(() => {
-            this.auxViewFocus.set(focus);
-        })();
+        this.auxViewFocus.set(focus);
         this.giveFocus();
     }
 
+    @mobx.computed
     shouldRenderAuxViewKeybindings(view: InputAuxViewType): boolean {
-        return mobx
-            .computed(() => {
-                if (view != null && this.getActiveAuxView() != view) {
-                    return false;
-                }
-                if (view != null && !this.getAuxViewFocus()) {
-                    return false;
-                }
-                if (view == null && this.hasFocus() && !this.getAuxViewFocus()) {
-                    return true;
-                }
-                if (view != null && this.getAuxViewFocus()) {
-                    return true;
-                }
-                if (
-                    GlobalModel.getActiveScreen().getFocusType() == "input" &&
-                    GlobalModel.activeMainView.get() == "session"
-                ) {
-                    return true;
-                }
-                return false;
-            })
-            .get();
+        if (view != null && this.getActiveAuxView() != view) {
+            return false;
+        }
+        if (view != null && !this.getAuxViewFocus()) {
+            return false;
+        }
+        if (view == null && this.hasFocus() && !this.getAuxViewFocus()) {
+            return true;
+        }
+        if (view != null && this.getAuxViewFocus()) {
+            return true;
+        }
+        if (GlobalModel.getActiveScreen().getFocusType() == "input" && GlobalModel.activeMainView.get() == "session") {
+            return true;
+        }
+        return false;
     }
 
+    @mobx.action
     setHistoryIndex(hidx: number, force?: boolean): void {
         if (hidx < 0) {
             return;
@@ -498,18 +487,16 @@ class InputModel {
         if (!force && this.historyIndex.get() == hidx) {
             return;
         }
-        mobx.action(() => {
-            this.historyIndex.set(hidx);
-            if (this.getActiveAuxView() == appconst.InputAuxView_History) {
-                let hitem = this.getHistorySelectedItem();
-                if (hitem == null) {
-                    hitem = this.getFirstHistoryItem();
-                }
-                if (hitem != null) {
-                    this.scrollHistoryItemIntoView(hitem.historynum);
-                }
+        this.historyIndex.set(hidx);
+        if (this.getActiveAuxView() == appconst.InputAuxView_History) {
+            let hitem = this.getHistorySelectedItem();
+            if (hitem == null) {
+                hitem = this.getFirstHistoryItem();
             }
-        })();
+            if (hitem != null) {
+                this.scrollHistoryItemIntoView(hitem.historynum);
+            }
+        }
     }
 
     moveHistorySelection(amt: number): void {
@@ -530,11 +517,10 @@ class InputModel {
         this.setHistoryIndex(idx);
     }
 
+    @mobx.action
     flashInfoMsg(info: InfoType, timeoutMs: number): void {
         this._clearInfoTimeout();
-        mobx.action(() => {
-            this.infoMsg.set(info);
-        })();
+        this.infoMsg.set(info);
 
         if (info == null && this.getActiveAuxView() == appconst.InputAuxView_Info) {
             this.setActiveAuxView(null);
@@ -573,7 +559,7 @@ class InputModel {
         ) {
             const curBlockRef = this.codeSelectBlockRefArray[this.codeSelectSelectedIndex.get()];
             const codeText = curBlockRef.current.innerText.replace(/\n$/, ""); // remove trailing newline
-            this.setCurLine(codeText);
+            this.curLine = codeText;
             this.giveFocus();
         }
     }
@@ -589,72 +575,68 @@ class InputModel {
         return rtn;
     }
 
+    @mobx.action
     setCodeSelectSelectedCodeBlock(blockIndex: number) {
-        mobx.action(() => {
-            if (blockIndex >= 0 && blockIndex < this.codeSelectBlockRefArray.length) {
-                this.codeSelectSelectedIndex.set(blockIndex);
-                const currentRef = this.codeSelectBlockRefArray[blockIndex].current;
-                if (currentRef != null && this.aiChatWindowRef?.current != null) {
-                    const chatWindowTop = this.aiChatWindowRef.current.scrollTop;
-                    const chatWindowBottom = chatWindowTop + this.aiChatWindowRef.current.clientHeight - 100;
-                    const elemTop = currentRef.offsetTop;
-                    let elemBottom = elemTop - currentRef.offsetHeight;
-                    const elementIsInView = elemBottom < chatWindowBottom && elemTop > chatWindowTop;
-                    if (!elementIsInView) {
-                        this.aiChatWindowRef.current.scrollTop =
-                            elemBottom - this.aiChatWindowRef.current.clientHeight / 3;
-                    }
+        if (blockIndex >= 0 && blockIndex < this.codeSelectBlockRefArray.length) {
+            this.codeSelectSelectedIndex.set(blockIndex);
+            const currentRef = this.codeSelectBlockRefArray[blockIndex].current;
+            if (currentRef != null && this.aiChatWindowRef?.current != null) {
+                const chatWindowTop = this.aiChatWindowRef.current.scrollTop;
+                const chatWindowBottom = chatWindowTop + this.aiChatWindowRef.current.clientHeight - 100;
+                const elemTop = currentRef.offsetTop;
+                let elemBottom = elemTop - currentRef.offsetHeight;
+                const elementIsInView = elemBottom < chatWindowBottom && elemTop > chatWindowTop;
+                if (!elementIsInView) {
+                    this.aiChatWindowRef.current.scrollTop = elemBottom - this.aiChatWindowRef.current.clientHeight / 3;
                 }
             }
-            this.codeSelectBlockRefArray = [];
-            this.setAIChatFocus();
-        })();
+        }
+        this.codeSelectBlockRefArray = [];
+        this.setAIChatFocus();
     }
 
+    @mobx.action
     codeSelectSelectNextNewestCodeBlock() {
         // oldest code block = index 0 in array
         // this decrements codeSelectSelected index
-        mobx.action(() => {
-            if (this.codeSelectSelectedIndex.get() == this.codeSelectTop) {
-                this.codeSelectSelectedIndex.set(this.codeSelectBottom);
-            } else if (this.codeSelectSelectedIndex.get() == this.codeSelectBottom) {
-                return;
+        if (this.codeSelectSelectedIndex.get() == this.codeSelectTop) {
+            this.codeSelectSelectedIndex.set(this.codeSelectBottom);
+        } else if (this.codeSelectSelectedIndex.get() == this.codeSelectBottom) {
+            return;
+        }
+        const incBlockIndex = this.codeSelectSelectedIndex.get() + 1;
+        if (this.codeSelectSelectedIndex.get() == this.codeSelectBlockRefArray.length - 1) {
+            this.codeSelectDeselectAll();
+            if (this.aiChatWindowRef?.current != null) {
+                this.aiChatWindowRef.current.scrollTop = this.aiChatWindowRef.current.scrollHeight;
             }
-            const incBlockIndex = this.codeSelectSelectedIndex.get() + 1;
-            if (this.codeSelectSelectedIndex.get() == this.codeSelectBlockRefArray.length - 1) {
-                this.codeSelectDeselectAll();
-                if (this.aiChatWindowRef?.current != null) {
-                    this.aiChatWindowRef.current.scrollTop = this.aiChatWindowRef.current.scrollHeight;
-                }
-            }
-            if (incBlockIndex >= 0 && incBlockIndex < this.codeSelectBlockRefArray.length) {
-                this.setCodeSelectSelectedCodeBlock(incBlockIndex);
-            }
-        })();
+        }
+        if (incBlockIndex >= 0 && incBlockIndex < this.codeSelectBlockRefArray.length) {
+            this.setCodeSelectSelectedCodeBlock(incBlockIndex);
+        }
     }
 
+    @mobx.action
     codeSelectSelectNextOldestCodeBlock() {
-        mobx.action(() => {
-            if (this.codeSelectSelectedIndex.get() == this.codeSelectBottom) {
-                if (this.codeSelectBlockRefArray.length > 0) {
-                    this.codeSelectSelectedIndex.set(this.codeSelectBlockRefArray.length);
-                } else {
-                    return;
-                }
-            } else if (this.codeSelectSelectedIndex.get() == this.codeSelectTop) {
+        if (this.codeSelectSelectedIndex.get() == this.codeSelectBottom) {
+            if (this.codeSelectBlockRefArray.length > 0) {
+                this.codeSelectSelectedIndex.set(this.codeSelectBlockRefArray.length);
+            } else {
                 return;
             }
-            const decBlockIndex = this.codeSelectSelectedIndex.get() - 1;
-            if (decBlockIndex < 0) {
-                this.codeSelectDeselectAll(this.codeSelectTop);
-                if (this.aiChatWindowRef?.current != null) {
-                    this.aiChatWindowRef.current.scrollTop = 0;
-                }
+        } else if (this.codeSelectSelectedIndex.get() == this.codeSelectTop) {
+            return;
+        }
+        const decBlockIndex = this.codeSelectSelectedIndex.get() - 1;
+        if (decBlockIndex < 0) {
+            this.codeSelectDeselectAll(this.codeSelectTop);
+            if (this.aiChatWindowRef?.current != null) {
+                this.aiChatWindowRef.current.scrollTop = 0;
             }
-            if (decBlockIndex >= 0 && decBlockIndex < this.codeSelectBlockRefArray.length) {
-                this.setCodeSelectSelectedCodeBlock(decBlockIndex);
-            }
-        })();
+        }
+        if (decBlockIndex >= 0 && decBlockIndex < this.codeSelectBlockRefArray.length) {
+            this.setCodeSelectSelectedCodeBlock(decBlockIndex);
+        }
     }
 
     getCodeSelectSelectedIndex() {
@@ -679,6 +661,7 @@ class InputModel {
         })();
     }
 
+    @mobx.action
     openAIAssistantChat(): void {
         this.setActiveAuxView(appconst.InputAuxView_AIChat);
         this.setAuxViewFocus(true);
@@ -718,19 +701,19 @@ class InputModel {
         }
     }
 
+    @mobx.action
     clearInfoMsg(setNull: boolean): void {
         this._clearInfoTimeout();
 
         if (this.getActiveAuxView() == appconst.InputAuxView_Info) {
             this.setActiveAuxView(null);
         }
-        mobx.action(() => {
-            if (setNull) {
-                this.infoMsg.set(null);
-            }
-        })();
+        if (setNull) {
+            this.infoMsg.set(null);
+        }
     }
 
+    @mobx.action
     toggleInfoMsg(): void {
         this._clearInfoTimeout();
         if (this.activeAuxView.get() == appconst.InputAuxView_Info) {
@@ -742,45 +725,42 @@ class InputModel {
 
     @boundMethod
     uiSubmitCommand(): void {
+        const commandStr = this.curLine;
+        if (commandStr.trim() == "") {
+            return;
+        }
         mobx.action(() => {
-            const commandStr = this.curLine;
-            if (commandStr.trim() == "") {
-                return;
-            }
             this.resetInput();
-            this.globalModel.submitRawCommand(commandStr, true, true);
         })();
+        this.globalModel.submitRawCommand(commandStr, true, true);
     }
 
     isEmpty(): boolean {
         return this.curLine.trim() == "";
     }
 
+    @mobx.action
     resetInputMode(): void {
-        mobx.action(() => {
-            this.setInputMode(null);
-            this.setCurLine("");
-        })();
+        this.setInputMode(null);
+        this.curLine = "";
     }
 
+    @mobx.action
     resetInput(): void {
-        mobx.action(() => {
-            this.setActiveAuxView(null);
-            this.inputMode.set(null);
-            this.resetHistory();
-            this.dropModHistory(false);
-            this.infoMsg.set(null);
-            this.inputExpanded.set(false);
-            this._clearInfoTimeout();
-        })();
+        this.setActiveAuxView(null);
+        this.inputMode.set(null);
+        this.resetHistory();
+        this.dropModHistory(false);
+        this.infoMsg.set(null);
+        this.inputExpanded.set(false);
+        this._clearInfoTimeout();
     }
 
+    @mobx.action
     @boundMethod
     toggleExpandInput(): void {
-        mobx.action(() => {
-            this.inputExpanded.set(!this.inputExpanded.get());
-            this.forceInputFocus = true;
-        })();
+        this.inputExpanded.set(!this.inputExpanded.get());
+        this.forceInputFocus = true;
     }
 
     @mobx.computed
@@ -800,11 +780,10 @@ class InputModel {
         return hitem.cmdstr;
     }
 
-    setCurLine(val: string): void {
+    set curLine(val: string) {
         this.lastCurLine = this.curLine;
         const hidx = this.historyIndex.get();
         mobx.action(() => {
-            const runGetSuggestions = this.curLine != val;
             if (this.modHistory.length <= hidx) {
                 this.modHistory.length = hidx + 1;
             }
@@ -812,31 +791,29 @@ class InputModel {
         })();
     }
 
+    @mobx.action
     dropModHistory(keepLine0: boolean): void {
-        mobx.action(() => {
-            if (keepLine0) {
-                if (this.modHistory.length > 1) {
-                    this.modHistory.splice(1, this.modHistory.length - 1);
-                }
-            } else {
-                this.modHistory.replace([""]);
+        if (keepLine0) {
+            if (this.modHistory.length > 1) {
+                this.modHistory.splice(1, this.modHistory.length - 1);
             }
-        })();
+        } else {
+            this.modHistory.replace([""]);
+        }
     }
 
+    @mobx.action
     resetHistory(): void {
-        mobx.action(() => {
-            if (this.getActiveAuxView() == appconst.InputAuxView_History) {
-                this.setActiveAuxView(null);
-            }
-            this.historyLoading.set(false);
-            this.historyType.set("screen");
-            this.historyItems.set(null);
-            this.historyIndex.set(0);
-            this.historyQueryOpts.set(getDefaultHistoryQueryOpts());
-            this.historyAfterLoadIndex = 0;
-            this.dropModHistory(true);
-        })();
+        if (this.getActiveAuxView() == appconst.InputAuxView_History) {
+            this.setActiveAuxView(null);
+        }
+        this.historyLoading.set(false);
+        this.historyType.set("screen");
+        this.historyItems.set(null);
+        this.historyIndex.set(0);
+        this.historyQueryOpts.set(getDefaultHistoryQueryOpts());
+        this.historyAfterLoadIndex = 0;
+        this.dropModHistory(true);
     }
 }
 

--- a/src/types/custom.d.ts
+++ b/src/types/custom.d.ts
@@ -821,6 +821,7 @@ declare global {
     type CommandRtnType = {
         success: boolean;
         error?: string;
+        update?: UpdatePacket;
     };
 
     type EphemeralCommandOutputType = {

--- a/waveshell/pkg/packet/packet.go
+++ b/waveshell/pkg/packet/packet.go
@@ -833,6 +833,7 @@ type RunPacketType struct {
 	Detached      bool            `json:"detached,omitempty"`
 	ReturnState   bool            `json:"returnstate,omitempty"`
 	IsSudo        bool            `json:"issudo,omitempty"`
+	Timeout       time.Duration   `json:"timeout"` // TODO: added vnext. This is the timeout for the command to run.  If the command does not complete in this time, it will be killed. The default zero value will not impose a timeout.
 }
 
 func (*RunPacketType) GetType() string {

--- a/wavesrv/pkg/bufferedpipe/bufferedpipe.go
+++ b/wavesrv/pkg/bufferedpipe/bufferedpipe.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/wavetermdev/waveterm/waveshell/pkg/wlog"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/scbase"
 	"github.com/wavetermdev/waveterm/wavesrv/pkg/waveenc"
 )
@@ -110,6 +111,7 @@ func (pipe *BufferedPipe) WriteTo(w io.Writer) (n int64, err error) {
 
 // Close the pipe. This will cause any blocking WriteTo calls to return.
 func (pipe *BufferedPipe) Close() error {
+	wlog.Logf("closing buffered pipe %s", pipe.Key)
 	defer pipe.bufferDataCond.Broadcast()
 	pipe.closed.Store(true)
 	return nil

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
-const {webDev, webProd} = require("./webpack/webpack.web.js");
-const {electronDev, electronProd} = require("./webpack/webpack.electron.js");
+const { webDev, webProd } = require("./webpack/webpack.web.js");
+const { electronDev, electronProd } = require("./webpack/webpack.electron.js");
 
 module.exports = (env) => {
     if (env.prod) {


### PR DESCRIPTION
This improves the ephemeral command runner to allow for honoring of timeouts and proper handling of overriding the current working directory. It also fixes some partially transparent font colors in light mode, making them solid instead. It also updates the InputModel to be auto-observable and utilize some getters to ensure the cmdinput is getting updated whenever necessary state changes take place.