### PR TITLE
Move default config and data dirs to better align with XDG spec and user expectations

### DIFF
--- a/cmd/server/main-server.go
+++ b/cmd/server/main-server.go
@@ -182,7 +182,7 @@ func main() {
 		log.Printf("error validating service map: %v\n", err)
 		return
 	}
-	err = wavebase.EnsureWaveHomeDir()
+	err = wavebase.EnsureWaveDataDir()
 	if err != nil {
 		log.Printf("error ensuring wave home dir: %v\n", err)
 		return
@@ -209,7 +209,8 @@ func main() {
 		}
 	}()
 	log.Printf("wave version: %s (%s)\n", WaveVersion, BuildTime)
-	log.Printf("wave home dir: %s\n", wavebase.GetWaveHomeDir())
+	log.Printf("wave data dir: %s\n", wavebase.GetWaveDataDir())
+	log.Printf("wave config dir: %s\n", wavebase.GetWaveConfigDir())
 	err = filestore.InitFilestore()
 	if err != nil {
 		log.Printf("error initializing filestore: %v\n", err)

--- a/emain/launchsettings.ts
+++ b/emain/launchsettings.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { getWaveHomeDir } from "./platform";
+import { getWaveConfigDir } from "./platform";
 
 /**
  * Get settings directly from the Wave Home directory on launch.
@@ -8,7 +8,7 @@ import { getWaveHomeDir } from "./platform";
  * @returns The initial launch settings for the application.
  */
 export function getLaunchSettings(): SettingsType {
-    const settingsPath = path.join(getWaveHomeDir(), "config", "settings.json");
+    const settingsPath = path.join(getWaveConfigDir(), "settings.json");
     try {
         const settingsContents = fs.readFileSync(settingsPath, "utf8");
         return JSON.parse(settingsContents);

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -52,10 +52,10 @@ function getWaveHomeDir(): string {
     if (!home) {
         const homeDir = process.env.HOME;
         if (homeDir) {
-            home = path.join(homeDir, getWaveDirName());
+            home = path.join(homeDir, `.${getWaveDirName()}`);
         }
     }
-    if (home && existsSync(home)) {
+    if (!!home && existsSync(home)) {
         return home;
     }
     return null;
@@ -152,4 +152,6 @@ export {
     isDevVite,
     unameArch,
     unamePlatform,
+    WaveConfigHomeVarName,
+    WaveDataHomeVarName,
 };

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -112,7 +112,7 @@ function getWaveDataDir(): string {
         if (configHome) {
             retVal = path.join(configHome, getWaveDirName());
         } else {
-            retVal = path.join(process.env.HOME, ".local", getWaveDirName());
+            retVal = path.join(process.env.HOME, ".local", "share", getWaveDirName());
         }
     }
     return ensurePathExists(retVal);

--- a/frontend/app/block/block.less
+++ b/frontend/app/block/block.less
@@ -221,15 +221,6 @@
                             font-size: 11px;
                         }
                     }
-
-                    .block-frame-div-url,
-                    .block-frame-div-search {
-                        background: rgba(255, 255, 255, 0.1);
-
-                        input {
-                            opacity: 1;
-                        }
-                    }
                 }
 
                 .block-frame-end-icons {

--- a/frontend/app/view/preview/directorypreview.tsx
+++ b/frontend/app/view/preview/directorypreview.tsx
@@ -534,6 +534,7 @@ function DirectoryPreview({ model }: DirectoryPreviewProps) {
     const [selectedPath, setSelectedPath] = useState("");
     const [refreshVersion, setRefreshVersion] = useAtom(model.refreshVersion);
     const conn = useAtomValue(model.connection);
+    const blockData = useAtomValue(model.blockAtom);
 
     useEffect(() => {
         model.refreshCallback = () => {
@@ -593,7 +594,12 @@ function DirectoryPreview({ model }: DirectoryPreviewProps) {
                 setSearchText((current) => current.slice(0, -1));
                 return true;
             }
-            if (checkKeyPressed(waveEvent, "Space") && searchText == "" && PLATFORM == "darwin") {
+            if (
+                checkKeyPressed(waveEvent, "Space") &&
+                searchText == "" &&
+                PLATFORM == "darwin" &&
+                !blockData?.meta?.connection
+            ) {
                 getApi().onQuicklook(selectedPath);
                 console.log(selectedPath);
                 return true;

--- a/frontend/app/view/webview/webview.less
+++ b/frontend/app/view/webview/webview.less
@@ -15,3 +15,16 @@
     transform: translate3d(0, 0, 0);
     will-change: transform;
 }
+
+.block-frame-div-url {
+    background: rgba(255, 255, 255, 0.1);
+
+    input {
+        opacity: 1;
+    }
+
+    .iconbutton {
+        width: fit-content !important;
+        margin-right: 5px;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "productName": "Wave",
     "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
     "license": "Apache-2.0",
-    "version": "0.8.11",
+    "version": "0.8.12-beta.0",
     "homepage": "https://waveterm.dev",
     "build": {
         "appId": "dev.commandline.waveterm"

--- a/pkg/filestore/blockstore_dbsetup.go
+++ b/pkg/filestore/blockstore_dbsetup.go
@@ -50,7 +50,7 @@ func InitFilestore() error {
 }
 
 func GetDBName() string {
-	waveHome := wavebase.GetWaveHomeDir()
+	waveHome := wavebase.GetWaveDataDir()
 	return filepath.Join(waveHome, wavebase.WaveDBDir, FilestoreDBName)
 }
 

--- a/pkg/shellexec/shellexec.go
+++ b/pkg/shellexec/shellexec.go
@@ -289,7 +289,7 @@ func StartShellProc(termSize waveobj.TermSize, cmdStr string, cmdOpts CommandOpt
 			// cant set -l or -i with --rcfile
 			shellOpts = append(shellOpts, "--rcfile", shellutil.GetBashRcFileOverride())
 		} else if isFishShell(shellPath) {
-			wshBinDir := filepath.Join(wavebase.GetWaveHomeDir(), shellutil.WaveHomeBinDir)
+			wshBinDir := filepath.Join(wavebase.GetWaveDataDir(), shellutil.WaveHomeBinDir)
 			quotedWshBinDir := utilfn.ShellQuote(wshBinDir, false, 300)
 			shellOpts = append(shellOpts, "-C", fmt.Sprintf("set -x PATH %s $PATH", quotedWshBinDir))
 		} else if remote.IsPowershell(shellPath) {

--- a/pkg/util/shellutil/shellutil.go
+++ b/pkg/util/shellutil/shellutil.go
@@ -149,7 +149,7 @@ func WaveshellLocalEnvVars(termType string) map[string]string {
 	rtn["TERM_PROGRAM"] = "waveterm"
 	rtn["WAVETERM"], _ = os.Executable()
 	rtn["WAVETERM_VERSION"] = wavebase.WaveVersion
-	rtn["WAVETERM_WSHBINDIR"] = filepath.Join(wavebase.GetWaveHomeDir(), WaveHomeBinDir)
+	rtn["WAVETERM_WSHBINDIR"] = filepath.Join(wavebase.GetWaveDataDir(), WaveHomeBinDir)
 	return rtn
 }
 
@@ -202,15 +202,15 @@ func InitCustomShellStartupFiles() error {
 }
 
 func GetBashRcFileOverride() string {
-	return filepath.Join(wavebase.GetWaveHomeDir(), BashIntegrationDir, ".bashrc")
+	return filepath.Join(wavebase.GetWaveDataDir(), BashIntegrationDir, ".bashrc")
 }
 
 func GetWavePowershellEnv() string {
-	return filepath.Join(wavebase.GetWaveHomeDir(), PwshIntegrationDir, "wavepwsh.ps1")
+	return filepath.Join(wavebase.GetWaveDataDir(), PwshIntegrationDir, "wavepwsh.ps1")
 }
 
 func GetZshZDotDir() string {
-	return filepath.Join(wavebase.GetWaveHomeDir(), ZshIntegrationDir)
+	return filepath.Join(wavebase.GetWaveDataDir(), ZshIntegrationDir)
 }
 
 func GetWshBaseName(version string, goos string, goarch string) string {
@@ -289,9 +289,9 @@ func InitRcFiles(waveHome string, wshBinDir string) error {
 
 func initCustomShellStartupFilesInternal() error {
 	log.Printf("initializing wsh and shell startup files\n")
-	waveHome := wavebase.GetWaveHomeDir()
-	binDir := filepath.Join(waveHome, WaveHomeBinDir)
-	err := InitRcFiles(waveHome, `$WAVETERM_WSHBINDIR`)
+	waveDataHome := wavebase.GetWaveDataDir()
+	binDir := filepath.Join(waveDataHome, WaveHomeBinDir)
+	err := InitRcFiles(waveDataHome, `$WAVETERM_WSHBINDIR`)
 	if err != nil {
 		return err
 	}

--- a/pkg/wavebase/wavebase-posix.go
+++ b/pkg/wavebase/wavebase-posix.go
@@ -14,8 +14,8 @@ import (
 )
 
 func AcquireWaveLock() (FDLock, error) {
-	homeDir := GetWaveHomeDir()
-	lockFileName := filepath.Join(homeDir, WaveLockFile)
+	dataHomeDir := GetWaveDataDir()
+	lockFileName := filepath.Join(dataHomeDir, WaveLockFile)
 	log.Printf("[base] acquiring lock on %s\n", lockFileName)
 	fd, err := os.OpenFile(lockFileName, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {

--- a/pkg/wavebase/wavebase-win.go
+++ b/pkg/wavebase/wavebase-win.go
@@ -14,8 +14,8 @@ import (
 )
 
 func AcquireWaveLock() (FDLock, error) {
-	homeDir := GetWaveHomeDir()
-	lockFileName := filepath.Join(homeDir, WaveLockFile)
+	dataHomeDir := GetWaveDataDir()
+	lockFileName := filepath.Join(dataHomeDir, WaveLockFile)
 	log.Printf("[base] acquiring lock on %s\n", lockFileName)
 	m, err := filemutex.New(lockFileName)
 	if err != nil {

--- a/pkg/wavebase/wavebase.go
+++ b/pkg/wavebase/wavebase.go
@@ -23,9 +23,8 @@ import (
 var WaveVersion = "0.0.0"
 var BuildTime = "0"
 
-const DefaultWaveHome = "~/.waveterm"
-const DevWaveHome = "~/.waveterm-dev"
-const WaveHomeVarName = "WAVETERM_HOME"
+const WaveConfigHomeEnvVar = "WAVETERM_CONFIG_HOME"
+const WaveDataHomeEnvVar = "WAVETERM_DATA_HOME"
 const WaveDevVarName = "WAVETERM_DEV"
 const WaveLockFile = "wave.lock"
 const DomainSocketBaseName = "wave.sock"
@@ -97,30 +96,27 @@ func ReplaceHomeDir(pathStr string) string {
 }
 
 func GetDomainSocketName() string {
-	return filepath.Join(GetWaveHomeDir(), DomainSocketBaseName)
+	return filepath.Join(GetWaveDataDir(), DomainSocketBaseName)
 }
 
-func GetWaveHomeDir() string {
-	homeVar := os.Getenv(WaveHomeVarName)
-	if homeVar != "" {
-		return ExpandHomeDirSafe(homeVar)
-	}
-	if IsDevMode() {
-		return ExpandHomeDirSafe(DevWaveHome)
-	}
-	return ExpandHomeDirSafe(DefaultWaveHome)
+func GetWaveDataDir() string {
+	return os.Getenv(WaveDataHomeEnvVar)
 }
 
-func EnsureWaveHomeDir() error {
-	return CacheEnsureDir(GetWaveHomeDir(), "wavehome", 0700, "wave home directory")
+func GetWaveConfigDir() string {
+	return os.Getenv(WaveConfigHomeEnvVar)
+}
+
+func EnsureWaveDataDir() error {
+	return CacheEnsureDir(GetWaveDataDir(), "wavehome", 0700, "wave home directory")
 }
 
 func EnsureWaveDBDir() error {
-	return CacheEnsureDir(filepath.Join(GetWaveHomeDir(), WaveDBDir), "wavedb", 0700, "wave db directory")
+	return CacheEnsureDir(filepath.Join(GetWaveDataDir(), WaveDBDir), "wavedb", 0700, "wave db directory")
 }
 
 func EnsureWaveConfigDir() error {
-	return CacheEnsureDir(filepath.Join(GetWaveHomeDir(), ConfigDir), "waveconfig", 0700, "wave config directory")
+	return CacheEnsureDir(GetWaveConfigDir(), "waveconfig", 0700, "wave config directory")
 }
 
 func CacheEnsureDir(dirName string, cacheKey string, perm os.FileMode, dirDesc string) error {

--- a/pkg/wconfig/filewatcher.go
+++ b/pkg/wconfig/filewatcher.go
@@ -14,7 +14,7 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/wps"
 )
 
-var configDirAbsPath = filepath.Join(wavebase.GetWaveHomeDir(), wavebase.ConfigDir)
+var configDirAbsPath = wavebase.GetWaveConfigDir()
 
 var instance *Watcher
 var once sync.Once

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -431,7 +431,7 @@ func MakeTCPListener(serviceName string) (net.Listener, error) {
 }
 
 func MakeUnixListener() (net.Listener, error) {
-	serverAddr := wavebase.GetWaveHomeDir() + "/wave.sock"
+	serverAddr := wavebase.GetWaveDataDir() + "/wave.sock"
 	os.Remove(serverAddr) // ignore error
 	rtn, err := net.Listen("unix", serverAddr)
 	if err != nil {

--- a/pkg/wstore/wstore_dbsetup.go
+++ b/pkg/wstore/wstore_dbsetup.go
@@ -42,7 +42,7 @@ func InitWStore() error {
 }
 
 func GetDBName() string {
-	waveHome := wavebase.GetWaveHomeDir()
+	waveHome := wavebase.GetWaveDataDir()
 	return filepath.Join(waveHome, wavebase.WaveDBDir, WStoreDBName)
 }
 


### PR DESCRIPTION
Defaults to using the old `~/.waveterm` or WAVETERM_HOME directory if it exists, to ensure backwards compatibility. Going forward for new installations, config files will be stored at `~/.config/waveterm` on macOS and Linux and `%LOCALAPPDATA%\waveterm\config` on Windows and everything else will be stored at `~/.local/share/waveterm` on macOS and Linux and `%LOCALAPPDATA%\waveterm\data` on Windows.

If XDG_DATA_HOME and XDG_CONFIG_HOME are defined, these will be used instead. WAVETERM_DATA_HOME and WAVETERM_CONFIG_HOME will further override all defaults.