### PR TITLE
Use gpt-4o-mini by default

### DIFF
--- a/src/app/clientsettings/clientsettings.tsx
+++ b/src/app/clientsettings/clientsettings.tsx
@@ -380,8 +380,8 @@ class ClientSettingsView extends React.Component<{ model: RemotesModel }, { hove
                         <div className="settings-label">AI Model</div>
                         <div className="settings-input">
                             <InlineSettingsTextEdit
-                                placeholder="gpt-3.5-turbo"
-                                text={isBlank(openAIOpts.model) ? "gpt-3.5-turbo" : openAIOpts.model}
+                                placeholder="gpt-4o-mini"
+                                text={isBlank(openAIOpts.model) ? "gpt-4o-mini" : openAIOpts.model}
                                 value={openAIOpts.model ?? ""}
                                 onChange={this.inlineUpdateOpenAIModel}
                                 maxLength={100}

--- a/wavesrv/pkg/remote/openai/openai.go
+++ b/wavesrv/pkg/remote/openai/openai.go
@@ -21,7 +21,7 @@ import (
 // https://github.com/tiktoken-go/tokenizer
 
 const DefaultMaxTokens = 1000
-const DefaultModel = "gpt-3.5-turbo"
+const DefaultModel = "gpt-4o-mini"
 const DefaultStreamChanSize = 10
 
 const CloudWebsocketConnectTimeout = 1 * time.Minute


### PR DESCRIPTION
OpenAI [recently announced](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/) the launch of GPT 4o mini, a small LLM model that's both smarter and cheaper than GPT-3.5 Turbo, meaning there's no reason not to use it by default.

This simple PR replaces all occurences of gpt-3.5-turbo with gpt-4o-mini.