### PR TITLE
added hide/show MenuBar feature

### DIFF
--- a/src/electron/emain.ts
+++ b/src/electron/emain.ts
@@ -341,6 +341,7 @@ function createWindow(clientData: ClientDataType | null): Electron.BrowserWindow
             preload: path.join(getElectronAppBasePath(), DistDir, "preload.js"),
         },
         show: false,
+        autoHideMenuBar: true,
     });
     win.once("ready-to-show", () => {
         win.show();


### PR DESCRIPTION
**Description:**
I recently installed waveterm and I just love it. I like to use my terminal without titlebar, So I removed the titlebar of waveterm in my ubuntu desktop but the menu bar is showing constantly. So I look into the code and made the changes. This pull request adds a simple feature which will hide/show the menubar using `ALT` key.

**Changes Made:**
1. When initializing electron's BrowserWindow, I added a parameter `autoHideMenuBar: true`.

**Testing Done:**
Tested the feature by pressing `ALT` Key. It works perfectly.