### PR TITLE
Run deploy-docsite check when Taskfile is modified

### DIFF
--- a/.github/workflows/deploy-docsite.yml
+++ b/.github/workflows/deploy-docsite.yml
@@ -20,6 +20,7 @@ on:
             - "**/*.story.*"
             - "**/*.stories.*"
             - ".github/workflows/deploy-docsite.yml"
+            - "Taskfile.yml"
 
 jobs:
     build:


### PR DESCRIPTION
Now that deploy-docsite depends on the Taskfile, we need to gate Taskfile changes on it.