### PR TITLE
Re-enable go and zig actions in codeql pipeline

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,16 +65,14 @@ jobs:
                   corepack enable
                   yarn install
 
-            - name: Setup Go (Go only)
-              if: matrix.language == 'go'
+            - name: Setup Go
               uses: actions/setup-go@v5
               with:
                   go-version: ${{env.GO_VERSION}}
                   cache-dependency-path: |
                       go.sum
             # We use Zig instead of glibc for cgo compilation as it is more-easily statically linked
-            - name: Setup Zig (Go only)
-              if: matrix.language == 'go'
+            - name: Setup Zig
               run: sudo snap install zig --classic --beta
 
             # Initializes the CodeQL tools for scanning.


### PR DESCRIPTION
This was causing the builds for the javascript-typescript job to actually run longer because Go was still required to generate the bindings