### PR TITLE
Add separate AI presets file and and dropdown to edit it from Wave AI widget

### DIFF
--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -23,23 +23,6 @@ const unamePlatform = process.platform;
 const unameArch: string = process.arch;
 keyutil.setKeyUtilPlatform(unamePlatform);
 
-ipcMain.on("get-is-dev", (event) => {
-    event.returnValue = isDev;
-});
-ipcMain.on("get-platform", (event, url) => {
-    event.returnValue = unamePlatform;
-});
-ipcMain.on("get-user-name", (event) => {
-    const userInfo = os.userInfo();
-    event.returnValue = userInfo.username;
-});
-ipcMain.on("get-host-name", (event) => {
-    event.returnValue = os.hostname();
-});
-ipcMain.on("get-webview-preload", (event) => {
-    event.returnValue = path.join(getElectronAppBasePath(), "preload", "preload-webview.cjs");
-});
-
 // must match golang
 function getWaveHomeDir() {
     const override = process.env[WaveHomeVarName];
@@ -71,6 +54,26 @@ function getWaveSrvPath(): string {
 function getWaveSrvCwd(): string {
     return getWaveHomeDir();
 }
+
+ipcMain.on("get-is-dev", (event) => {
+    event.returnValue = isDev;
+});
+ipcMain.on("get-platform", (event, url) => {
+    event.returnValue = unamePlatform;
+});
+ipcMain.on("get-user-name", (event) => {
+    const userInfo = os.userInfo();
+    event.returnValue = userInfo.username;
+});
+ipcMain.on("get-host-name", (event) => {
+    event.returnValue = os.hostname();
+});
+ipcMain.on("get-webview-preload", (event) => {
+    event.returnValue = path.join(getElectronAppBasePath(), "preload", "preload-webview.cjs");
+});
+ipcMain.on("get-config-dir", (event) => {
+    event.returnValue = path.join(getWaveHomeDir(), "config");
+});
 
 export {
     getElectronAppBasePath,

--- a/emain/preload.ts
+++ b/emain/preload.ts
@@ -10,6 +10,7 @@ contextBridge.exposeInMainWorld("api", {
     getCursorPoint: () => ipcRenderer.sendSync("get-cursor-point"),
     getUserName: () => ipcRenderer.sendSync("get-user-name"),
     getHostName: () => ipcRenderer.sendSync("get-host-name"),
+    getConfigDir: () => ipcRenderer.sendSync("get-config-dir"),
     getAboutModalDetails: () => ipcRenderer.sendSync("get-about-modal-details"),
     getDocsiteUrl: () => ipcRenderer.sendSync("get-docsite-url"),
     getWebviewPreload: () => ipcRenderer.sendSync("get-webview-preload"),

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -63,7 +63,6 @@ function initGlobalAtoms(initOpts: GlobalInitOptions) {
         // do nothing
     }
 
-    const showAboutModalAtom = atom(false) as PrimitiveAtom<boolean>;
     try {
         getApi().onMenuItemAbout(() => {
             modalsModel.pushModal("AboutModal");

--- a/frontend/app/view/waveai/waveai.tsx
+++ b/frontend/app/view/waveai/waveai.tsx
@@ -6,7 +6,7 @@ import { Markdown } from "@/app/element/markdown";
 import { TypingIndicator } from "@/app/element/typingindicator";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { WindowRpcClient } from "@/app/store/wshrpcutil";
-import { atoms, fetchWaveFile, globalStore, WOS } from "@/store/global";
+import { atoms, createBlock, fetchWaveFile, getApi, globalStore, WOS } from "@/store/global";
 import { BlockService, ObjectService } from "@/store/services";
 import { adaptFromReactOrNativeKeyEvent, checkKeyPressed } from "@/util/keyutil";
 import { fireAndForget, isBlank, makeIconClass } from "@/util/util";
@@ -182,26 +182,41 @@ export class WaveAiModel implements ViewModel {
                     });
                 }
             }
-
+            const dropdownItems = Object.entries(presets)
+                .sort((a, b) => (a[1]["display:order"] > b[1]["display:order"] ? 1 : -1))
+                .map(
+                    (preset) =>
+                        ({
+                            label: preset[1]["display:name"],
+                            onClick: () =>
+                                fireAndForget(async () => {
+                                    await ObjectService.UpdateObjectMeta(WOS.makeORef("block", this.blockId), {
+                                        ...preset[1],
+                                        "ai:preset": preset[0],
+                                    });
+                                }),
+                        }) as MenuItem
+                );
+            dropdownItems.push({
+                label: "Add AI preset...",
+                onClick: () => {
+                    fireAndForget(async () => {
+                        const path = `${getApi().getConfigDir()}/ai-presets.json`;
+                        const blockDef: BlockDef = {
+                            meta: {
+                                view: "preview",
+                                file: path,
+                            },
+                        };
+                        await createBlock(blockDef, true);
+                    });
+                },
+            });
             viewTextChildren.push({
                 elemtype: "menubutton",
                 text: presetName,
                 title: "Select AI Configuration",
-                items: Object.entries(presets)
-                    .sort((a, b) => (a[1]["display:order"] > b[1]["display:order"] ? 1 : -1))
-                    .map(
-                        (preset) =>
-                            ({
-                                label: preset[1]["display:name"],
-                                onClick: () =>
-                                    fireAndForget(async () => {
-                                        await ObjectService.UpdateObjectMeta(WOS.makeORef("block", this.blockId), {
-                                            ...preset[1],
-                                            "ai:preset": preset[0],
-                                        });
-                                    }),
-                            }) as MenuItem
-                    ),
+                items: dropdownItems,
             });
             return viewTextChildren;
         });

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -58,6 +58,7 @@ declare global {
         getEnv: (varName: string) => string;
         getUserName: () => string;
         getHostName: () => string;
+        getConfigDir: () => string;
         getWebviewPreload: () => string;
         getAboutModalDetails: () => AboutModalDetails;
         getDocsiteUrl: () => string;

--- a/pkg/wconfig/defaultconfig/ai-presets.json
+++ b/pkg/wconfig/defaultconfig/ai-presets.json
@@ -1,0 +1,15 @@
+{
+    "ai@global": {
+        "display:name": "Global default",
+        "display:order": -1,
+        "ai:*": true
+    },
+    "ai@wave": {
+        "display:name": "Wave Proxy - gpt-4o-mini",
+        "display:order": 0,
+        "ai:*": true,
+        "ai:model": "gpt-4o-mini",
+        "ai:maxtokens": 2048,
+        "ai:timeoutms": 60000
+    }
+}

--- a/pkg/wconfig/defaultconfig/presets.json
+++ b/pkg/wconfig/defaultconfig/presets.json
@@ -94,25 +94,5 @@
         "bg": "linear-gradient(120deg,hsla(350, 65%, 57%, 1),hsla(30,60%,60%, .75), hsla(208,69%,50%,.15), hsl(230,60%,40%)),radial-gradient(at top right,hsla(300,60%,70%,0.3),transparent),radial-gradient(at top left,hsla(330,100%,70%,.20),transparent),radial-gradient(at top right,hsla(190,100%,40%,.20),transparent),radial-gradient(at bottom left,hsla(323,54%,50%,.5),transparent),radial-gradient(at bottom left,hsla(144,54%,50%,.25),transparent)",
         "bg:blendmode": "overlay",
         "bg:text": "rgb(200, 200, 200)"
-    },
-    "ai@global": {
-        "display:name": "Global default",
-        "display:order": -1,
-        "ai:*": true
-    },
-    "ai@wave": {
-        "display:name": "Wave Proxy - gpt-4o-mini",
-        "display:order": 0,
-        "ai:*": true,
-        "ai:model": "gpt-4o-mini",
-        "ai:maxtokens": 2048,
-        "ai:timeoutms": 60000
-    },
-    "ai@ollama-llama3.1": {
-        "display:name": "ollama - llama3.1",
-        "display:order": 0,
-        "ai:*": true,
-        "ai:baseurl": "http://localhost:11434/v1",
-        "ai:model": "llama3.1:latest"
     }
 }

--- a/pkg/wconfig/filewatcher.go
+++ b/pkg/wconfig/filewatcher.go
@@ -115,6 +115,7 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 	if event.Op == fsnotify.Chmod {
 		return
 	}
+	log.Printf("handleEvent: %s, %s\n", fileName, event.Op)
 	if !isValidSubSettingsFileName(fileName) {
 		return
 	}

--- a/pkg/wconfig/filewatcher.go
+++ b/pkg/wconfig/filewatcher.go
@@ -115,7 +115,6 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 	if event.Op == fsnotify.Chmod {
 		return
 	}
-	log.Printf("handleEvent: %s, %s\n", fileName, event.Op)
 	if !isValidSubSettingsFileName(fileName) {
 		return
 	}

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -310,7 +309,6 @@ func ReadFullConfig() FullConfigType {
 			continue
 		} else if jsonTag == "presets" {
 			configPart, errs = ReadConfigsBySuffix(fileName, simpleMerge)
-			log.Printf("presets %v, %v\n", configPart, errs)
 		} else {
 			configPart, errs = ReadConfigPart(fileName, simpleMerge)
 		}


### PR DESCRIPTION
Adds new functionality on the backend that will merge any file from the config directory that matches `*presets.json` into the presets settings struct. This lets us separate the AI presets into `ai-presets.json` so that we can add a dropdown in the AI preset selector that will directly open the the `ai-presets.json` file so a user can edit it more easily. Right now, this will create a preview block in the layout, but in the future we can look into making this block disconnected from the layout. 

If you put AI presets in the regular presets.json file, it will still work, since all the presets get merged.