### PR TITLE
Fetch settings directly from filesystem on launch

### DIFF
--- a/emain/launchsettings.ts
+++ b/emain/launchsettings.ts
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+import { getWaveHomeDir } from "./platform";
+
+/**
+ * Get settings directly from the Wave Home directory on launch.
+ * Only use this when the app is first starting up. Otherwise, prefer the settings.GetFullConfig function.
+ * @returns The initial launch settings for the application.
+ */
+export function getLaunchSettings(): SettingsType {
+    const settingsPath = path.join(getWaveHomeDir(), "config", "settings.json");
+    try {
+        const settingsContents = fs.readFileSync(settingsPath, "utf8");
+        return JSON.parse(settingsContents);
+    } catch (e) {
+        console.error("Unable to load settings.json to get initial launch settings", e);
+    }
+}


### PR DESCRIPTION
This bypasses the Go backend when fetching the settings for the app on first launch. This allows for actions that need to be performed before the app is ready, such as disabling hardware acceleration.