### PR TITLE
Ensure the auto update checker runs every hour

### DIFF
--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -980,9 +980,7 @@ function configureAutoUpdater(enabled: boolean) {
         if (electron.BrowserWindow.getAllWindows().length === 0) {
             createMainWindowWrap().then();
         }
-        if (autoUpdateInterval) {
-            checkForUpdates();
-        }
+        checkForUpdates();
     });
 })();
 

--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -976,7 +976,6 @@ function configureAutoUpdater(enabled: boolean) {
     await app.whenReady();
     await createMainWindowWrap();
     app.on("activate", () => {
-        console.log("activated");
         if (electron.BrowserWindow.getAllWindows().length === 0) {
             createMainWindowWrap().then();
         }


### PR DESCRIPTION
The hour long interval that I set was being subjected to background throttling and wasn't reliably getting invoked. I am shortening the inteval to 10 mins and adding a check within it to see if an hour has passed since the last update check. I am also running the same logic every time the main window is activated. This should ensure that the auto update check happens more reliably and not just on first launch.