### PR TITLE
touch up final test condition

### DIFF
--- a/testdriver/onboarding.yml
+++ b/testdriver/onboarding.yml
@@ -10,3 +10,5 @@ steps:
         text: Get Started
         description: button to complete onboarding
         action: click
+      - command: assert
+        expect: the cpu usage graph is being displayed


### PR DESCRIPTION
The action used to fail a few times at the end as it wasn't aware of what the end state should look like.
With having an `assert` block, it should now be able to judge more accurately.