### PR TITLE
Fix edge case with Wave Proxy AI preset

### DIFF
--- a/pkg/wconfig/defaultconfig/presets.json
+++ b/pkg/wconfig/defaultconfig/presets.json
@@ -104,6 +104,11 @@
         "display:name": "Wave Proxy - gpt-4o-mini",
         "display:order": 0,
         "ai:*": true,
+        "ai:apitype": "",
+        "ai:baseurl": "",
+        "ai:apitoken": "",
+        "ai:name": "",
+        "ai:orgid": "",
         "ai:model": "gpt-4o-mini",
         "ai:maxtokens": 2048,
         "ai:timeoutms": 60000


### PR DESCRIPTION
If a user has changed the global AI settings and added a different base url, the Wave Proxy preset would not work because it doesn't unset all the AI settings.