### PR TITLE
Add Don't Ask Again Checkbox for Wsh Install

### DIFF
--- a/frontend/app/element/markdown.less
+++ b/frontend/app/element/markdown.less
@@ -13,7 +13,7 @@
         width: 100%;
         overflow: scroll;
         line-height: 1.5;
-        color: var(--app-text-color);
+        color: var(--main-text-color);
         font-family: var(--markdown-font);
         font-size: 14px;
         overflow-wrap: break-word;
@@ -26,13 +26,13 @@
             &:first-of-type {
                 margin-top: 0 !important;
             }
-            color: var(--app-text-color);
+            color: var(--main-text-color);
             margin-top: 16px;
             margin-bottom: 8px;
         }
 
         strong {
-            color: var(--app-text-color);
+            color: var(--main-text-color);
         }
 
         a {

--- a/frontend/app/modals/userinputmodal.less
+++ b/frontend/app/modals/userinputmodal.less
@@ -42,4 +42,14 @@
             outline-color: var(--accent-color);
         }
     }
+
+    .userinput-checkbox-container {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+
+        .userinput-checkbox {
+            accent-color: var(--accent-color);
+        }
+    }
 }

--- a/frontend/app/modals/userinputmodal.tsx
+++ b/frontend/app/modals/userinputmodal.tsx
@@ -93,6 +93,18 @@ const UserInputModal = (userInputRequest: UserInputRequest) => {
         );
     }, [userInputRequest.responsetype, userInputRequest.publictext, responseText, handleKeyDown, setResponseText]);
 
+    const optionalCheckbox = useMemo(() => {
+        if (userInputRequest.checkboxmsg == "") {
+            return <></>;
+        }
+        return (
+            <div className="userinput-checkbox-container">
+                <input type="checkbox" id={`uicheckbox-${userInputRequest.requestid}`} className="userinput-checkbox" />
+                <label htmlFor={`uicheckbox-${userInputRequest.requestid}}`}>{userInputRequest.checkboxmsg}</label>
+            </div>
+        );
+    }, []);
+
     useEffect(() => {
         let timeout: ReturnType<typeof setTimeout>;
         if (countdown <= 0) {
@@ -113,6 +125,7 @@ const UserInputModal = (userInputRequest: UserInputRequest) => {
             <div className="userinput-body">
                 {queryText}
                 {inputBox}
+                {optionalCheckbox}
             </div>
         </Modal>
     );

--- a/frontend/app/modals/userinputmodal.tsx
+++ b/frontend/app/modals/userinputmodal.tsx
@@ -13,7 +13,7 @@ import "./userinputmodal.less";
 const UserInputModal = (userInputRequest: UserInputRequest) => {
     const [responseText, setResponseText] = useState("");
     const [countdown, setCountdown] = useState(Math.floor(userInputRequest.timeoutms / 1000));
-    const checkboxStatus = useRef(false);
+    const checkboxRef = useRef<HTMLInputElement>();
 
     const handleSendCancel = useCallback(() => {
         UserInputService.SendUserInputResponse({
@@ -29,7 +29,7 @@ const UserInputModal = (userInputRequest: UserInputRequest) => {
             type: "userinputresp",
             requestid: userInputRequest.requestid,
             text: responseText,
-            checkboxstat: checkboxStatus.current,
+            checkboxstat: checkboxRef.current?.checked ?? false,
         });
         modalsModel.popModal();
     }, [responseText, userInputRequest]);
@@ -39,7 +39,7 @@ const UserInputModal = (userInputRequest: UserInputRequest) => {
             type: "userinputresp",
             requestid: userInputRequest.requestid,
             confirm: true,
-            checkboxstat: checkboxStatus.current,
+            checkboxstat: checkboxRef.current?.checked ?? false,
         });
         modalsModel.popModal();
     }, [userInputRequest]);
@@ -99,7 +99,12 @@ const UserInputModal = (userInputRequest: UserInputRequest) => {
         }
         return (
             <div className="userinput-checkbox-container">
-                <input type="checkbox" id={`uicheckbox-${userInputRequest.requestid}`} className="userinput-checkbox" />
+                <input
+                    type="checkbox"
+                    id={`uicheckbox-${userInputRequest.requestid}`}
+                    className="userinput-checkbox"
+                    ref={checkboxRef}
+                />
                 <label htmlFor={`uicheckbox-${userInputRequest.requestid}}`}>{userInputRequest.checkboxmsg}</label>
             </div>
         );

--- a/frontend/app/view/preview/csvview.less
+++ b/frontend/app/view/preview/csvview.less
@@ -39,7 +39,7 @@
                 border-bottom: 1px solid var(--scrollbar-thumb-hover-color);
 
                 th {
-                    color: var(--app-text-color);
+                    color: var(--main-text-color);
                     border-right: 1px solid var(--scrollbar-thumb-hover-color);
                     border-bottom: none;
                     padding: 2px 10px;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -471,6 +471,7 @@ declare global {
         "window:disablehardwareacceleration"?: boolean;
         "telemetry:*"?: boolean;
         "telemetry:enabled"?: boolean;
+        askbeforewshinstall?: boolean;
     };
 
     // waveobj.StickerClickOptsType

--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -298,11 +298,8 @@ func (conn *SSHConn) CheckAndInstallWsh(ctx context.Context, clientDisplayName s
 			"Would you like to install them?", clientDisplayName)
 		title = "Install Wave Shell Extensions"
 	} else {
-		queryText = fmt.Sprintf("Wave requires the Wave Shell Extensions  \n"+
-			"installed on `%s`  \n"+
-			"to be updated from %s to %s.  \n\n"+
-			"Would you like to update?", clientDisplayName, clientVersion, expectedVersion)
-		title = "Update Wave Shell Extensions"
+		// don't ask for upgrading the version
+		opts.NoUserPrompt = true
 	}
 	if !opts.NoUserPrompt {
 		request := &userinput.UserInputRequest{

--- a/pkg/wconfig/defaultconfig/settings.json
+++ b/pkg/wconfig/defaultconfig/settings.json
@@ -9,5 +9,6 @@
     "web:defaulturl": "https://github.com/wavetermdev/waveterm",
     "web:defaultsearch": "https://www.google.com/search?q={query}",
     "window:tilegapsize": 3,
-    "telemetry:enabled": true
+    "telemetry:enabled": true,
+	"askbeforewshinstall": true
 }

--- a/pkg/wconfig/metaconsts.go
+++ b/pkg/wconfig/metaconsts.go
@@ -61,5 +61,7 @@ const (
 
 	ConfigKey_TelemetryClear                 = "telemetry:*"
 	ConfigKey_TelemetryEnabled               = "telemetry:enabled"
+
+	ConfigKey_AskBeforeWshInstall            = "askbeforewshinstall"
 )
 

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -95,6 +95,8 @@ type SettingsType struct {
 
 	TelemetryClear   bool `json:"telemetry:*,omitempty"`
 	TelemetryEnabled bool `json:"telemetry:enabled,omitempty"`
+
+	AskBeforeWshInstall bool `json:"askbeforewshinstall,omitempty"`
 }
 
 type ConfigError struct {


### PR DESCRIPTION
This provides a checkbox when installing wsh that will prevent the message from popping up in the future. It can also be disabled by adding `"askbeforewshinstall": false` to the config file.