### PR TITLE
Remove release creation race in build helper

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -147,6 +147,7 @@ jobs:
                   STATIC_DOCSITE_PATH: ${{env.STATIC_DOCSITE_PATH}}
               shell: powershell # electron-builder's Windows code signing package has some compatibility issues with pwsh, so we need to use Windows Powershell
 
+            # Upload artifacts to the S3 staging and to the workflow output for the draft release job
             - name: Upload to S3 staging
               if: github.event_name != 'workflow_dispatch'
               run: task artifacts:upload

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -162,6 +162,7 @@ jobs:
                   path: make
     create-release:
         runs-on: ubuntu-latest
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         steps:
             - name: Download artifacts
               uses: actions/download-artifact@v4
@@ -169,7 +170,6 @@ jobs:
                   path: make
                   merge-multiple: true
             - name: Create draft release
-              if: github.event_name != 'workflow_dispatch'
               uses: softprops/action-gh-release@v2
               with:
                   prerelease: ${{ contains(github.ref_name, '-beta') }}

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -154,6 +154,19 @@ jobs:
                   AWS_ACCESS_KEY_ID: "${{ secrets.ARTIFACTS_KEY_ID }}"
                   AWS_SECRET_ACCESS_KEY: "${{ secrets.ARTIFACTS_KEY_SECRET }}"
                   AWS_DEFAULT_REGION: us-west-2
+            - name: Upload artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ matrix.runner }}
+                  path: make
+    create-release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Download artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  path: make
+                  merge-multiple: true
             - name: Create draft release
               if: github.event_name != 'workflow_dispatch'
               uses: softprops/action-gh-release@v2
@@ -173,9 +186,3 @@ jobs:
                       make/*.snap
                       make/*.flatpak
                       make/*.AppImage
-            - name: Upload build artifacts to workflow (manual runs only)
-              if: github.event_name == 'workflow_dispatch'
-              uses: actions/upload-artifact@v4
-              with:
-                  name: ${{matrix.runner}}
-                  path: make


### PR DESCRIPTION
There was a race condition in the Build Helper where if multiple runners got to the "Create draft release" step at the same time, we could get duplicate releases created. Now, each of the build runners will upload the artifacts to the workflow artifact feed. Then, a single runner will create the draft release.