### PR TITLE
restore old tab naming logic

### DIFF
--- a/pkg/wcore/wcore.go
+++ b/pkg/wcore/wcore.go
@@ -93,11 +93,15 @@ func CreateTab(ctx context.Context, windowId string, tabName string, activateTab
 		return "", fmt.Errorf("error getting window: %w", err)
 	}
 	if tabName == "" {
+		ws, err := wstore.DBMustGet[*waveobj.Workspace](ctx, windowData.WorkspaceId)
+		if err != nil {
+			return "", fmt.Errorf("error getting workspace: %w", err)
+		}
+		tabName = "T" + fmt.Sprint(len(ws.TabIds)+1)
 		client, err := wstore.DBGetSingleton[*waveobj.Client](ctx)
 		if err != nil {
 			return "", fmt.Errorf("error getting client: %w", err)
 		}
-		tabName = "T" + fmt.Sprint(client.NextTabId)
 		client.NextTabId++
 		err = wstore.DBUpdate(ctx, client)
 		if err != nil {


### PR DESCRIPTION
fixes the tab naming confusion going on in #1167 