### PR TITLE
Fix runaway name appending on the default AI preset

### DIFF
--- a/frontend/app/view/waveai/waveai.tsx
+++ b/frontend/app/view/waveai/waveai.tsx
@@ -81,7 +81,6 @@ export class WaveAiModel implements ViewModel {
                     .filter(([k]) => k.startsWith("ai@"))
                     .map(([k, v]) => {
                         const aiPresetKeys = Object.keys(v).filter((k) => k.startsWith("ai:"));
-                        console.log(aiPresetKeys);
                         const newV = { ...v };
                         newV["display:name"] =
                             aiPresetKeys.length == 1 && aiPresetKeys.includes("ai:*")
@@ -319,7 +318,6 @@ export class WaveAiModel implements ViewModel {
                         content: errMsg,
                     };
                     updatedHist.push(errorPrompt);
-                    console.log(updatedHist);
                     await BlockService.SaveWaveAiData(blockId, updatedHist);
                 }
                 setLocked(false);

--- a/frontend/app/view/waveai/waveai.tsx
+++ b/frontend/app/view/waveai/waveai.tsx
@@ -82,11 +82,12 @@ export class WaveAiModel implements ViewModel {
                     .map(([k, v]) => {
                         const aiPresetKeys = Object.keys(v).filter((k) => k.startsWith("ai:"));
                         console.log(aiPresetKeys);
-                        v["display:name"] =
+                        const newV = { ...v };
+                        newV["display:name"] =
                             aiPresetKeys.length == 1 && aiPresetKeys.includes("ai:*")
-                                ? `${v["display:name"] ?? "Default"} (${settings["ai:model"]})`
-                                : v["display:name"];
-                        return [k, v];
+                                ? `${newV["display:name"] ?? "Default"} (${settings["ai:model"]})`
+                                : newV["display:name"];
+                        return [k, newV];
                     })
             );
         });
@@ -109,7 +110,7 @@ export class WaveAiModel implements ViewModel {
             messages.pop();
             set(this.messagesAtom, [...messages]);
         });
-        this.simulateAssistantResponseAtom = atom(null, async (get, set, userMessage: ChatMessageType) => {
+        this.simulateAssistantResponseAtom = atom(null, async (_, set, userMessage: ChatMessageType) => {
             // unused at the moment. can replace the temp() function in the future
             const typingMessage: ChatMessageType = {
                 id: crypto.randomUUID(),
@@ -213,7 +214,7 @@ export class WaveAiModel implements ViewModel {
     }
 
     async fetchAiData(): Promise<Array<OpenAIPromptMessageType>> {
-        const { data, fileInfo } = await fetchWaveFile(this.blockId, "aidata");
+        const { data } = await fetchWaveFile(this.blockId, "aidata");
         if (!data) {
             return [];
         }


### PR DESCRIPTION
Shallow copy the presets when updating `display:name` so that the appending of the model name for the default preset doesn't accumulate every time the tab refreshes.

closes #1040 