### PR TITLE
fix: ignore the match statement in ssh config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,6 @@ require (
 	golang.org/x/net v0.29.0 // indirect
 )
 
-replace github.com/kevinburke/ssh_config => github.com/wavetermdev/ssh_config v0.0.0-20240306041034-17e2087ebde2
+replace github.com/kevinburke/ssh_config => github.com/wavetermdev/ssh_config v0.0.0-20241027232332-ed124367682d
 
 replace github.com/creack/pty => github.com/photostorm/pty v1.1.19-0.20230903182454-31354506054b

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/ubuntu/gowsl v0.0.0-20240906163211-049fd49bd93b h1:wFBKF5k5xbJQU8bYgc
 github.com/ubuntu/gowsl v0.0.0-20240906163211-049fd49bd93b/go.mod h1:N1CYNinssZru+ikvYTgVbVeSi21thHUTCoJ9xMvWe+s=
 github.com/wavetermdev/htmltoken v0.1.0 h1:RMdA9zTfnYa5jRC4RRG3XNoV5NOP8EDxpaVPjuVz//Q=
 github.com/wavetermdev/htmltoken v0.1.0/go.mod h1:5FM0XV6zNYiNza2iaTcFGj+hnMtgqumFHO31Z8euquk=
-github.com/wavetermdev/ssh_config v0.0.0-20240306041034-17e2087ebde2 h1:onqZrJVap1sm15AiIGTfWzdr6cEF0KdtddeuuOVhzyY=
-github.com/wavetermdev/ssh_config v0.0.0-20240306041034-17e2087ebde2/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
+github.com/wavetermdev/ssh_config v0.0.0-20241027232332-ed124367682d h1:ArHaUBaiQWUqBzM2G/oLlm3Be0kwUMDt9vTNOWIfOd0=
+github.com/wavetermdev/ssh_config v0.0.0-20241027232332-ed124367682d/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=

--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -554,7 +554,7 @@ func resolveSshConfigPatterns(configFiles []string) ([]string, error) {
 			continue
 		}
 
-		cfg, _ := ssh_config.Decode(fd)
+		cfg, _ := ssh_config.Decode(fd, true)
 		for _, host := range cfg.Hosts {
 			// for each host, find the first good alias
 			for _, hostPattern := range host.Patterns {
@@ -620,7 +620,7 @@ func GetConnectionsFromConfig() ([]string, error) {
 	localConfig := filepath.Join(home, ".ssh", "config")
 	systemConfig := filepath.Join("/etc", "ssh", "config")
 	sshConfigFiles := []string{localConfig, systemConfig}
-	ssh_config.ReloadConfigs()
+	remote.WaveSshConfigUserSettings().ReloadConfigs()
 
 	return resolveSshConfigPatterns(sshConfigFiles)
 }

--- a/pkg/remote/connutil.go
+++ b/pkg/remote/connutil.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kevinburke/ssh_config"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -339,14 +338,14 @@ func IsPowershell(shellPath string) bool {
 }
 
 func NormalizeConfigPattern(pattern string) string {
-	userName, err := ssh_config.GetStrict(pattern, "User")
+	userName, err := WaveSshConfigUserSettings().GetStrict(pattern, "User")
 	if err != nil {
 		localUser, err := user.Current()
 		if err == nil {
 			userName = localUser.Username
 		}
 	}
-	port, err := ssh_config.GetStrict(pattern, "Port")
+	port, err := WaveSshConfigUserSettings().GetStrict(pattern, "Port")
 	if err != nil {
 		port = "22"
 	}


### PR DESCRIPTION
This change will skip over match statements in the ssh config without panicking. Note that this change still does not add match statement parsing--it merely makes it possible to continue parsing if the match keyword is present.