### PR TITLE
Fix code scanning alert no. 50: Size computation for allocation may overflow

### DIFF
--- a/pkg/wshutil/wshutil.go
+++ b/pkg/wshutil/wshutil.go
@@ -67,9 +67,13 @@ func makeOscPrefix(oscNum string) []byte {
 	return output
 }
 
-func EncodeWaveOSCBytes(oscNum string, barr []byte) []byte {
+func EncodeWaveOSCBytes(oscNum string, barr []byte) ([]byte, error) {
 	if len(oscNum) != 5 {
-		panic("oscNum must be 5 characters")
+		return nil, fmt.Errorf("oscNum must be 5 characters")
+	}
+	const maxSize = 64 * 1024 * 1024 // 64 MB
+	if len(barr) > maxSize {
+		return nil, fmt.Errorf("input data too large")
 	}
 	hasControlChars := false
 	for _, b := range barr {
@@ -85,7 +89,7 @@ func EncodeWaveOSCBytes(oscNum string, barr []byte) []byte {
 		copyOscPrefix(output, oscNum)
 		copy(output[oscPrefixLen(oscNum):], barr)
 		output[len(output)-1] = BEL
-		return output
+		return output, nil
 	}
 
 	var buf bytes.Buffer
@@ -101,7 +105,7 @@ func EncodeWaveOSCBytes(oscNum string, barr []byte) []byte {
 		}
 	}
 	buf.WriteByte(BEL)
-	return buf.Bytes()
+	return buf.Bytes(), nil
 }
 
 func EncodeWaveOSCMessageEx(oscNum string, msg *RpcMessage) ([]byte, error) {
@@ -112,7 +116,7 @@ func EncodeWaveOSCMessageEx(oscNum string, msg *RpcMessage) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling message to json: %w", err)
 	}
-	return EncodeWaveOSCBytes(oscNum, barr), nil
+	return EncodeWaveOSCBytes(oscNum, barr)
 }
 
 var termModeLock = sync.Mutex{}


### PR DESCRIPTION
Fixes [https://github.com/wavetermdev/waveterm/security/code-scanning/50](https://github.com/wavetermdev/waveterm/security/code-scanning/50)

To fix the problem, we need to ensure that the size computation for the allocation does not overflow. This can be achieved by validating the length of `barr` before performing the arithmetic operation. We will set a maximum allowable size for `barr` to ensure that the sum of `oscPrefixLen(oscNum)` and `len(barr)` does not exceed the maximum value for an `int`.

1. Define a maximum allowable size for `barr` (e.g., 64 MB).
2. Check the length of `barr` against this maximum size before performing the allocation.
3. If `barr` exceeds the maximum size, return an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
