### PR TITLE
Remove the debounce when setting the backdrop for the ephemeral nodes

### DIFF
--- a/frontend/layout/lib/TileLayout.tsx
+++ b/frontend/layout/lib/TileLayout.tsx
@@ -139,14 +139,14 @@ function NodeBackdrops({ layoutModel }: { layoutModel: LayoutModel }) {
     const [showMagnifiedBackdrop, setShowMagnifiedBackdrop] = useState(!!ephemeralNode);
     const [showEphemeralBackdrop, setShowEphemeralBackdrop] = useState(!!magnifiedNodeId);
 
-    const debouncedCallback = useCallback(
-        debounce(100, (callback: () => void) => callback()),
+    const debouncedSetMagnifyBackdrop = useCallback(
+        debounce(100, () => setShowMagnifiedBackdrop(true)),
         []
     );
 
     useEffect(() => {
         if (magnifiedNodeId && !showMagnifiedBackdrop) {
-            debouncedCallback(() => setShowMagnifiedBackdrop(true));
+            debouncedSetMagnifyBackdrop();
         }
         if (!magnifiedNodeId) {
             setShowMagnifiedBackdrop(false);

--- a/frontend/layout/lib/TileLayout.tsx
+++ b/frontend/layout/lib/TileLayout.tsx
@@ -152,7 +152,7 @@ function NodeBackdrops({ layoutModel }: { layoutModel: LayoutModel }) {
             setShowMagnifiedBackdrop(false);
         }
         if (ephemeralNode && !showEphemeralBackdrop) {
-            debouncedCallback(() => setShowEphemeralBackdrop(true));
+            setShowEphemeralBackdrop(true);
         }
         if (!ephemeralNode) {
             setShowEphemeralBackdrop(false);


### PR DESCRIPTION
I added this debounce to delay the blurring of the background nodes when a node was magnified to account for the animation, but it looks weird for the ephemeral nodes since there's no animation when first showing them. When we work on node creation animations maybe I'll add back this delay