### PR TITLE
Quick Ssh Fix/Logging

### DIFF
--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -580,7 +580,7 @@ func resolveSshConfigPatterns(configFiles []string) ([]string, error) {
 			for _, hostPattern := range host.Patterns {
 				hostPatternStr := hostPattern.String()
 				normalized := remote.NormalizeConfigPattern(hostPatternStr)
-				if (!strings.Contains(hostPatternStr, "*") && !strings.Contains(hostPatternStr, "?") && !strings.Contains(hostPatternStr, "!")) || alreadyUsed[normalized] {
+				if !strings.Contains(hostPatternStr, "*") && !strings.Contains(hostPatternStr, "?") && !strings.Contains(hostPatternStr, "!") && !alreadyUsed[normalized] {
 					discoveredPatterns = append(discoveredPatterns, normalized)
 					alreadyUsed[normalized] = true
 					break

--- a/pkg/remote/connutil.go
+++ b/pkg/remote/connutil.go
@@ -340,6 +340,7 @@ func IsPowershell(shellPath string) bool {
 func NormalizeConfigPattern(pattern string) string {
 	userName, err := WaveSshConfigUserSettings().GetStrict(pattern, "User")
 	if err != nil {
+		log.Printf("warning: error parsing username of %s for conn dropdown: %v", pattern, err)
 		localUser, err := user.Current()
 		if err == nil {
 			userName = localUser.Username


### PR DESCRIPTION
This adds two things:
- prints a log error if the user isn't parsed properly in ssh
- ensures that a host isn't reused when sending to the conn list