### PR TITLE
Remove global.ts dependency from emain

### DIFF
--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -11,14 +11,14 @@ import {
 import { getWebServerEndpoint } from "@/util/endpoints";
 import { fetch } from "@/util/fetchutil";
 import { getPrefixedSettings, isBlank } from "@/util/util";
-import { atom, Atom, createStore, PrimitiveAtom, useAtomValue } from "jotai";
+import { atom, Atom, PrimitiveAtom, useAtomValue } from "jotai";
+import { globalStore } from "./jotaiStore";
 import { modalsModel } from "./modalmodel";
 import { ClientService, ObjectService } from "./services";
 import * as WOS from "./wos";
 import { getFileSubject, waveEventSubscribe } from "./wps";
 
 let PLATFORM: NodeJS.Platform = "darwin";
-const globalStore = createStore();
 let atoms: GlobalAtomsType;
 let globalEnvironment: "electron" | "renderer";
 const blockComponentModelMap = new Map<string, BlockComponentModel>();

--- a/frontend/app/store/jotaiStore.ts
+++ b/frontend/app/store/jotaiStore.ts
@@ -1,0 +1,3 @@
+import { createStore } from "jotai";
+
+export const globalStore = createStore();

--- a/frontend/app/store/wos.ts
+++ b/frontend/app/store/wos.ts
@@ -7,7 +7,7 @@ import { getWebServerEndpoint } from "@/util/endpoints";
 import { fetch } from "@/util/fetchutil";
 import { atom, Atom, Getter, PrimitiveAtom, Setter, useAtomValue } from "jotai";
 import { useEffect } from "react";
-import { atoms, globalStore } from "./global";
+import { globalStore } from "./global";
 import { ObjectService } from "./services";
 
 type WaveObjectDataItemType<T extends WaveObj> = {
@@ -79,8 +79,8 @@ function debugLogBackendCall(methodName: string, durationStr: string, args: any[
 function callBackendService(service: string, method: string, args: any[], noUIContext?: boolean): Promise<any> {
     const startTs = Date.now();
     let uiContext: UIContext = null;
-    if (!noUIContext) {
-        uiContext = globalStore.get(atoms.uiContext);
+    if (!noUIContext && globalThis.window != null) {
+        uiContext = globalStore.get(((window as any).globalAtoms as GlobalAtomsType).uiContext);
     }
     const waveCall: WebCallType = {
         service: service,

--- a/frontend/app/store/wos.ts
+++ b/frontend/app/store/wos.ts
@@ -7,7 +7,7 @@ import { getWebServerEndpoint } from "@/util/endpoints";
 import { fetch } from "@/util/fetchutil";
 import { atom, Atom, Getter, PrimitiveAtom, Setter, useAtomValue } from "jotai";
 import { useEffect } from "react";
-import { globalStore } from "./global";
+import { globalStore } from "./jotaiStore";
 import { ObjectService } from "./services";
 
 type WaveObjectDataItemType<T extends WaveObj> = {

--- a/frontend/app/store/wps.ts
+++ b/frontend/app/store/wps.ts
@@ -1,6 +1,6 @@
 import { isBlank } from "@/util/util";
 import { Subject } from "rxjs";
-import { sendRawRpcMessage } from "./wshrpcutil";
+import { sendRawRpcMessage } from "./ws";
 
 type WaveEventSubject = {
     handler: (event: WaveEvent) => void;

--- a/frontend/app/store/ws.ts
+++ b/frontend/app/store/ws.ts
@@ -218,4 +218,32 @@ class WSControl {
     }
 }
 
-export { WSControl, addWSReconnectHandler, removeWSReconnectHandler, type ElectronOverrideOpts };
+let globalWS: WSControl;
+function initGlobalWS(
+    baseHostPort: string,
+    windowId: string,
+    messageCallback: WSEventCallback,
+    electronOverrideOpts?: ElectronOverrideOpts
+) {
+    globalWS = new WSControl(baseHostPort, windowId, messageCallback, electronOverrideOpts);
+}
+
+function sendRawRpcMessage(msg: RpcMessage) {
+    const wsMsg: WSRpcCommand = { wscommand: "rpc", message: msg };
+    sendWSCommand(wsMsg);
+}
+
+function sendWSCommand(cmd: WSCommandType) {
+    globalWS?.pushMessage(cmd);
+}
+
+export {
+    WSControl,
+    addWSReconnectHandler,
+    globalWS,
+    initGlobalWS,
+    removeWSReconnectHandler,
+    sendRawRpcMessage,
+    sendWSCommand,
+    type ElectronOverrideOpts,
+};

--- a/frontend/app/store/wshrouter.ts
+++ b/frontend/app/store/wshrouter.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { handleWaveEvent } from "@/app/store/wps";
+import * as util from "@/util/util";
 import debug from "debug";
-import * as util from "../../util/util";
 
 const dlog = debug("wave:router");
 

--- a/frontend/app/store/wshrpcutil.ts
+++ b/frontend/app/store/wshrpcutil.ts
@@ -5,9 +5,8 @@ import { wpsReconnectHandler } from "@/app/store/wps";
 import { WshClient } from "@/app/store/wshclient";
 import { makeWindowRouteId, WshRouter } from "@/app/store/wshrouter";
 import { getWSServerEndpoint } from "@/util/endpoints";
-import { addWSReconnectHandler, ElectronOverrideOpts, WSControl } from "./ws";
+import { addWSReconnectHandler, ElectronOverrideOpts, globalWS, initGlobalWS, WSControl } from "./ws";
 
-let globalWS: WSControl;
 let DefaultRouter: WshRouter;
 let WindowRpcClient: WshClient;
 
@@ -91,11 +90,6 @@ function sendRpcCommand(
     return rtnGen;
 }
 
-function sendRawRpcMessage(msg: RpcMessage) {
-    const wsMsg: WSRpcCommand = { wscommand: "rpc", message: msg };
-    sendWSCommand(wsMsg);
-}
-
 async function consumeGenerator(gen: AsyncGenerator<any, any, any>) {
     let idx = 0;
     try {
@@ -119,7 +113,7 @@ function initElectronWshrpc(electronClient: WshClient, eoOpts: ElectronOverrideO
     const handleFn = (event: WSEventType) => {
         DefaultRouter.recvRpcMessage(event.data);
     };
-    globalWS = new WSControl(getWSServerEndpoint(), "electron", handleFn, eoOpts);
+    initGlobalWS(getWSServerEndpoint(), "electron", handleFn, eoOpts);
     globalWS.connectNow("connectWshrpc");
     DefaultRouter.registerRoute(electronClient.routeId, electronClient);
     addWSReconnectHandler(() => {
@@ -137,7 +131,7 @@ function initWshrpc(windowId: string): WSControl {
     const handleFn = (event: WSEventType) => {
         DefaultRouter.recvRpcMessage(event.data);
     };
-    globalWS = new WSControl(getWSServerEndpoint(), windowId, handleFn);
+    initGlobalWS(getWSServerEndpoint(), windowId, handleFn);
     globalWS.connectNow("connectWshrpc");
     WindowRpcClient = new WshClient(makeWindowRouteId(windowId));
     DefaultRouter.registerRoute(WindowRpcClient.routeId, WindowRpcClient);
@@ -146,10 +140,6 @@ function initWshrpc(windowId: string): WSControl {
     });
     addWSReconnectHandler(wpsReconnectHandler);
     return globalWS;
-}
-
-function sendWSCommand(cmd: WSCommandType) {
-    globalWS?.pushMessage(cmd);
 }
 
 class UpstreamWshRpcProxy implements AbstractWshClient {
@@ -163,10 +153,8 @@ export {
     DefaultRouter,
     initElectronWshrpc,
     initWshrpc,
-    sendRawRpcMessage,
     sendRpcCommand,
     sendRpcResponse,
-    sendWSCommand,
     shutdownWshrpc,
     WindowRpcClient,
 };

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -74,6 +74,8 @@ const TabBar = React.memo(({ workspace }: TabBarProps) => {
 
     const isFullScreen = useAtomValue(atoms.isFullScreen);
 
+    const settings = useAtomValue(atoms.settingsAtom);
+
     let prevDelta: number;
     let prevDragDirection: string;
 
@@ -469,7 +471,7 @@ const TabBar = React.memo(({ workspace }: TabBarProps) => {
         </div>
     ) : undefined;
     const appMenuButton =
-        PLATFORM !== "darwin" ? (
+        PLATFORM !== "darwin" && !settings["window:showmenubar"] ? (
             <div className="app-menu-button" onClick={onEllipsisClick}>
                 <i className="fa fa-ellipsis" />
             </div>

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getFileSubject } from "@/app/store/wps";
+import { sendWSCommand } from "@/app/store/ws";
 import { RpcApi } from "@/app/store/wshclientapi";
-import { WindowRpcClient, sendWSCommand } from "@/app/store/wshrpcutil";
+import { WindowRpcClient } from "@/app/store/wshrpcutil";
 import { PLATFORM, WOS, atoms, fetchWaveFile, globalStore, openLink } from "@/store/global";
 import * as services from "@/store/services";
 import * as util from "@/util/util";

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -466,6 +466,7 @@ declare global {
         "window:bgcolor"?: string;
         "window:reducedmotion"?: boolean;
         "window:tilegapsize"?: number;
+        "window:showmenubar"?: boolean;
         "window:nativetitlebar"?: boolean;
         "window:disablehardwareacceleration"?: boolean;
         "telemetry:*"?: boolean;

--- a/pkg/wconfig/metaconsts.go
+++ b/pkg/wconfig/metaconsts.go
@@ -55,6 +55,7 @@ const (
 	ConfigKey_WindowBgColor                  = "window:bgcolor"
 	ConfigKey_WindowReducedMotion            = "window:reducedmotion"
 	ConfigKey_WindowTileGapSize              = "window:tilegapsize"
+	ConfigKey_WindowShowMenuBar              = "window:showmenubar"
 	ConfigKey_WindowNativeTitleBar           = "window:nativetitlebar"
 	ConfigKey_WindowDisableHardwareAcceleration = "window:disablehardwareacceleration"
 

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -89,6 +89,7 @@ type SettingsType struct {
 	WindowBgColor                     string   `json:"window:bgcolor,omitempty"`
 	WindowReducedMotion               bool     `json:"window:reducedmotion,omitempty"`
 	WindowTileGapSize                 *int64   `json:"window:tilegapsize,omitempty"`
+	WindowShowMenuBar                 bool     `json:"window:showmenubar,omitempty"`
 	WindowNativeTitleBar              bool     `json:"window:nativetitlebar,omitempty"`
 	WindowDisableHardwareAcceleration bool     `json:"window:disablehardwareacceleration,omitempty"`
 


### PR DESCRIPTION
Removes global atoms dependency from emain by moving WOS to grab the globalAtoms from window, if present. Also removes interdependency between wshrpcutil and wps

Also adds showmenubar setting for Windows and Linux