### PR TITLE
fix: do not canonicalize hostname in list

### DIFF
--- a/pkg/remote/connutil.go
+++ b/pkg/remote/connutil.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/kevinburke/ssh_config"
-	"github.com/skeema/knownhosts"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -356,6 +355,5 @@ func NormalizeConfigPattern(pattern string) string {
 	} else {
 		port = ":" + port
 	}
-	unnormalized := fmt.Sprintf("%s%s%s", userName, pattern, port)
-	return knownhosts.Normalize(unnormalized)
+	return fmt.Sprintf("%s%s%s", userName, pattern, port)
 }


### PR DESCRIPTION
This removes the brackets for connections with non-standard ports in the dropdown list.