### PR TITLE
Add step to bump Winget package version on publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,6 +24,7 @@ jobs:
                   AWS_DEFAULT_REGION: us-west-2
               shell: bash
     bump-winget:
+        if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, 'beta') }}
         runs-on: windows-latest
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,3 +23,17 @@ jobs:
                   AWS_SECRET_ACCESS_KEY: "${{ secrets.PUBLISHER_KEY_SECRET }}"
                   AWS_DEFAULT_REGION: us-west-2
               shell: bash
+    bump-winget:
+        runs-on: windows-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Install Task
+              uses: arduino/setup-task@v2
+              with:
+                  version: 3.x
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Submit Winget version bump
+              run: "task artifacts:publish:winget:${{ github.ref_name }}"
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              shell: pwsh

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,5 +35,5 @@ jobs:
             - name: Submit Winget version bump
               run: "task artifacts:publish:winget:${{ github.ref_name }}"
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.WINGET_BUMP_PAT }}
               shell: pwsh

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,7 @@ on:
         types: [published]
 jobs:
     publish:
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -16,7 +17,6 @@ jobs:
                   version: 3.x
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Publish from staging
-              if: startsWith(github.ref, 'refs/tags/')
               run: "task artifacts:publish:${{ github.ref_name }}"
               env:
                   AWS_ACCESS_KEY_ID: "${{ secrets.PUBLISHER_KEY_ID }}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,6 +13,7 @@ vars:
     DATE: '{{if eq OS "windows"}}powershell Get-Date -UFormat{{else}}date{{end}}'
     ARTIFACTS_BUCKET: waveterm-github-artifacts/staging-w2
     RELEASES_BUCKET: dl.waveterm.dev/releases-w2
+    WINGET_PACKAGE: CommandLine.Wave
 
 tasks:
     electron:dev:
@@ -229,6 +230,16 @@ tasks:
                     echo "https://$SUFFIX"
                 fi
             done
+
+    artifacts:publish:winget:*:
+        desc: Submits a version bump request to WinGet for the latest release.
+        status:
+            - exit {{if contains UP_VERSION "beta"}}0{{else}}1{{end}}
+        vars:
+            UP_VERSION: '{{ replace "v" "" (index .MATCH 0)}}'
+        cmd: |
+            iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+            .\wingetcreate.exe update {{.WINGET_PACKAGE}} -s -v {{.UP_VERSION}} -u "https://{{.RELEASES_BUCKET}}/{{.APP_NAME}}-win32-x64-{{.UP_VERSION}}.exe" -t $env:GITHUB_TOKEN
 
     yarn:
         desc: Runs `yarn`


### PR DESCRIPTION
This will only bump the version when we publish a latest release, not a beta one. It'll automatically create a PR to the [winget-pkgs ](https://github.com/microsoft/winget-pkgs) repo.

Draft until my New Package PR gets merged: https://github.com/microsoft/winget-pkgs/pull/185133