### PR TITLE
Add a Notification Subcommand to Wsh

### DIFF
--- a/cmd/wsh/cmd/wshcmd-notify.go
+++ b/cmd/wsh/cmd/wshcmd-notify.go
@@ -15,7 +15,7 @@ var notifyIcon string
 var notifySilent bool
 
 var setNotifyCmd = &cobra.Command{
-	Use:     "notify [-t <title>] [-b <body>] [-i <icon>] [-s]",
+	Use:     "notify [options]",
 	Short:   "create a notification",
 	Args:    cobra.NoArgs,
 	Run:     notifyRun,
@@ -24,7 +24,7 @@ var setNotifyCmd = &cobra.Command{
 
 func init() {
 	setNotifyCmd.Flags().StringVarP(&notifyTitle, "title", "t", "Wsh Notify", "the notification title")
-	setNotifyCmd.Flags().StringVarP(&notifyBody, "body", "b", "", "the message within the notification")
+	setNotifyCmd.Flags().StringVarP(&notifyBody, "body", "m", "", "the message within the notification")
 	setNotifyCmd.Flags().StringVarP(&notifyIcon, "icon", "i", "", "the name of an icon to appear with along with the notification. requires a path to an image file.")
 	setNotifyCmd.Flags().BoolVarP(&notifySilent, "silent", "s", false, "whether or not the notification should display sound")
 	rootCmd.AddCommand(setNotifyCmd)

--- a/cmd/wsh/cmd/wshcmd-notify.go
+++ b/cmd/wsh/cmd/wshcmd-notify.go
@@ -10,28 +10,27 @@ import (
 )
 
 var notifyTitle string
-var notifyBody string
 var notifySilent bool
 
 var setNotifyCmd = &cobra.Command{
-	Use:     "notify [options]",
+	Use:     "notify <message> [-t <title>] [-s]",
 	Short:   "create a notification",
-	Args:    cobra.NoArgs,
+	Args:    cobra.ExactArgs(1),
 	Run:     notifyRun,
 	PreRunE: preRunSetupRpcClient,
 }
 
 func init() {
 	setNotifyCmd.Flags().StringVarP(&notifyTitle, "title", "t", "Wsh Notify", "the notification title")
-	setNotifyCmd.Flags().StringVarP(&notifyBody, "message", "m", "", "the message within the notification")
 	setNotifyCmd.Flags().BoolVarP(&notifySilent, "silent", "s", false, "whether or not the notification sound is silenced")
 	rootCmd.AddCommand(setNotifyCmd)
 }
 
 func notifyRun(cmd *cobra.Command, args []string) {
+	message := args[0]
 	notificationOptions := &wshrpc.WaveNotificationOptions{
 		Title:  notifyTitle,
-		Body:   notifyBody,
+		Body:   message,
 		Silent: notifySilent,
 	}
 	_, err := RpcClient.SendRpcRequest(wshrpc.Command_Notify, notificationOptions, &wshrpc.RpcOpts{Timeout: 2000, Route: wshutil.ElectronRoute})

--- a/cmd/wsh/cmd/wshcmd-notify.go
+++ b/cmd/wsh/cmd/wshcmd-notify.go
@@ -11,7 +11,6 @@ import (
 
 var notifyTitle string
 var notifyBody string
-var notifyIcon string
 var notifySilent bool
 
 var setNotifyCmd = &cobra.Command{
@@ -24,8 +23,7 @@ var setNotifyCmd = &cobra.Command{
 
 func init() {
 	setNotifyCmd.Flags().StringVarP(&notifyTitle, "title", "t", "Wsh Notify", "the notification title")
-	setNotifyCmd.Flags().StringVarP(&notifyBody, "body", "m", "", "the message within the notification")
-	setNotifyCmd.Flags().StringVarP(&notifyIcon, "icon", "i", "", "the name of an icon to appear with along with the notification. requires a path to an image file.")
+	setNotifyCmd.Flags().StringVarP(&notifyBody, "message", "m", "", "the message within the notification")
 	setNotifyCmd.Flags().BoolVarP(&notifySilent, "silent", "s", false, "whether or not the notification should display sound")
 	rootCmd.AddCommand(setNotifyCmd)
 }
@@ -34,7 +32,6 @@ func notifyRun(cmd *cobra.Command, args []string) {
 	notificationOptions := &wshrpc.WaveNotificationOptions{
 		Title:  notifyTitle,
 		Body:   notifyBody,
-		Icon:   notifyIcon,
 		Silent: notifySilent,
 	}
 	_, err := RpcClient.SendRpcRequest(wshrpc.Command_Notify, notificationOptions, &wshrpc.RpcOpts{Timeout: 2000, Route: wshutil.ElectronRoute})

--- a/cmd/wsh/cmd/wshcmd-notify.go
+++ b/cmd/wsh/cmd/wshcmd-notify.go
@@ -24,7 +24,7 @@ var setNotifyCmd = &cobra.Command{
 func init() {
 	setNotifyCmd.Flags().StringVarP(&notifyTitle, "title", "t", "Wsh Notify", "the notification title")
 	setNotifyCmd.Flags().StringVarP(&notifyBody, "message", "m", "", "the message within the notification")
-	setNotifyCmd.Flags().BoolVarP(&notifySilent, "silent", "s", false, "whether or not the notification should display sound")
+	setNotifyCmd.Flags().BoolVarP(&notifySilent, "silent", "s", false, "whether or not the notification sound is silenced")
 	rootCmd.AddCommand(setNotifyCmd)
 }
 

--- a/cmd/wsh/cmd/wshcmd-notify.go
+++ b/cmd/wsh/cmd/wshcmd-notify.go
@@ -38,5 +38,4 @@ func notifyRun(cmd *cobra.Command, args []string) {
 		WriteStderr("[error] sending notification: %v\n", err)
 		return
 	}
-	WriteStdout("notification sent\n")
 }

--- a/cmd/wsh/cmd/wshcmd-notify.go
+++ b/cmd/wsh/cmd/wshcmd-notify.go
@@ -1,0 +1,46 @@
+// Copyright 2024, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wavetermdev/waveterm/pkg/wshrpc"
+	"github.com/wavetermdev/waveterm/pkg/wshutil"
+)
+
+var notifyTitle string
+var notifyBody string
+var notifyIcon string
+var notifySilent bool
+
+var setNotifyCmd = &cobra.Command{
+	Use:     "notify [-t <title>] [-b <body>] [-i <icon>] [-s]",
+	Short:   "create a notification",
+	Args:    cobra.NoArgs,
+	Run:     notifyRun,
+	PreRunE: preRunSetupRpcClient,
+}
+
+func init() {
+	setNotifyCmd.Flags().StringVarP(&notifyTitle, "title", "t", "Wsh Notify", "the notification title")
+	setNotifyCmd.Flags().StringVarP(&notifyBody, "body", "b", "", "the message within the notification")
+	setNotifyCmd.Flags().StringVarP(&notifyIcon, "icon", "i", "", "the name of an icon to appear with along with the notification. requires a path to an image file.")
+	setNotifyCmd.Flags().BoolVarP(&notifySilent, "silent", "s", false, "whether or not the notification should display sound")
+	rootCmd.AddCommand(setNotifyCmd)
+}
+
+func notifyRun(cmd *cobra.Command, args []string) {
+	notificationOptions := &wshrpc.WaveNotificationOptions{
+		Title:  notifyTitle,
+		Body:   notifyBody,
+		Icon:   notifyIcon,
+		Silent: notifySilent,
+	}
+	_, err := RpcClient.SendRpcRequest(wshrpc.Command_Notify, notificationOptions, &wshrpc.RpcOpts{Timeout: 2000, Route: wshutil.ElectronRoute})
+	if err != nil {
+		WriteStderr("[error] sending notification: %v\n", err)
+		return
+	}
+	WriteStdout("notification sent\n")
+}

--- a/emain/emain-wsh.ts
+++ b/emain/emain-wsh.ts
@@ -33,7 +33,6 @@ export class ElectronWshClientType extends WshClient {
         new electron.Notification({
             title: notificationOptions.title,
             body: notificationOptions.body,
-            icon: notificationOptions.icon,
             silent: notificationOptions.silent,
         }).show();
     }

--- a/emain/emain-wsh.ts
+++ b/emain/emain-wsh.ts
@@ -28,6 +28,15 @@ export class ElectronWshClientType extends WshClient {
         const rtn = await webGetSelector(wc, data.selector, data.opts);
         return rtn;
     }
+
+    async handle_notify(rh: RpcResponseHelper, notificationOptions: WaveNotificationOptions) {
+        new electron.Notification({
+            title: notificationOptions.title,
+            body: notificationOptions.body,
+            icon: notificationOptions.icon,
+            silent: notificationOptions.silent,
+        }).show();
+    }
 }
 
 export let ElectronWshClient: ElectronWshClientType;

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -132,6 +132,11 @@ class RpcApiType {
         return client.wshRpcCall("message", data, opts);
     }
 
+    // command "notify" [call]
+    NotifyCommand(client: WshClient, data: WaveNotificationOptions, opts?: RpcOpts): Promise<void> {
+        return client.wshRpcCall("notify", data, opts);
+    }
+
     // command "remotefiledelete" [call]
     RemoteFileDeleteCommand(client: WshClient, data: string, opts?: RpcOpts): Promise<void> {
         return client.wshRpcCall("remotefiledelete", data, opts);

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -636,7 +636,6 @@ declare global {
     type WaveNotificationOptions = {
         title?: string;
         body?: string;
-        icon?: string;
         silent?: boolean;
     };
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -632,6 +632,14 @@ declare global {
         meta: {[key: string]: any};
     };
 
+    // wshrpc.WaveNotificationOptions
+    type WaveNotificationOptions = {
+        title?: string;
+        body?: string;
+        icon?: string;
+        silent?: boolean;
+    };
+
     // waveobj.WaveObj
     type WaveObj = {
         otype: string;

--- a/pkg/wshrpc/wshclient/wshclient.go
+++ b/pkg/wshrpc/wshclient/wshclient.go
@@ -163,6 +163,12 @@ func MessageCommand(w *wshutil.WshRpc, data wshrpc.CommandMessageData, opts *wsh
 	return err
 }
 
+// command "notify", wshserver.NotifyCommand
+func NotifyCommand(w *wshutil.WshRpc, data wshrpc.WaveNotificationOptions, opts *wshrpc.RpcOpts) error {
+	_, err := sendRpcRequestCallHelper[any](w, "notify", data, opts)
+	return err
+}
+
 // command "remotefiledelete", wshserver.RemoteFileDeleteCommand
 func RemoteFileDeleteCommand(w *wshutil.WshRpc, data string, opts *wshrpc.RpcOpts) error {
 	_, err := sendRpcRequestCallHelper[any](w, "remotefiledelete", data, opts)

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -380,6 +380,5 @@ type BlockInfoData struct {
 type WaveNotificationOptions struct {
 	Title  string `json:"title,omitempty"`
 	Body   string `json:"body,omitempty"`
-	Icon   string `json:"icon,omitempty"`
 	Silent bool   `json:"silent,omitempty"`
 }

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -68,6 +68,7 @@ const (
 	Command_ConnList         = "connlist"
 
 	Command_WebSelector = "webselector"
+	Command_Notify      = "notify"
 )
 
 type RespOrErrorUnion[T any] struct {
@@ -126,6 +127,7 @@ type WshRpcInterface interface {
 	RemoteStreamCpuDataCommand(ctx context.Context) chan RespOrErrorUnion[TimeSeriesData]
 
 	WebSelectorCommand(ctx context.Context, data CommandWebSelectorData) ([]string, error)
+	NotifyCommand(ctx context.Context, notificationOptions WaveNotificationOptions) error
 }
 
 // for frontend
@@ -373,4 +375,11 @@ type BlockInfoData struct {
 	TabId    string              `json:"tabid"`
 	WindowId string              `json:"windowid"`
 	Meta     waveobj.MetaMapType `json:"meta"`
+}
+
+type WaveNotificationOptions struct {
+	Title  string `json:"title,omitempty"`
+	Body   string `json:"body,omitempty"`
+	Icon   string `json:"icon,omitempty"`
+	Silent bool   `json:"silent,omitempty"`
 }


### PR DESCRIPTION
This allows users to use the `wsh notify` command to make a popup notification, even from a remote connection.