### PR TITLE
Move docsite build scripts to Taskfile, make the electron tasks depend on them

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -25,15 +25,18 @@ jobs:
               run: |
                   corepack enable
                   yarn install
-              working-directory: docs/
+            - name: Install Task
+              uses: arduino/setup-task@v2
+              with:
+                  version: 3.x
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Build embedded docsite
-              run: yarn build-embedded
-              working-directory: docs/
+              run: task docsite:build:embedded
             - name: Upload Build Artifact
               uses: actions/upload-artifact@v4
               with:
                   name: docsite
-                  path: docs/build
+                  path: docsite
     build-app:
         needs: build-docsite
         outputs:

--- a/.github/workflows/deploy-docsite.yml
+++ b/.github/workflows/deploy-docsite.yml
@@ -37,13 +37,7 @@ jobs:
                   corepack enable
                   yarn install
             - name: Build docsite
-              run: yarn build
-              working-directory: docs/
-
-            - name: Build Storybook
-              run: yarn build-storybook
-            - name: Copy Storybook to docsite output
-              run: cp -r storybook-static docs/build/storybook
+              run: task docsite:build:public
             - name: Upload Build Artifact
               # Only upload the build artifact when pushed to the main branch
               if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy-docsite.yml
+++ b/.github/workflows/deploy-docsite.yml
@@ -32,6 +32,11 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: ${{env.NODE_VERSION}}
+            - name: Install Task
+              uses: arduino/setup-task@v2
+              with:
+                  version: 3.x
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Install yarn
               run: |
                   corepack enable

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,7 @@ tasks:
         cmd: yarn dev
         deps:
             - yarn
+            - docsite:build:embedded
             - build:backend
         env:
             WCLOUD_ENDPOINT: "https://ot2e112zx5.execute-api.us-west-2.amazonaws.com/dev"
@@ -31,6 +32,7 @@ tasks:
         cmd: yarn start
         deps:
             - yarn
+            - docsite:build:embedded
             - build:backend
         env:
             WCLOUD_ENDPOINT: "https://ot2e112zx5.execute-api.us-west-2.amazonaws.com/dev"
@@ -39,6 +41,54 @@ tasks:
     storybook:
         desc: Start the Storybook server.
         cmd: yarn storybook
+        deps:
+            - yarn
+
+    storybook:build:
+        desc: Build the Storybook static site.
+        cmd: yarn build-storybook
+        generates:
+            - storybook-static/**/*
+        deps:
+            - yarn
+
+    docsite:start:
+        desc: Start the docsite dev server.
+        cmd: yarn start
+        dir: docs
+        deps:
+            - yarn
+
+    docsite:build:public:
+        desc: Build the full docsite.
+        cmds:
+            - cd docs && yarn build
+            - task: copyfiles:'storybook-static/':'docs/build/storybook'
+        sources:
+            - "docs/*"
+            - "docs/src/**/*"
+            - "docs/docs/**/*"
+            - "docs/static/**/*"
+        generates:
+            - "docs/build/**/*"
+        deps:
+            - yarn
+            - storybook:build
+
+    docsite:build:embedded:
+        desc: Build the embedded docsite and copy it to ./docsite
+        sources:
+            - "docs/*"
+            - "docs/src/**/*"
+            - "docs/docs/**/*"
+            - "docs/static/**/*"
+        generates:
+            - "docsite/**/*"
+        cmds:
+            - cd docs && yarn build-embedded
+            - task: copyfiles:'docs/build/':'../docsite'
+        deps:
+            - yarn
 
     package:
         desc: Package the application for the current platform.
@@ -66,8 +116,7 @@ tasks:
 
     build:server:macos:
         desc: Build the wavesrv component for macOS (Darwin) platforms (generates artifacts for both arm64 and amd64).
-        status:
-            - exit {{if eq OS "darwin"}}1{{else}}0{{end}}
+        platforms: [darwin]
         cmds:
             - cmd: "{{.RM}} dist/bin/wavesrv*"
               ignore_error: true
@@ -77,8 +126,7 @@ tasks:
 
     build:server:windows:
         desc: Build the wavesrv component for Windows platforms (only generates artifacts for the current architecture).
-        status:
-            - exit {{if eq OS "windows"}}1{{else}}0{{end}}
+        platforms: [windows]
         cmds:
             - cmd: "{{.RM}} dist/bin/wavesrv*"
               ignore_error: true
@@ -89,8 +137,7 @@ tasks:
 
     build:server:linux:
         desc: Build the wavesrv component for Linux platforms (only generates artifacts for the current architecture).
-        status:
-            - exit {{if eq OS "linux"}}1{{else}}0{{end}}
+        platforms: [linux]
         cmds:
             - cmd: "{{.RM}} dist/bin/wavesrv*"
               ignore_error: true
@@ -273,3 +320,10 @@ tasks:
         sources:
             - go.mod
         cmd: go mod tidy
+
+    copyfiles:*:*:
+        desc: Recursively copy directory contents to a new directory, creating the directory if needed.
+        internal: true
+        cmds:
+            - '{{if eq OS "windows"}}powershell New-Item -Path "." -Force -Name "{{index .MATCH 1}}" -ItemType "directory"{{else}}mkdir -p {{index .MATCH 1}}{{end}}'
+            - '{{if eq OS "windows"}}powershell Copy-Item -Recurse -Force -Path {{index .MATCH 0}} -Destination {{index .MATCH 1}}{{else}}cp -r {{index .MATCH 0}} {{index .MATCH 1}}{{end}}'


### PR DESCRIPTION
This adds the new tasks `docsite:start`, `docsite:build:public`, `docsite:build:embedded`, `storybook:build`, and `copyfiles:*:*` to Taskfile.

It also updates the "Build Helper" and "Docsite and Storybook CI/CD" workflows to use these new tasks.

It also makes the docsite embedded build a dependency of the electron tasks, ensuring that the embedded docsite is included when building locally.

Tested and confirms this works on Windows