### PR TITLE
chore: fix incorrect alt text #682

### DIFF
--- a/src/app/line/linecomps.tsx
+++ b/src/app/line/linecomps.tsx
@@ -178,7 +178,7 @@ class LineActions extends React.Component<{ screen: LineContainerType; line: Lin
             <div className="line-actions">
                 <Choose>
                     <When condition={containerType == appconst.LineContainer_Main}>
-                        <div key="chat" title="Restart Command" className="line-icon" onClick={this.clickChat}>
+                        <div key="chat" title="Ask Wave AI" className="line-icon" onClick={this.clickChat}>
                             <i className="fa-sharp fa-regular fa-sparkles fa-fw" />
                         </div>
                         <div key="restart" title="Restart Command" className="line-icon" onClick={this.clickRestart}>


### PR DESCRIPTION
fix #682
new look:
![image](https://github.com/wavetermdev/waveterm/assets/113882203/c51145c0-a34d-4c45-824c-15e205fe74bd)
