### PR TITLE
Sysinfo Plot Height

### DIFF
--- a/frontend/app/view/sysinfo/sysinfo.less
+++ b/frontend/app/view/sysinfo/sysinfo.less
@@ -1,12 +1,12 @@
 // Copyright 2024, Command Line Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-.scrollable {
+.sysinfo-view {
     flex-flow: column nowrap;
     flex-grow: 1;
     margin-bottom: 0;
     overflow-y: auto;
-    .sysinfo-view {
+    .sysinfo-inner {
         width: 100%;
         height: 100%;
         display: grid;

--- a/frontend/app/view/sysinfo/sysinfo.tsx
+++ b/frontend/app/view/sysinfo/sysinfo.tsx
@@ -531,8 +531,12 @@ const SysinfoViewInner = React.memo(({ model }: SysinfoViewProps) => {
     }
 
     return (
-        <OverlayScrollbarsComponent ref={osRef} className="scrollable" options={{ scrollbars: { autoHide: "leave" } }}>
-            <div className={clsx("sysinfo-view", { "two-columns": cols2 })}>
+        <OverlayScrollbarsComponent
+            ref={osRef}
+            className="sysinfo-view"
+            options={{ scrollbars: { autoHide: "leave" } }}
+        >
+            <div className={clsx("sysinfo-inner", { "two-columns": cols2 })}>
                 {yvals.map((yval, idx) => {
                     return (
                         <SingleLinePlot


### PR DESCRIPTION
This makes two small changes
- renames a class to resolve two css classes having the same name
- ensures sysinfo's outermost element follows the *-view pattern