### PR TITLE
Fix WinGet version bump

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,6 +46,9 @@ jobs:
               with:
                   version: 3.x
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Install wingetcreate
+              run: winget install wingetcreate
+              shell: pwsh
             - name: Submit WinGet version bump
               run: "task artifacts:winget:publish:${{ github.ref_name }}"
               env:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -247,8 +247,7 @@ tasks:
         vars:
             UP_VERSION: '{{ replace "v" "" (index .MATCH 0)}}'
         cmd: |
-            Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-            .\wingetcreate.exe update {{.WINGET_PACKAGE}} -s -v {{.UP_VERSION}} -u "https://{{.RELEASES_BUCKET}}/{{.APP_NAME}}-win32-x64-{{.UP_VERSION}}.msi" -t $env:GITHUB_TOKEN
+            wingetcreate update {{.WINGET_PACKAGE}} -s -v {{.UP_VERSION}} -u "https://{{.RELEASES_BUCKET}}/{{.APP_NAME}}-win32-x64-{{.UP_VERSION}}.msi" -t $env:GITHUB_TOKEN
 
     yarn:
         desc: Runs `yarn`


### PR DESCRIPTION
Use WinGet to install `wingetcreate`, rather than using Invoke-WebRequest