### PR TITLE
fix: allow capital letters on host match

### DIFF
--- a/pkg/remote/connutil.go
+++ b/pkg/remote/connutil.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-var userHostRe = regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9._@\\-]*@)?([a-z0-9][a-z0-9.-]*)(?::([0-9]+))?$`)
+var userHostRe = regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9._@\\-]*@)?([a-zA-Z0-9][a-zA-Z0-9.-]*)(?::([0-9]+))?$`)
 
 func ParseOpts(input string) (*SSHOpts, error) {
 	m := userHostRe.FindStringSubmatch(input)


### PR DESCRIPTION
While matching [user@]host[:port], we previously did not allow capital letters in host.

While this makes sense for a hostname, it does not make sense to make that restriction for a host. Since this can match on both, we must widen it to accept characters allowed in host.