### PR TITLE
Various updater fixes

### DIFF
--- a/frontend/wave.ts
+++ b/frontend/wave.ts
@@ -92,6 +92,7 @@ async function reinitWave() {
     document.title = `Wave Terminal - ${initialTab.name}`; // TODO update with tab name change
     getApi().setWindowInitStatus("wave-ready");
     globalStore.set(atoms.reinitVersion, globalStore.get(atoms.reinitVersion) + 1);
+    globalStore.set(atoms.updaterStatusAtom, getApi().getUpdaterStatus());
 }
 
 function reloadAllWorkspaceTabs(ws: Workspace) {


### PR DESCRIPTION
- Fixes updater status not showing on tabs that were previously unloaded.
- Fixes updater status showing as error when not connected to the internet
- Adds delay after setting installing status to avoid race condition with any window close event handlers. This may fix #1167 