### PR TITLE
Update AI Library

### DIFF
--- a/wavesrv/go.mod
+++ b/wavesrv/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/mattn/go-sqlite3 v1.14.16
-	github.com/sashabaranov/go-openai v1.9.0
+	github.com/sashabaranov/go-openai v1.30.0
 	github.com/sawka/txwrap v0.1.2
 	github.com/wavetermdev/waveterm/waveshell v0.0.0
 	golang.org/x/crypto v0.24.0

--- a/wavesrv/go.sum
+++ b/wavesrv/go.sum
@@ -51,6 +51,8 @@ github.com/rogpeppe/go-internal v1.10.1-0.20230524175051-ec119421bb97 h1:3RPlVWz
 github.com/rogpeppe/go-internal v1.10.1-0.20230524175051-ec119421bb97/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/sashabaranov/go-openai v1.9.0 h1:NoiO++IISxxJ1pRc0n7uZvMGMake0G+FJ1XPwXtprsA=
 github.com/sashabaranov/go-openai v1.9.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/sashabaranov/go-openai v1.30.0 h1:fHv9urGxABfm885xGWsXFSk5cksa+8dJ4jGli/UQQcI=
+github.com/sashabaranov/go-openai v1.30.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/sawka/txwrap v0.1.2 h1:v8xS0Z1LE7/6vMZA81PYihI+0TSR6Zm1MalzzBIuXKc=
 github.com/sawka/txwrap v0.1.2/go.mod h1:T3nlw2gVpuolo6/XEetvBbk1oMXnY978YmBFy1UyHvw=
 github.com/skeema/knownhosts v1.3.0 h1:AM+y0rI04VksttfwjkSTNQorvGqmwATnvnAHpSgc0LY=

--- a/wavesrv/pkg/remote/openai/openai.go
+++ b/wavesrv/pkg/remote/openai/openai.go
@@ -190,7 +190,7 @@ func RunCompletionStream(ctx context.Context, opts *sstore.OpenAIOptsType, promp
 				pk := packet.MakeOpenAIPacket()
 				pk.Index = choice.Index
 				pk.Text = choice.Delta.Content
-				pk.FinishReason = choice.FinishReason
+				pk.FinishReason = string(choice.FinishReason)
 				rtn <- pk
 			}
 		}
@@ -209,7 +209,7 @@ func marshalResponse(resp openaiapi.ChatCompletionResponse) []*packet.OpenAIPack
 		choicePk := packet.MakeOpenAIPacket()
 		choicePk.Index = choice.Index
 		choicePk.Text = choice.Message.Content
-		choicePk.FinishReason = choice.FinishReason
+		choicePk.FinishReason = string(choice.FinishReason)
 		rtn = append(rtn, choicePk)
 	}
 	return rtn


### PR DESCRIPTION
The AI library was outdated and seemed to prevent newer project-based keys from working. This update should hopefully correct that.