### PR TITLE
Dispose of the window DB entry when no tabs are left

### DIFF
--- a/pkg/service/windowservice/windowservice.go
+++ b/pkg/service/windowservice/windowservice.go
@@ -76,6 +76,7 @@ func (svc *WindowService) CloseTab(ctx context.Context, uiContext waveobj.UICont
 	}
 	if window.ActiveTabId == tabId && tabIndex != -1 {
 		if len(ws.TabIds) == 1 {
+			svc.CloseWindow(ctx, uiContext.WindowId)
 			eventbus.SendEventToElectron(eventbus.WSEventType{
 				EventType: eventbus.WSEvent_ElectronCloseWindow,
 				Data:      uiContext.WindowId,


### PR DESCRIPTION
Fixes issue where closing the last tab in the last window would cause app to show a blank window the next time it opens. Instead, we should dispose of the window so that it can be created from scratch the next time the app launches.

Also fixes a potential DB resource leak from dead windows cluttering up the DB