### PR TITLE
Add ephemeral block support

### DIFF
--- a/frontend/app/block/block.less
+++ b/frontend/app/block/block.less
@@ -272,7 +272,8 @@
         }
 
         &.magnified {
-            background-color: rgb(from var(--block-bg-color) r g b / 70%);
+            background-color: rgb(from var(--block-bg-color) r g b / 60%);
+            backdrop-filter: blur(10px);
         }
 
         .connstatus-overlay {

--- a/frontend/app/block/block.less
+++ b/frontend/app/block/block.less
@@ -61,7 +61,7 @@
     }
 
     &.block-preview.block-frame-default .block-frame-default-inner .block-frame-default-header {
-        background-color: rgba(0, 0, 0, 0.7);
+        background-color: rgb(from var(--block-bg-color) r g b / 70%);
     }
 
     &.block-frame-default {
@@ -254,7 +254,7 @@
             }
 
             .block-frame-preview {
-                background-color: rgba(0, 0, 0, 0.7);
+                background-color: rgb(from var(--block-bg-color) r g b / 70%);
                 width: 100%;
                 flex-grow: 1;
                 border-bottom-left-radius: var(--block-border-radius);
@@ -269,6 +269,10 @@
                     margin: -30px 0 0 0;
                 }
             }
+        }
+
+        &.magnified {
+            background-color: rgb(from var(--block-bg-color) r g b / 70%);
         }
 
         .connstatus-overlay {
@@ -385,7 +389,7 @@
 
             &.show-block-mask .block-mask-inner {
                 margin-top: var(--header-height); // TODO fix this magic
-                background-color: rgba(0, 0, 0, 0.5);
+                background-color: rgb(from var(--block-bg-color) r g b / 50%);
                 height: calc(100% - var(--header-height));
                 width: 100%;
                 display: flex;

--- a/frontend/app/block/block.less
+++ b/frontend/app/block/block.less
@@ -271,7 +271,8 @@
             }
         }
 
