### PR TITLE
Introduce corepack dependency

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -28,6 +28,7 @@ jobs:
                       cd ~/actions-runner/_work/testdriver/testdriver/
                       brew install go
                       brew tap scripthaus-dev/scripthaus
+                      brew install corepack
                       brew install scripthaus
                       corepack enable
                       yarn install


### PR DESCRIPTION
This Pull Request introduces the corepack dependency, necessary for the Testdriver infrastructure to run.

## Rationale:

Corepack enables faster installations and is required for `yarn`
By default, corepack is not installed on the testdriver infrastructure, necessitating this addition.

## Benefits:

Allows better handling of `yarn` installation.

## Testing:
Local testing has confirmed successful corepack installation and functionality within the testdriver infrastructure.