### PR TITLE
Fix double scrollbars in dir preview

### DIFF
--- a/frontend/app/view/preview/directorypreview.less
+++ b/frontend/app/view/preview/directorypreview.less
@@ -6,15 +6,12 @@
 .dir-table-container {
     display: flex;
     flex-direction: column;
-    height: 100%;
     .dir-table {
-        height: 100%;
         min-width: 600px;
         --col-size-size: 0.2rem;
         border-radius: 3px;
         display: flex;
         flex-direction: column;
-        font: var(--base-font);
         .dir-table-head {
             .dir-table-head-row {
                 display: flex;
@@ -30,14 +27,12 @@
                     position: relative;
                     display: flex;
                     white-space: nowrap;
-                    overflow: hidden;
 
                     .dir-table-head-cell-content {
                         padding: 2px 4px;
                         display: flex;
                         gap: 0.3rem;
                         flex: 1 1 auto;
-                        overflow-x: hidden;
                         letter-spacing: -0.12px;
 
                         .dir-table-head-direction {
@@ -67,11 +62,19 @@
             }
         }
 
+        .table-body-container {
+            height: 100%;
+        }
+
+        .table-body-os {
+            height: 100%;
+            width: 100%;
+        }
+
         .dir-table-body {
-            flex: 1 1 auto;
             display: flex;
             flex-direction: column;
-            overflow: hidden;
+            height: 100%;
             .dir-table-body-search-display {
                 display: flex;
                 border-radius: 3px;
@@ -128,7 +131,6 @@
                     }
 
                     .dir-table-body-cell {
-                        overflow: hidden;
                         white-space: nowrap;
                         padding: 0.25rem;
                         cursor: default;

--- a/frontend/app/view/preview/directorypreview.less
+++ b/frontend/app/view/preview/directorypreview.less
@@ -78,19 +78,8 @@
         }
 
         .dir-table-body {
-            // @property --viewport-height {
-            //     syntax: "<pixel>";
-            //     initial-value: 0px;
-            //     inherits: false;
-            // }
             display: flex;
             flex-direction: column;
-            z-index: 9;
-            // height: 100px;
-            // clip-path: inset(var(--viewport-height) 0 0 0);
-            // overflow-x: visible;
-            // overflow-y: scroll;
-            // overflow: hidden;
             .dir-table-body-search-display {
                 display: flex;
                 border-radius: 3px;

--- a/frontend/app/view/preview/directorypreview.less
+++ b/frontend/app/view/preview/directorypreview.less
@@ -6,16 +6,29 @@
 .dir-table-container {
     display: flex;
     flex-direction: column;
+    height: 100%;
+    --min-row-width: 35rem;
     .dir-table {
-        min-width: 600px;
+        height: 100%;
+        width: 100%;
         --col-size-size: 0.2rem;
-        border-radius: 3px;
         display: flex;
         flex-direction: column;
+
+        &:not([data-scroll-height="0"]) .dir-table-head {
+            background: rgba(10, 10, 10, 0.5);
+            backdrop-filter: blur(4px);
+        }
         .dir-table-head {
+            position: sticky;
+            top: 0;
+            z-index: 10;
+            width: fit-content;
+            border-bottom: 1px solid var(--border-color);
+
             .dir-table-head-row {
                 display: flex;
-                border-bottom: 1px solid var(--border-color);
+                min-width: var(--min-row-width);
                 padding: 4px 6px;
                 font-size: 0.75rem;
 
@@ -27,12 +40,14 @@
                     position: relative;
                     display: flex;
                     white-space: nowrap;
+                    overflow: hidden;
 
                     .dir-table-head-cell-content {
                         padding: 2px 4px;
                         display: flex;
                         gap: 0.3rem;
                         flex: 1 1 auto;
+                        overflow-x: hidden;
                         letter-spacing: -0.12px;
 
                         .dir-table-head-direction {
@@ -62,19 +77,20 @@
             }
         }
 
-        .table-body-container {
-            height: 100%;
-        }
-
-        .table-body-os {
-            height: 100%;
-            width: 100%;
-        }
-
         .dir-table-body {
+            // @property --viewport-height {
+            //     syntax: "<pixel>";
+            //     initial-value: 0px;
+            //     inherits: false;
+            // }
             display: flex;
             flex-direction: column;
-            height: 100%;
+            z-index: 9;
+            // height: 100px;
+            // clip-path: inset(var(--viewport-height) 0 0 0);
+            // overflow-x: visible;
+            // overflow-y: scroll;
+            // overflow: hidden;
             .dir-table-body-search-display {
                 display: flex;
                 border-radius: 3px;
@@ -97,6 +113,7 @@
                     align-items: center;
                     border-radius: 5px;
                     padding: 0 6px;
+                    min-width: var(--min-row-width);
 
                     &.focused {
                         background-color: rgb(from var(--accent-color) r g b / 0.5);
@@ -131,6 +148,7 @@
                     }
 
                     .dir-table-body-cell {
+                        overflow: hidden;
                         white-space: nowrap;
                         padding: 0.25rem;
                         cursor: default;

--- a/frontend/app/view/preview/directorypreview.tsx
+++ b/frontend/app/view/preview/directorypreview.tsx
@@ -262,7 +262,7 @@ function DirectoryTable({
 
     const innerRef = useRef<HTMLDivElement>();
     const [initializeOSInner, osInner] = useOverlayScrollbars({
-        options: { scrollbars: { autoHide: "leave" }, overflow: { x: "visible", y: "scroll" } },
+        options: { scrollbars: { autoHide: "leave" }, overflow: { x: "hidden", y: "scroll" } },
     });
 
     useEffect(() => {
@@ -272,7 +272,7 @@ function DirectoryTable({
 
     return (
         <OverlayScrollbarsComponent
-            options={{ scrollbars: { autoHide: "leave" }, overflow: { x: "scroll", y: "visible" } }}
+            options={{ scrollbars: { autoHide: "leave" }, overflow: { x: "scroll", y: "hidden" } }}
             className="dir-table"
             style={{ ...columnSizeVars }}
         >
@@ -365,25 +365,25 @@ function TableBody({
     setRefreshVersion,
     osElements,
 }: TableBodyProps) {
-    const [bodyHeight, setBodyHeight] = useState(0);
+    // const [bodyHeight, setBodyHeight] = useState(0);
 
     const dummyLineRef = useRef<HTMLDivElement>(null);
     const warningBoxRef = useRef<HTMLDivElement>(null);
     const rowRefs = useRef<HTMLDivElement[]>([]);
     const domRect = useDimensionsWithExistingRef(bodyRef, 30);
-    const parentHeight = domRect?.height ?? 0;
     const conn = jotai.useAtomValue(model.connection);
 
-    useEffect(() => {
-        if (dummyLineRef.current && data && bodyRef.current) {
-            const rowHeight = dummyLineRef.current.offsetHeight;
-            const fullTBodyHeight = rowHeight * data.length;
-            const warningBoxHeight = warningBoxRef.current?.offsetHeight ?? 0;
-            const maxHeightLessHeader = parentHeight - warningBoxHeight;
-            const tbodyHeight = Math.min(maxHeightLessHeader, fullTBodyHeight);
-            setBodyHeight(tbodyHeight);
-        }
-    }, [data, parentHeight]);
+    // useEffect(() => {
+    //     const parentHeight = domRect?.height ?? 0;
+    //     if (dummyLineRef.current && data && bodyRef.current) {
+    //         const rowHeight = dummyLineRef.current.offsetHeight;
+    //         const fullTBodyHeight = rowHeight * data.length;
+    //         const warningBoxHeight = warningBoxRef.current?.offsetHeight ?? 0;
+    //         const maxHeightLessHeader = parentHeight - warningBoxHeight;
+    //         const tbodyHeight = Math.min(maxHeightLessHeader, fullTBodyHeight);
+    //         setBodyHeight(tbodyHeight);
+    //     }
+    // }, [data, domRect]);
 
     useEffect(() => {
         if (focusIndex !== null && rowRefs.current[focusIndex] && bodyRef.current && osElements) {
@@ -405,7 +405,7 @@ function TableBody({
                 viewport.scrollTo({ top: rowBottomRelativeToViewport - viewportHeight });
             }
         }
-    }, [focusIndex, parentHeight]);
+    }, [focusIndex]);
 
     const handleFileContextMenu = useCallback(
         (e: any, path: string, mimetype: string) => {
@@ -521,7 +521,7 @@ function TableBody({
                     </div>
                 </div>
             )}
-            <div className="dir-table-body-scroll-box" style={{ height: bodyHeight }}>
+            <div className="dir-table-body-scroll-box">
                 <div className="dummy dir-table-body-row" ref={dummyLineRef}>
                     <div className="dir-table-body-cell">dummy-data</div>
                 </div>

--- a/frontend/app/view/preview/preview.less
+++ b/frontend/app/view/preview/preview.less
@@ -79,5 +79,5 @@
 
 .full-preview-content {
     flex-grow: 1;
-    overflow-y: hidden;
+    overflow: hidden;
 }


### PR DESCRIPTION
Phew this took a while, but I think it's a good compromise. All the scrolling for a preview view now must happen inside the individual views, rather than at the root level. Now, the scrollbars render in the right places and are always visible inside the block. I don't love the blurred header for the table, but it was make it blurry or make it even more opaque, which would ruin the transparency