### PR TITLE
Fix Build Helper for Yarn Modern

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -51,7 +51,7 @@ jobs:
                   yarn install
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
-              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+              run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
             - name: Setup Yarn cache
               uses: actions/cache@v4
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -49,24 +49,11 @@ jobs:
               run: |
                   corepack enable
                   yarn install
-            - name: Get yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-            - name: Setup Yarn cache
-              uses: actions/cache@v4
-              id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-              with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
             - name: Set Version
               id: set-version
               run: |
                   VERSION=$(node -e 'console.log(require("./version.js"))')
                   echo "WAVETERM_VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
-            - name: Install Yarn Dependencies
-              run: yarn --frozen-lockfile
             - name: Build ${{ matrix.platform }}/${{ matrix.arch }}
               run: scripthaus run ${{ matrix.scripthaus }}
               env:

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -45,11 +45,21 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: ${{env.NODE_VERSION}}
-                  cache: "yarn"
             - name: Install yarn
               run: |
                   corepack enable
                   yarn install
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+            - name: Setup Yarn cache
+              uses: actions/cache@v4
+              id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Set Version
               id: set-version
               run: |


### PR DESCRIPTION
I am removing the Yarn cache from our Build Helper. The actions/node-setup cache option is not compatible with Yarn Modern. With Yarn Modern, the `yarn install` command that sets up our project-specific yarn config will also install all the module dependencies, meaning we don't need a separate call to resolve these. Altogether, even without the cache, it only takes 21s for Yarn Modern to install and resolve dependencies.