### PR TITLE
ExpandHomeDir Fix on Windows

### DIFF
--- a/pkg/wavebase/wavebase.go
+++ b/pkg/wavebase/wavebase.go
@@ -52,7 +52,7 @@ func GetHomeDir() string {
 }
 
 func ExpandHomeDir(pathStr string) (string, error) {
-	if pathStr != "~" && !strings.HasPrefix(pathStr, "~/") && !strings.HasPrefix(pathStr, `~\`) {
+	if pathStr != "~" && !strings.HasPrefix(pathStr, "~/") && (!strings.HasPrefix(pathStr, `~\`) && runtime.GOOS == "windows") {
 		return filepath.Clean(pathStr), nil
 	}
 	homeDir := GetHomeDir()

--- a/pkg/wavebase/wavebase.go
+++ b/pkg/wavebase/wavebase.go
@@ -57,7 +57,6 @@ func ExpandHomeDir(pathStr string) (string, error) {
 	}
 	if runtime.GOOS == "windows" && pathStr != "~" && !strings.HasPrefix(pathStr, `~\`) {
 		return filepath.Clean(pathStr), nil
-
 	}
 	homeDir := GetHomeDir()
 	if pathStr == "~" {

--- a/pkg/wavebase/wavebase.go
+++ b/pkg/wavebase/wavebase.go
@@ -52,7 +52,7 @@ func GetHomeDir() string {
 }
 
 func ExpandHomeDir(pathStr string) (string, error) {
-	if pathStr != "~" && !strings.HasPrefix(pathStr, "~/") && (!strings.HasPrefix(pathStr, `~\`) && runtime.GOOS == "windows") {
+	if pathStr != "~" && !strings.HasPrefix(pathStr, "~/") && !strings.HasPrefix(pathStr, `~\`) {
 		return filepath.Clean(pathStr), nil
 	}
 	homeDir := GetHomeDir()

--- a/pkg/wavebase/wavebase.go
+++ b/pkg/wavebase/wavebase.go
@@ -52,10 +52,7 @@ func GetHomeDir() string {
 }
 
 func ExpandHomeDir(pathStr string) (string, error) {
-	if pathStr != "~" && !strings.HasPrefix(pathStr, "~/") {
-		return filepath.Clean(pathStr), nil
-	}
-	if runtime.GOOS == "windows" && pathStr != "~" && !strings.HasPrefix(pathStr, `~\`) {
+	if pathStr != "~" && !strings.HasPrefix(pathStr, "~/") && (!strings.HasPrefix(pathStr, `~\`) || runtime.GOOS != "windows") {
 		return filepath.Clean(pathStr), nil
 	}
 	homeDir := GetHomeDir()

--- a/pkg/wavebase/wavebase.go
+++ b/pkg/wavebase/wavebase.go
@@ -52,8 +52,12 @@ func GetHomeDir() string {
 }
 
 func ExpandHomeDir(pathStr string) (string, error) {
-	if pathStr != "~" && !strings.HasPrefix(pathStr, "~/") && !strings.HasPrefix(pathStr, `~\`) {
+	if pathStr != "~" && !strings.HasPrefix(pathStr, "~/") {
 		return filepath.Clean(pathStr), nil
+	}
+	if runtime.GOOS == "windows" && pathStr != "~" && !strings.HasPrefix(pathStr, `~\`) {
+		return filepath.Clean(pathStr), nil
+
 	}
 	homeDir := GetHomeDir()
 	if pathStr == "~" {

--- a/pkg/wavebase/wavebase.go
+++ b/pkg/wavebase/wavebase.go
@@ -52,7 +52,7 @@ func GetHomeDir() string {
 }
 
 func ExpandHomeDir(pathStr string) (string, error) {
-	if pathStr != "~" && !strings.HasPrefix(pathStr, "~/") {
+	if pathStr != "~" && !strings.HasPrefix(pathStr, "~/") && !strings.HasPrefix(pathStr, `~\`) {
 		return filepath.Clean(pathStr), nil
 	}
 	homeDir := GetHomeDir()


### PR DESCRIPTION
fix: check for backslash when expanding the home directory (~ character -> full path)