### PR TITLE
Fix docsite path error in docsite.go

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -135,7 +135,7 @@ jobs:
                   path: ${{env.STATIC_DOCSITE_PATH}}
 
             - name: tree
-              run: tree -L 3
+              run: tree -L 3 ..
 
             # Build and upload packages
             - name: Build (Linux)

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -32,7 +32,7 @@ jobs:
             - name: Upload Build Artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: ${{env.STATIC_DOCSITE_PATH}}
+                  name: docsite
                   path: docs/build
     build-app:
         needs: build-docsite
@@ -65,7 +65,7 @@ jobs:
             # The pre-installed version of the AWS CLI has a segfault problem so we'll install it via Homebrew instead.
             - name: Upgrade AWS CLI (Mac only)
               if: matrix.platform == 'darwin'
-              run: brew install awscli && brew install tree
+              run: brew install awscli
 
             # The version of FPM that comes bundled with electron-builder doesn't include a Linux ARM target. Installing Gems onto the runner is super quick so we'll just do this for all targets.
             - name: Install FPM (not Windows)
@@ -131,11 +131,8 @@ jobs:
             - name: Download embedded docsite
               uses: actions/download-artifact@v4
               with:
-                  name: ${{env.STATIC_DOCSITE_PATH}}
+                  name: docsite
                   path: ${{env.STATIC_DOCSITE_PATH}}
-
-            - name: tree
-              run: tree -L 3 ..
 
             # Build and upload packages
             - name: Build (Linux)

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -32,7 +32,7 @@ jobs:
             - name: Upload Build Artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: docsite
+                  name: ${{env.STATIC_DOCSITE_PATH}}
                   path: docs/build
     build-app:
         needs: build-docsite
@@ -131,8 +131,7 @@ jobs:
             - name: Download embedded docsite
               uses: actions/download-artifact@v4
               with:
-                  name: docsite
-                  path: ${{env.STATIC_DOCSITE_PATH}}
+                  name: ${{env.STATIC_DOCSITE_PATH}}
 
             # Build and upload packages
             - name: Build (Linux)

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -132,6 +132,7 @@ jobs:
               uses: actions/download-artifact@v4
               with:
                   name: ${{env.STATIC_DOCSITE_PATH}}
+                  path: ./${{env.STATIC_DOCSITE_PATH}}
 
             # Build and upload packages
             - name: Build (Linux)

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -65,7 +65,7 @@ jobs:
             # The pre-installed version of the AWS CLI has a segfault problem so we'll install it via Homebrew instead.
             - name: Upgrade AWS CLI (Mac only)
               if: matrix.platform == 'darwin'
-              run: brew install awscli
+              run: brew install awscli && brew install tree
 
             # The version of FPM that comes bundled with electron-builder doesn't include a Linux ARM target. Installing Gems onto the runner is super quick so we'll just do this for all targets.
             - name: Install FPM (not Windows)
@@ -132,7 +132,10 @@ jobs:
               uses: actions/download-artifact@v4
               with:
                   name: ${{env.STATIC_DOCSITE_PATH}}
-                  path: ./${{env.STATIC_DOCSITE_PATH}}
+                  path: ${{env.STATIC_DOCSITE_PATH}}
+
+            - name: tree
+              run: tree -L 3
 
             # Build and upload packages
             - name: Build (Linux)

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ artifacts/
 storybook-static/
 
 test-results.xml
+
+docsite/

--- a/pkg/docsite/docsite.go
+++ b/pkg/docsite/docsite.go
@@ -21,7 +21,7 @@ func GetDocsiteHandler() http.Handler {
 			log.Printf("Found static site at %s, serving\n", docsiteStaticPath)
 			docsiteHandler = http.FileServer(HTMLDir{http.Dir(docsiteStaticPath)})
 		} else {
-			log.Println("Did not find static site, serving not found handler")
+			log.Printf("Did not find static site at %s, serving not found handler. stat: %v, err: %v\n", docsiteStaticPath, stat, err)
 			docsiteHandler = http.NotFoundHandler()
 		}
 	}

--- a/pkg/docsite/docsite.go
+++ b/pkg/docsite/docsite.go
@@ -9,11 +9,10 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/wavebase"
 )
 
-var docsiteStaticPath = filepath.Join(wavebase.GetWaveAppPath(), "docsite")
-
 var docsiteHandler http.Handler
 
 func GetDocsiteHandler() http.Handler {
+	docsiteStaticPath := filepath.Join(wavebase.GetWaveAppPath(), "docsite")
 	stat, err := os.Stat(docsiteStaticPath)
 	if docsiteHandler == nil {
 		log.Println("Docsite is nil, initializing")


### PR DESCRIPTION
The docsite path was being initialized as a global variable. This wasn't an issue before we were caching and unsetting the env vars, but now that `wavebase.GetWaveAppPath()` returns the contents of the cached variable, we need to read its value at runtime, since it won't be set at the time the global variable is initialized.