### PR TITLE
Fix number parsing for MetaSettingsType

### DIFF
--- a/cmd/wsh/cmd/wshcmd-setconfig.go
+++ b/cmd/wsh/cmd/wshcmd-setconfig.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/spf13/cobra"
 	"github.com/wavetermdev/waveterm/pkg/wconfig"
 	"github.com/wavetermdev/waveterm/pkg/wshrpc"
@@ -30,6 +32,7 @@ func setConfigRun(cmd *cobra.Command, args []string) {
 		return
 	}
 	commandData := wconfig.MetaSettingsType{MetaMapType: meta}
+	log.Printf("commandData: %v\n", commandData)
 	err = wshclient.SetConfigCommand(RpcClient, commandData, &wshrpc.RpcOpts{Timeout: 2000})
 	if err != nil {
 		WriteStderr("[error] setting config: %v\n", err)

--- a/cmd/wsh/cmd/wshcmd-setconfig.go
+++ b/cmd/wsh/cmd/wshcmd-setconfig.go
@@ -4,8 +4,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/spf13/cobra"
 	"github.com/wavetermdev/waveterm/pkg/wconfig"
 	"github.com/wavetermdev/waveterm/pkg/wshrpc"
@@ -32,7 +30,6 @@ func setConfigRun(cmd *cobra.Command, args []string) {
 		return
 	}
 	commandData := wconfig.MetaSettingsType{MetaMapType: meta}
-	log.Printf("commandData: %v\n", commandData)
 	err = wshclient.SetConfigCommand(RpcClient, commandData, &wshrpc.RpcOpts{Timeout: 2000})
 	if err != nil {
 		WriteStderr("[error] setting config: %v\n", err)

--- a/cmd/wsh/cmd/wshcmd-setmeta.go
+++ b/cmd/wsh/cmd/wshcmd-setmeta.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -47,11 +48,18 @@ func parseMetaSets(metaSets []string) (map[string]interface{}, error) {
 			}
 			meta[fields[0]] = val
 		} else {
-			fval, err := strconv.ParseFloat(setVal, 64)
+			ival, err := strconv.ParseInt(setVal, 0, 64)
 			if err == nil {
-				meta[fields[0]] = fval
+				log.Println("int")
+				meta[fields[0]] = ival
 			} else {
-				meta[fields[0]] = setVal
+				fval, err := strconv.ParseFloat(setVal, 64)
+				if err == nil {
+					log.Println("float")
+					meta[fields[0]] = fval
+				} else {
+					meta[fields[0]] = setVal
+				}
 			}
 		}
 	}

--- a/cmd/wsh/cmd/wshcmd-setmeta.go
+++ b/cmd/wsh/cmd/wshcmd-setmeta.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
@@ -50,7 +49,6 @@ func parseMetaSets(metaSets []string) (map[string]interface{}, error) {
 		} else {
 			ival, err := strconv.ParseInt(setVal, 0, 64)
 			if err == nil {
-				log.Println("int")
 				meta[fields[0]] = ival
 			} else {
 				fval, err := strconv.ParseFloat(setVal, 64)

--- a/cmd/wsh/cmd/wshcmd-setmeta.go
+++ b/cmd/wsh/cmd/wshcmd-setmeta.go
@@ -55,7 +55,6 @@ func parseMetaSets(metaSets []string) (map[string]interface{}, error) {
 			} else {
 				fval, err := strconv.ParseFloat(setVal, 64)
 				if err == nil {
-					log.Println("float")
 					meta[fields[0]] = fval
 				} else {
 					meta[fields[0]] = setVal

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -100,8 +99,6 @@ type FullConfigType struct {
 	TermThemes     map[string]TermThemeType       `json:"termthemes"`
 	ConfigErrors   []ConfigError                  `json:"configerrors" configfile:"-"`
 }
-
-var settingsAbsPath = filepath.Join(configDirAbsPath, SettingsFile)
 
 func readConfigHelper(fileName string, barr []byte, readErr error) (waveobj.MetaMapType, []ConfigError) {
 	var cerrs []ConfigError
@@ -308,9 +305,7 @@ func SetBaseConfigValue(toMerge waveobj.MetaMapType) error {
 			delete(m, configKey)
 		} else {
 			rtype := reflect.TypeOf(val)
-			log.Printf("val: %v, config value type: %s, reflection type: %s\n", val, ctype, rtype)
 			if rtype == reflect.TypeOf(dummyNumber) {
-				log.Println("json.Number")
 				numval := val.(json.Number)
 				ival, err := numval.Int64()
 				if err == nil {

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -305,15 +305,13 @@ func SetBaseConfigValue(toMerge waveobj.MetaMapType) error {
 			delete(m, configKey)
 		} else {
 			rtype := reflect.TypeOf(val)
+
+			// Parse out JSON numbers. If the config is an integer or pointer to an integer, we will attempt to parse the number as an integer, before falling back to float, then string.
+			// If the number is a float, we will only attempt to parse it as a float, before falling back to string.
 			if rtype == reflect.TypeOf(dummyNumber) {
 				numval := val.(json.Number)
-				if reflect.Int64 == ctype.Kind() {
-					ival, err := numval.Int64()
-					if err == nil {
-						val = ival
-					} else {
-						val = numval.String()
-					}
+				if ival, err := numval.Int64(); err == nil && (reflect.Int64 == ctype.Kind() || reflect.Int64 == ctype.Elem().Kind()) {
+					val = ival
 				} else {
 					fval, err := numval.Float64()
 					if err == nil {

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -307,20 +307,22 @@ func SetBaseConfigValue(toMerge waveobj.MetaMapType) error {
 			rtype := reflect.TypeOf(val)
 			if rtype == reflect.TypeOf(dummyNumber) {
 				numval := val.(json.Number)
-				ival, err := numval.Int64()
-				if err == nil {
-					val = ival
-					rtype = reflect.TypeOf(ival)
+				if reflect.Int64 == ctype.Kind() {
+					ival, err := numval.Int64()
+					if err == nil {
+						val = ival
+					} else {
+						val = numval.String()
+					}
 				} else {
 					fval, err := numval.Float64()
 					if err == nil {
 						val = fval
-						rtype = reflect.TypeOf(fval)
 					} else {
 						val = numval.String()
-						rtype = reflect.TypeOf(numval)
 					}
 				}
+				rtype = reflect.TypeOf(val)
 			}
 			if rtype != ctype {
 				if ctype == reflect.PointerTo(rtype) {


### PR DESCRIPTION
json.Unmarshal parses all numbers to float64, which breaks any integer settings values. This PR changes MetaSettingsType.UnmarshalJSON to use json.Decoder, which is capable of parsing into a meta-type json.Number, which can be interpreted as a float or an integer. It also properly handles pointer types.