### PR TITLE
Update our build workflows to use NodeJS 22

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -11,7 +11,7 @@ on:
     workflow_dispatch:
 env:
     GO_VERSION: "1.22"
-    NODE_VERSION: "20"
+    NODE_VERSION: "22"
     STATIC_DOCSITE_PATH: docsite
 jobs:
     build-docsite:

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -11,7 +11,7 @@ on:
     workflow_dispatch:
 env:
     GO_VERSION: "1.22"
-    NODE_VERSION: "22"
+    NODE_VERSION: 22
     STATIC_DOCSITE_PATH: docsite
 jobs:
     build-docsite:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,7 +23,7 @@ on:
                 type: boolean
                 default: true
 env:
-    NODE_VERSION: "22"
+    NODE_VERSION: 22
 jobs:
     bump-version:
         runs-on: ubuntu-latest

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,7 +23,7 @@ on:
                 type: boolean
                 default: true
 env:
-    NODE_VERSION: "20"
+    NODE_VERSION: "22"
 jobs:
     bump-version:
         runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ on:
         - cron: "36 5 * * 5"
 
 env:
-    NODE_VERSION: "22"
+    NODE_VERSION: 22
     GO_VERSION: "1.22.5"
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ on:
         - cron: "36 5 * * 5"
 
 env:
-    NODE_VERSION: "20"
+    NODE_VERSION: "22"
     GO_VERSION: "1.22.5"
 
 jobs:

--- a/.github/workflows/deploy-docsite.yml
+++ b/.github/workflows/deploy-docsite.yml
@@ -3,7 +3,7 @@ name: Docsite and Storybook CI/CD
 run-name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'Build and Deploy' || 'Test Build' }} Docsite and Storybook
 
 env:
-    NODE_VERSION: 20
+    NODE_VERSION: 22
 
 on:
     push:

--- a/.github/workflows/testdriver.yml
+++ b/.github/workflows/testdriver.yml
@@ -24,7 +24,7 @@ on:
 
 env:
     GO_VERSION: "1.22"
-    NODE_VERSION: "20"
+    NODE_VERSION: "22"
 
 permissions:
     contents: read # To allow the action to read repository contents

--- a/.github/workflows/testdriver.yml
+++ b/.github/workflows/testdriver.yml
@@ -24,7 +24,7 @@ on:
 
 env:
     GO_VERSION: "1.22"
-    NODE_VERSION: "22"
+    NODE_VERSION: 22
 
 permissions:
     contents: read # To allow the action to read repository contents

--- a/BUILD.md
+++ b/BUILD.md
@@ -68,7 +68,7 @@ Download and install Go via your package manager or directly from the website: h
 
 ### NodeJS
 
-Make sure you have a NodeJS 20 LTS installed.
+Make sure you have a NodeJS 22 LTS installed.
 
 See NodeJS's website for platform-specific instructions: https://nodejs.org/en/download
 


### PR DESCRIPTION
NodeJS 20 is almost EOL so I'm updating our workflows to use NodeJS 22. This does not change anything about our app, which will still use NodeJS 20 until Electron shifts away from it. NodeJS 22 is fully backwards-compatible with NodeJS 20 so there's no issue from a testing standpoint.