### PR TITLE
Add markdown alert parsing, fix buffer issue when switching files

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 To report vulnerabilities or security concerns, please email us at: [security@commandline.dev](mailto:security@commandline.dev)
 
-** Please do not report security vulnerabilities through public github issues. **
+**Please do not report security vulnerabilities through public github issues.**

--- a/frontend/app/element/markdown.tsx
+++ b/frontend/app/element/markdown.tsx
@@ -17,6 +17,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import rehypeSlug from "rehype-slug";
 import RemarkFlexibleToc, { TocItem } from "remark-flexible-toc";
 import remarkGfm from "remark-gfm";
+import { remarkAlert } from "remark-github-blockquote-alert";
 import { openLink } from "../store/global";
 import { IconButton } from "./iconbutton";
 import "./markdown.less";
@@ -258,7 +259,7 @@ const Markdown = ({
                 options={{ scrollbars: { autoHide: "leave" } }}
             >
                 <ReactMarkdown
-                    remarkPlugins={[remarkGfm, [RemarkFlexibleToc, { tocRef: tocRef.current }]]}
+                    remarkPlugins={[remarkGfm, remarkAlert, [RemarkFlexibleToc, { tocRef: tocRef.current }]]}
                     rehypePlugins={[
                         rehypeRaw,
                         rehypeHighlight,

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
         "rehype-slug": "^6.0.0",
         "remark-flexible-toc": "^1.1.1",
         "remark-gfm": "^4.0.0",
+        "remark-github-blockquote-alert": "^1.2.1",
         "rxjs": "^7.8.1",
         "sharp": "^0.33.5",
         "shell-quote": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9632,6 +9632,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-github-blockquote-alert@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "remark-github-blockquote-alert@npm:1.2.1"
+  dependencies:
+    unist-util-visit: "npm:^5.0.0"
+  checksum: 10c0/48f70a56347ba6d2649ec647f9b126fe2e22ee4efcbc4962e1645967ac0994859a930a1af3a8b75c2989d55ed5b7ce2df6fc86a4b0f2c0aa39d5ed2162c857ca
+  languageName: node
+  linkType: hard
+
 "remark-parse@npm:^11.0.0":
   version: 11.0.0
   resolution: "remark-parse@npm:11.0.0"
@@ -11496,6 +11505,7 @@ __metadata:
     rehype-slug: "npm:^6.0.0"
     remark-flexible-toc: "npm:^1.1.1"
     remark-gfm: "npm:^4.0.0"
+    remark-github-blockquote-alert: "npm:^1.2.1"
     rollup-plugin-flow: "npm:^1.1.1"
     rxjs: "npm:^7.8.1"
     semver: "npm:^7.6.3"


### PR DESCRIPTION
Adds the GitHub alert syntax parsing to the markdown element, fixes an issue where the file edit buffer was not getting unset when the file path changed, continues my crusade on star imports