### PR TITLE
Add expect-error to two emain event handlers

### DIFF
--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -471,10 +471,12 @@ function createBrowserWindow(clientId: string, waveWindow: WaveWindow, fullConfi
         }
     });
     win.on(
+        // @ts-expect-error
         "resize",
         debounce(400, (e) => mainResizeHandler(e, waveWindow.oid, win))
     );
     win.on(
+        // @ts-expect-error
         "move",
         debounce(400, (e) => mainResizeHandler(e, waveWindow.oid, win))
     );


### PR DESCRIPTION
There were two type errors after the most recent electron upgrade, but they're both benign (event handler parameter mismatch) so I am adding ts-expect-error to both instances.