### PR TITLE
Fix bad contrast in the platform pill in the docsite

### DIFF
--- a/docs/src/components/platformcontext.css
+++ b/docs/src/components/platformcontext.css
@@ -22,7 +22,7 @@
 
 .pill-option.active {
     background-color: var(--ifm-color-primary);
-    color: var(--ifm-color-secondary-lightest);
+    color: var(--ifm-color-secondary-contrast-background);
     font-weight: bold;
 }
 


### PR DESCRIPTION
White text on green breaks site accessibility standards so I'm updating the active text color for the platform picker pill to be `--ifm-color-secondary-contrast-foreground`, which is white on light mode and light grey on dark mode.