### PR TITLE
Revert "Bump the prod-dependencies group with 2 updates"

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "vitest": "^2.1.3"
     },
     "dependencies": {
-        "@floating-ui/react": "^0.26.25",
+        "@floating-ui/react": "^0.26.24",
         "@monaco-editor/loader": "^1.4.0",
         "@monaco-editor/react": "^4.6.0",
         "@observablehq/plot": "^0.6.16",
@@ -136,7 +136,7 @@
         "use-device-pixel-ratio": "^1.1.2",
         "winston": "^3.15.0",
         "ws": "^8.18.0",
-        "yaml": "^2.6.0"
+        "yaml": "^2.5.1"
     },
     "resolutions": {
         "send@npm:0.18.0": "0.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,9 +847,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/react@npm:^0.26.25":
-  version: 0.26.25
-  resolution: "@floating-ui/react@npm:0.26.25"
+"@floating-ui/react@npm:^0.26.24":
+  version: 0.26.24
+  resolution: "@floating-ui/react@npm:0.26.24"
   dependencies:
     "@floating-ui/react-dom": "npm:^2.1.2"
     "@floating-ui/utils": "npm:^0.2.8"
@@ -857,7 +857,7 @@ __metadata:
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: 10c0/5206b06a5963e795af2f0b0a6ac39230012263ffa38dd60158e0f0b82d43a24e6a1c005fc8556ee5fe26e6353546ffb72e54716f6bd584fdab516dc128a78995
+  checksum: 10c0/c5c3ac265802087673a69b0e08b3bea1ee02de9da4cdbc40bb1c9e06823be72628a82f1655b40d56a4383715b4ab3b6deddff4e69146f513970ee592e1dd8f92
   languageName: node
   linkType: hard
 
@@ -11635,7 +11635,7 @@ __metadata:
   dependencies:
     "@chromatic-com/storybook": "npm:^2.0.2"
     "@eslint/js": "npm:^9.12.0"
-    "@floating-ui/react": "npm:^0.26.25"
+    "@floating-ui/react": "npm:^0.26.24"
     "@monaco-editor/loader": "npm:^1.4.0"
     "@monaco-editor/react": "npm:^4.6.0"
     "@observablehq/plot": "npm:^0.6.16"
@@ -11740,7 +11740,7 @@ __metadata:
     vitest: "npm:^2.1.3"
     winston: "npm:^3.15.0"
     ws: "npm:^8.18.0"
-    yaml: "npm:^2.6.0"
+    yaml: "npm:^2.5.1"
   languageName: unknown
   linkType: soft
 
@@ -11939,12 +11939,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0, yaml@npm:^2.6.0":
+"yaml@npm:^2.0.0":
   version: 2.6.0
   resolution: "yaml@npm:2.6.0"
   bin:
     yaml: bin.mjs
   checksum: 10c0/9e74cdb91cc35512a1c41f5ce509b0e93cc1d00eff0901e4ba831ee75a71ddf0845702adcd6f4ee6c811319eb9b59653248462ab94fa021ab855543a75396ceb
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.5.1":
+  version: 2.5.1
+  resolution: "yaml@npm:2.5.1"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/40fba5682898dbeeb3319e358a968fe886509fab6f58725732a15f8dda3abac509f91e76817c708c9959a15f786f38ff863c1b88062d7c1162c5334a7d09cb4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts wavetermdev/waveterm#1062,

Will reapply after 0.8.12