-        &.magnified {
+        &.magnified,
+        &.ephemeral {
             background-color: rgb(from var(--block-bg-color) r g b / 60%);
             backdrop-filter: blur(10px);
         }

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -180,8 +180,9 @@ const BlockFrame_Header = ({
     const preIconButton = util.useAtomValueSafe(viewModel?.preIconButton);
     let headerTextUnion = util.useAtomValueSafe(viewModel?.viewText);
     const magnified = jotai.useAtomValue(nodeModel.isMagnified);
+    const ephemeral = jotai.useAtomValue(nodeModel.isEphemeral);
     const manageConnection = util.useAtomValueSafe(viewModel?.manageConnection);
-    const dragHandleRef = preview || magnified ? null : nodeModel.dragHandleRef;
+    const dragHandleRef = preview ? null : nodeModel.dragHandleRef;
 
     if (blockData?.meta?.["frame:title"]) {
         viewName = blockData.meta["frame:title"];
@@ -235,7 +236,12 @@ const BlockFrame_Header = ({
     }
 
     return (
-        <div className="block-frame-default-header" ref={dragHandleRef} onContextMenu={onContextMenu}>
+        <div
+            className="block-frame-default-header"
+            ref={dragHandleRef}
+            onContextMenu={onContextMenu}
+            draggable={!(preview || magnified || ephemeral)}
+        >
             {preIconButtonElem}
             <div className="block-frame-default-header-iconview">
                 {viewIconElem}
@@ -323,7 +329,6 @@ const ConnStatusOverlay = React.memo(
         const [overlayRefCallback, _, domRect] = useDimensionsWithCallbackRef(30);
         const width = domRect?.width;
         const [showError, setShowError] = React.useState(false);
-        const blockNum = jotai.useAtomValue(nodeModel.blockNum);
 
         React.useEffect(() => {
             if (width) {

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -120,6 +120,7 @@ function computeEndIcons(
     const endIconsElem: JSX.Element[] = [];
     const endIconButtons = util.useAtomValueSafe(viewModel?.endIconButtons);
     const magnified = jotai.useAtomValue(nodeModel.isMagnified);
+    const ephemeral = jotai.useAtomValue(nodeModel.isEphemeral);
     const numLeafs = jotai.useAtomValue(nodeModel.numLeafs);
     const magnifyDisabled = numLeafs <= 1;
 
@@ -133,14 +134,27 @@ function computeEndIcons(
         click: onContextMenu,
     };
     endIconsElem.push(<IconButton key="settings" decl={settingsDecl} className="block-frame-settings" />);
-    endIconsElem.push(
-        <OptMagnifyButton
-            key="unmagnify"
-            magnified={magnified}
-            toggleMagnify={nodeModel.toggleMagnify}
-            disabled={magnifyDisabled}
-        />
-    );
+    if (ephemeral) {
+        const addToLayoutDecl: IconButtonDecl = {
+            elemtype: "iconbutton",
+            icon: "circle-plus",
+            title: "Add to Layout",
+            click: () => {
+                nodeModel.addEphemeralNodeToLayout();
+            },
+        };
+        endIconsElem.push(<IconButton key="add-to-layout" decl={addToLayoutDecl} />);
+    } else {
+        endIconsElem.push(
+            <OptMagnifyButton
+                key="unmagnify"
+                magnified={magnified}
+                toggleMagnify={nodeModel.toggleMagnify}
+                disabled={magnifyDisabled}
+            />
+        );
+    }
+
     const closeDecl: IconButtonDecl = {
         elemtype: "iconbutton",
         icon: "xmark-large",
@@ -167,7 +181,7 @@ const BlockFrame_Header = ({
     let headerTextUnion = util.useAtomValueSafe(viewModel?.viewText);
     const magnified = jotai.useAtomValue(nodeModel.isMagnified);
     const manageConnection = util.useAtomValueSafe(viewModel?.manageConnection);
-    const dragHandleRef = preview ? null : nodeModel.dragHandleRef;
+    const dragHandleRef = preview || magnified ? null : nodeModel.dragHandleRef;
 
     if (blockData?.meta?.["frame:title"]) {
         viewName = blockData.meta["frame:title"];

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -435,6 +435,8 @@ const BlockFrame_Default_Component = (props: BlockFrameProps) => {
         return jotai.atom(false);
     }) as jotai.PrimitiveAtom<boolean>;
     const connModalOpen = jotai.useAtomValue(changeConnModalAtom);
+    const isMagnified = jotai.useAtomValue(nodeModel.isMagnified);
+    const isEphemeral = jotai.useAtomValue(nodeModel.isEphemeral);
 
     const connBtnRef = React.useRef<HTMLDivElement>();
     React.useEffect(() => {
@@ -490,6 +492,8 @@ const BlockFrame_Default_Component = (props: BlockFrameProps) => {
                 "block-focused": isFocused || preview,
                 "block-preview": preview,
                 "block-no-highlight": numBlocksInTab === 1,
+                ephemeral: isEphemeral,
+                magnified: isMagnified,
             })}
             data-blockid={nodeModel.blockId}
             onClick={blockModel?.onClick}

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -341,17 +341,21 @@ function getApi(): ElectronApi {
     return (window as any).api;
 }
 
-async function createBlock(blockDef: BlockDef, magnified = false): Promise<string> {
+async function createBlock(blockDef: BlockDef, magnified = false, ephemeral = false): Promise<string> {
+    const tabId = globalStore.get(atoms.staticTabId);
+    const layoutModel = getLayoutModelForTabById(tabId);
     const rtOpts: RuntimeOpts = { termsize: { rows: 25, cols: 80 } };
     const blockId = await ObjectService.CreateBlock(blockDef, rtOpts);
+    if (ephemeral) {
+        layoutModel.newEphemeralNode(blockId);
+        return blockId;
+    }
     const insertNodeAction: LayoutTreeInsertNodeAction = {
         type: LayoutTreeActionType.InsertNode,
         node: newLayoutNode(undefined, undefined, undefined, { blockId }),
         magnified,
         focused: true,
     };
-    const tabId = globalStore.get(atoms.staticTabId);
-    const layoutModel = getLayoutModelForTabById(tabId);
     layoutModel.treeReducer(insertNodeAction);
     return blockId;
 }

--- a/frontend/app/theme.less
+++ b/frontend/app/theme.less
@@ -56,10 +56,14 @@
     --zindex-tab-name: 3;
     --zindex-layout-display-container: 0;
     --zindex-layout-last-magnified-node: 1;
-    --zindex-layout-resize-handle: 2;
-    --zindex-layout-placeholder-container: 3;
-    --zindex-layout-overlay-container: 4;
-    --zindex-layout-magnified-node: 5;
+    --zindex-layout-last-ephemeral-node: 2;
+    --zindex-layout-resize-handle: 3;
+    --zindex-layout-placeholder-container: 4;
+    --zindex-layout-overlay-container: 5;
+    --zindex-layout-magnified-node-backdrop: 6;
+    --zindex-layout-magnified-node: 7;
+    --zindex-layout-ephemeral-node-backdrop: 8;
+    --zindex-layout-ephemeral-node: 9;
     --zindex-block-mask-inner: 10;
     --zindex-flash-error-container: 550;
     --zindex-app-background: -1;

--- a/frontend/app/view/waveai/waveai.tsx
+++ b/frontend/app/view/waveai/waveai.tsx
@@ -240,7 +240,7 @@ export class WaveAiModel implements ViewModel {
                                 file: path,
                             },
                         };
-                        await createBlock(blockDef, true);
+                        await createBlock(blockDef, false, true);
                     });
                 },
             });

--- a/frontend/layout/lib/TileLayout.tsx
+++ b/frontend/layout/lib/TileLayout.tsx
@@ -161,8 +161,22 @@ function NodeBackdrops({ layoutModel }: { layoutModel: LayoutModel }) {
 
     return (
         <>
-            {showMagnifiedBackdrop && <div className="magnified-node-backdrop" />}
-            {showEphemeralBackdrop && <div className="ephemeral-node-backdrop" />}
+            {showMagnifiedBackdrop && (
+                <div
+                    className="magnified-node-backdrop"
+                    onClick={() => {
+                        layoutModel.magnifyNodeToggle(magnifiedNodeId);
+                    }}
+                />
+            )}
+            {showEphemeralBackdrop && (
+                <div
+                    className="ephemeral-node-backdrop"
+                    onClick={() => {
+                        layoutModel.closeNode(ephemeralNode?.id);
+                    }}
+                />
+            )}
         </>
     );
 }

--- a/frontend/layout/lib/TileLayout.tsx
+++ b/frontend/layout/lib/TileLayout.tsx
@@ -122,9 +122,6 @@ function TileLayoutComponent({ tabAtom, contents, getCursorPoint }: TileLayoutPr
                 <div key="display" ref={layoutModel.displayContainerRef} className="display-container">
                     <ResizeHandleWrapper layoutModel={layoutModel} />
                     <DisplayNodesWrapper layoutModel={layoutModel} />
-                    {ephemeralNode && (
-                        <DisplayNode key={ephemeralNode.id} layoutModel={layoutModel} node={ephemeralNode} />
-                    )}
                     <NodeBackdrops layoutModel={layoutModel} />
                 </div>
                 <Placeholder key="placeholder" layoutModel={layoutModel} style={{ top: 10000, ...overlayTransform }} />

--- a/frontend/layout/lib/TileLayout.tsx
+++ b/frontend/layout/lib/TileLayout.tsx
@@ -122,6 +122,9 @@ function TileLayoutComponent({ tabAtom, contents, getCursorPoint }: TileLayoutPr
                 <div key="display" ref={layoutModel.displayContainerRef} className="display-container">
                     <ResizeHandleWrapper layoutModel={layoutModel} />
                     <DisplayNodesWrapper layoutModel={layoutModel} />
+                    {ephemeralNode && (
+                        <DisplayNode key={ephemeralNode.id} layoutModel={layoutModel} node={ephemeralNode} />
+                    )}
                     <NodeBackdrops layoutModel={layoutModel} />
                 </div>
                 <Placeholder key="placeholder" layoutModel={layoutModel} style={{ top: 10000, ...overlayTransform }} />

--- a/frontend/layout/lib/TileLayout.tsx
+++ b/frontend/layout/lib/TileLayout.tsx
@@ -136,10 +136,33 @@ function NodeBackdrops({ layoutModel }: { layoutModel: LayoutModel }) {
     const ephemeralNode = useAtomValue(layoutModel.ephemeralNode);
     const magnifiedNodeId = useAtomValue(layoutModel.treeStateAtom).magnifiedNodeId;
 
+    const [showMagnifiedBackdrop, setShowMagnifiedBackdrop] = useState(!!ephemeralNode);
+    const [showEphemeralBackdrop, setShowEphemeralBackdrop] = useState(!!magnifiedNodeId);
+
+    const debouncedCallback = useCallback(
+        debounce(100, (callback: () => void) => callback()),
+        []
+    );
+
+    useEffect(() => {
+        if (magnifiedNodeId && !showMagnifiedBackdrop) {
+            debouncedCallback(() => setShowMagnifiedBackdrop(true));
+        }
+        if (!magnifiedNodeId) {
+            setShowMagnifiedBackdrop(false);
+        }
+        if (ephemeralNode && !showEphemeralBackdrop) {
+            debouncedCallback(() => setShowEphemeralBackdrop(true));
+        }
+        if (!ephemeralNode) {
+            setShowEphemeralBackdrop(false);
+        }
+    }, [ephemeralNode, magnifiedNodeId]);
+
     return (
         <>
-            {magnifiedNodeId && <div className="magnified-node-backdrop" />}
-            {ephemeralNode && <div className="ephemeral-node-backdrop" />}
+            {showMagnifiedBackdrop && <div className="magnified-node-backdrop" />}
+            {showEphemeralBackdrop && <div className="ephemeral-node-backdrop" />}
         </>
     );
 }

--- a/frontend/layout/lib/TileLayout.tsx
+++ b/frontend/layout/lib/TileLayout.tsx
@@ -57,6 +57,7 @@ function TileLayoutComponent({ tabAtom, contents, getCursorPoint }: TileLayoutPr
     const setActiveDrag = useSetAtom(layoutModel.activeDrag);
     const setReady = useSetAtom(layoutModel.ready);
     const isResizing = useAtomValue(layoutModel.isResizing);
+    const ephemeralNode = useAtomValue(layoutModel.ephemeralNode);
 
     const { activeDrag, dragClientOffset } = useDragLayer((monitor) => ({
         activeDrag: monitor.isDragging(),
@@ -121,6 +122,7 @@ function TileLayoutComponent({ tabAtom, contents, getCursorPoint }: TileLayoutPr
                 <div key="display" ref={layoutModel.displayContainerRef} className="display-container">
                     <ResizeHandleWrapper layoutModel={layoutModel} />
                     <DisplayNodesWrapper layoutModel={layoutModel} />
+                    <NodeBackdrops layoutModel={layoutModel} />
                 </div>
                 <Placeholder key="placeholder" layoutModel={layoutModel} style={{ top: 10000, ...overlayTransform }} />
                 <OverlayNodeWrapper layoutModel={layoutModel} />
@@ -129,6 +131,18 @@ function TileLayoutComponent({ tabAtom, contents, getCursorPoint }: TileLayoutPr
     );
 }
 export const TileLayout = memo(TileLayoutComponent) as typeof TileLayoutComponent;
+
+function NodeBackdrops({ layoutModel }: { layoutModel: LayoutModel }) {
+    const ephemeralNode = useAtomValue(layoutModel.ephemeralNode);
+    const magnifiedNodeId = useAtomValue(layoutModel.treeStateAtom).magnifiedNodeId;
+
+    return (
+        <>
+            {magnifiedNodeId && <div className="magnified-node-backdrop" />}
+            {ephemeralNode && <div className="ephemeral-node-backdrop" />}
+        </>
+    );
+}
 
 interface DisplayNodesWrapperProps {
     /**
@@ -173,7 +187,6 @@ const DisplayNode = ({ layoutModel, node }: DisplayNodeProps) => {
         () => ({
             type: dragItemType,
             item: () => node,
-            canDrag: () => !addlProps?.isMagnifiedNode,
             collect: (monitor) => ({
                 isDragging: monitor.isDragging(),
             }),
@@ -243,8 +256,6 @@ const DisplayNode = ({ layoutModel, node }: DisplayNodeProps) => {
         <div
             className={clsx("tile-node", {
                 dragging: isDragging,
-                magnified: addlProps?.isMagnifiedNode,
-                "last-magnified": addlProps?.isLastMagnifiedNode,
             })}
             key={node.id}
             ref={tileNodeRef}

--- a/frontend/layout/lib/layoutModel.ts
+++ b/frontend/layout/lib/layoutModel.ts
@@ -517,7 +517,7 @@ export class LayoutModel {
             // Process ephemeral node, if present.
             const ephemeralNode = this.getter(this.ephemeralNode);
             if (ephemeralNode) {
-                this.updateEphemeralNodeProps(ephemeralNode, newAdditionalProps, boundingRect);
+                this.updateEphemeralNodeProps(ephemeralNode, newAdditionalProps, newLeafs, boundingRect);
             }
 
             this.treeState.leafOrder = getLeafOrder(newLeafs, newAdditionalProps);
@@ -1019,12 +1019,17 @@ export class LayoutModel {
     }
 
     newEphemeralNode(blockId: string) {
+        if (this.getter(this.ephemeralNode)) {
+            this.closeNode(this.getter(this.ephemeralNode).id);
+        }
+
         const ephemeralNode = newLayoutNode(undefined, undefined, undefined, { blockId });
         this.setter(this.ephemeralNode, ephemeralNode);
 
         const addlProps = this.getter(this.additionalProps);
+        const leafs = this.getter(this.leafs);
         const boundingRect = this.getBoundingRect();
-        this.updateEphemeralNodeProps(ephemeralNode, addlProps, boundingRect);
+        this.updateEphemeralNodeProps(ephemeralNode, addlProps, leafs, boundingRect);
         this.setter(this.additionalProps, addlProps);
         this.focusNode(ephemeralNode.id);
     }
@@ -1050,6 +1055,7 @@ export class LayoutModel {
     updateEphemeralNodeProps(
         node: LayoutNode,
         addlPropsMap: Record<string, LayoutNodeAdditionalProps>,
+        leafs: LayoutNode[],
         boundingRect: Dimensions
     ) {
         const transform = setTransform(
@@ -1064,6 +1070,7 @@ export class LayoutModel {
             "var(--zindex-layout-ephemeral-node)"
         );
         addlPropsMap[node.id] = { treeKey: "-1", transform };
+        leafs.push(node);
     }
 
     /**

--- a/frontend/layout/lib/layoutModel.ts
+++ b/frontend/layout/lib/layoutModel.ts
@@ -832,7 +832,7 @@ export class LayoutModel {
                     const ephemeralNode = get(this.ephemeralNode);
                     return ephemeralNode?.id === nodeid;
                 }),
-                addEphemeralNodeToLayout: this.addEphemeralNodeToLayout,
+                addEphemeralNodeToLayout: () => this.addEphemeralNodeToLayout(),
                 animationTimeS: this.animationTimeS,
                 ready: this.ready,
                 disablePointerEvents: this.activeDrag,
@@ -946,10 +946,15 @@ export class LayoutModel {
      */
     focusNode(nodeId: string) {
         if (this.focusedNodeId === nodeId) return;
-        const layoutNode = findNode(this.treeState?.rootNode, nodeId);
+        let layoutNode = findNode(this.treeState?.rootNode, nodeId);
         if (!layoutNode) {
-            console.error("unable to focus node, cannot find it in tree", nodeId);
-            return;
+            const ephemeralNode = this.getter(this.ephemeralNode);
+            if (ephemeralNode?.id === nodeId) {
+                layoutNode = ephemeralNode;
+            } else {
+                console.error("unable to focus node, cannot find it in tree", nodeId);
+                return;
+            }
         }
         const action: LayoutTreeFocusNodeAction = {
             type: LayoutTreeActionType.FocusNode,
@@ -1021,6 +1026,7 @@ export class LayoutModel {
         const boundingRect = this.getBoundingRect();
         this.updateEphemeralNodeProps(ephemeralNode, addlProps, boundingRect);
         this.setter(this.additionalProps, addlProps);
+        this.focusNode(ephemeralNode.id);
     }
 
     addEphemeralNodeToLayout() {
@@ -1048,10 +1054,10 @@ export class LayoutModel {
     ) {
         const transform = setTransform(
             {
-                top: boundingRect.height * 0.1,
-                left: boundingRect.width * 0.1,
-                width: boundingRect.width * 0.8,
-                height: boundingRect.height * 0.8,
+                top: boundingRect.height * 0.075,
+                left: boundingRect.width * 0.075,
+                width: boundingRect.width * 0.85,
+                height: boundingRect.height * 0.85,
             },
             true,
             true,

--- a/frontend/layout/lib/tilelayout.less
+++ b/frontend/layout/lib/tilelayout.less
@@ -113,8 +113,7 @@
         left: 0;
         width: 100%;
         height: 100%;
-        // background-color: rgb(from var(--block-bg-color) r g b / 40%);
-        backdrop-filter: blur(4px);
+        backdrop-filter: blur(2px);
     }
 
     .magnified-node-backdrop {

--- a/frontend/layout/lib/tilelayout.less
+++ b/frontend/layout/lib/tilelayout.less
@@ -113,8 +113,8 @@
         left: 0;
         width: 100%;
         height: 100%;
-        background-color: var(--block-bg-color);
-        backdrop-filter: blur(2px);
+        // background-color: rgb(from var(--block-bg-color) r g b / 40%);
+        backdrop-filter: blur(4px);
     }
 
     .magnified-node-backdrop {

--- a/frontend/layout/lib/tilelayout.less
+++ b/frontend/layout/lib/tilelayout.less
@@ -84,14 +84,6 @@
             backdrop-filter: blur(8px);
         }
 
-        &.magnified {
-            background-color: var(--block-bg-solid-color);
-            z-index: var(--zindex-layout-magnified-node);
-        }
-        &.last-magnified {
-            z-index: var(--zindex-layout-last-magnified-node);
-        }
-
         .tile-leaf {
             overflow: hidden;
         }
@@ -109,9 +101,28 @@
             }
         }
 
-        &:not(:only-child, .magnified) .tile-leaf {
+        &:not(:only-child) .tile-leaf {
             padding: calc(var(--gap-size-px) / 2);
         }
+    }
+
+    .magnified-node-backdrop,
+    .ephemeral-node-backdrop {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: var(--block-bg-color);
+        backdrop-filter: blur(2px);
+    }
+
+    .magnified-node-backdrop {
+        z-index: var(--zindex-layout-magnified-node-backdrop);
+    }
+
+    .ephemeral-node-backdrop {
+        z-index: var(--zindex-layout-ephemeral-node-backdrop);
     }
 
     &.animate {

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -332,8 +332,7 @@ export interface LayoutNodeAdditionalProps {
     rect?: Dimensions;
     pixelToSizeRatio?: number;
     resizeHandles?: ResizeHandleProps[];
-    isMagnifiedNode?: boolean;
-    isLastMagnifiedNode?: boolean;
+    isLastEphemeralNode?: boolean;
 }
 
 export interface NodeModel {
@@ -343,10 +342,12 @@ export interface NodeModel {
     numLeafs: Atom<number>;
     nodeId: string;
     blockId: string;
+    addEphemeralNodeToLayout: () => void;
     animationTimeS: Atom<number>;
     isResizing: Atom<boolean>;
     isFocused: Atom<boolean>;
     isMagnified: Atom<boolean>;
+    isEphemeral: Atom<boolean>;
     ready: Atom<boolean>;
     disablePointerEvents: Atom<boolean>;
     toggleMagnify: () => void;

--- a/frontend/layout/lib/utils.ts
+++ b/frontend/layout/lib/utils.ts
@@ -61,7 +61,8 @@ export function determineDropDirection(dimensions?: Dimensions, offset?: XYCoord
 export function setTransform(
     { top, left, width, height }: Dimensions,
     setSize = true,
-    roundVals = true
+    roundVals = true,
+    zIndex?: number | string
 ): CSSProperties {
     // Replace unitless items with px
     const topRounded = roundVals ? Math.floor(top) : top;
@@ -80,6 +81,7 @@ export function setTransform(
         width: setSize ? `${widthRounded}px` : undefined,
         height: setSize ? `${heightRounded}px` : undefined,
         position: "absolute",
+        zIndex: zIndex,
     };
 }
 


### PR DESCRIPTION
Ephemeral blocks can now be added to the LayoutModel for a tab. Only one ephemeral block can exist at a time. It is placed above all other blocks, including the magnified blocks.

Updates how magnified and ephemeral blocks overlay the other blocks. Now, there's a blurred backdrop behind them that will obscure the other blocks. As a result of this, the overlayed blocks are now translucent.