### PR TITLE
Fix TSGen so it accounts for ctx when assigning argument names for services

### DIFF
--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -12,7 +12,7 @@ class BlockServiceType {
     }
 
     // save the terminal state to a blockfile
-    SaveTerminalState(blockId: string, state: string, stateType: string, ptyOffset: number, termSize: TermSize): Promise<void> {
+    SaveTerminalState(ctx: string, blockId: string, state: string, stateType: number, ptyOffset: TermSize): Promise<void> {
         return WOS.callBackendService("block", "SaveTerminalState", Array.from(arguments))
     }
     SaveWaveAiData(arg2: string, arg3: OpenAIPromptMessageType[]): Promise<void> {
@@ -95,12 +95,12 @@ class ObjectServiceType {
     }
 
     // @returns blockId (and object updates)
-    CreateBlock(blockDef: BlockDef, rtOpts: RuntimeOpts): Promise<string> {
+    CreateBlock(uiContext: BlockDef, blockDef: RuntimeOpts): Promise<string> {
         return WOS.callBackendService("object", "CreateBlock", Array.from(arguments))
     }
 
     // @returns object updates
-    DeleteBlock(blockId: string): Promise<void> {
+    DeleteBlock(uiContext: string): Promise<void> {
         return WOS.callBackendService("object", "DeleteBlock", Array.from(arguments))
     }
 
@@ -120,22 +120,22 @@ class ObjectServiceType {
     }
 
     // @returns object updates
-    UpdateObject(waveObj: WaveObj, returnUpdates: boolean): Promise<void> {
+    UpdateObject(uiContext: WaveObj, waveObj: boolean): Promise<void> {
         return WOS.callBackendService("object", "UpdateObject", Array.from(arguments))
     }
 
     // @returns object updates
-    UpdateObjectMeta(oref: string, meta: MetaType): Promise<void> {
+    UpdateObjectMeta(uiContext: string, oref: MetaType): Promise<void> {
         return WOS.callBackendService("object", "UpdateObjectMeta", Array.from(arguments))
     }
 
     // @returns object updates
-    UpdateTabName(tabId: string, name: string): Promise<void> {
+    UpdateTabName(uiContext: string, tabId: string): Promise<void> {
         return WOS.callBackendService("object", "UpdateTabName", Array.from(arguments))
     }
 
     // @returns object updates
-    UpdateWorkspaceTabIds(workspaceId: string, tabIds: string[]): Promise<void> {
+    UpdateWorkspaceTabIds(uiContext: string, workspaceId: string[]): Promise<void> {
         return WOS.callBackendService("object", "UpdateWorkspaceTabIds", Array.from(arguments))
     }
 }
@@ -163,7 +163,7 @@ class WindowServiceType {
 
     // move block to new window
     // @returns object updates
-    MoveBlockToNewWindow(currentTabId: string, blockId: string): Promise<void> {
+    MoveBlockToNewWindow(ctx: string, currentTabId: string): Promise<void> {
         return WOS.callBackendService("window", "MoveBlockToNewWindow", Array.from(arguments))
     }
 

--- a/pkg/tsgen/tsgen.go
+++ b/pkg/tsgen/tsgen.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"reflect"
 	"strings"
 
@@ -342,19 +343,23 @@ func GenerateMethodSignature(serviceName string, method reflect.Method, meta tsg
 	sb.WriteString(method.Name)
 	sb.WriteString("(")
 	wroteArg := false
+	log.Printf("method %s: %s, args: %v", method.Name, method.Type, meta.ArgNames)
+	idxOffset := 1
 	// skip first arg, which is the receiver
-	for idx := 1; idx < method.Type.NumIn(); idx++ {
+	for idx := idxOffset; idx < method.Type.NumIn(); idx++ {
 		if wroteArg {
 			sb.WriteString(", ")
 		}
 		inType := method.Type.In(idx)
 		if inType == contextRType || inType == uiContextRType {
+			idxOffset++
 			continue
 		}
 		tsTypeName, _ := TypeToTSType(inType, tsTypesMap)
 		var argName string
-		if idx-1 < len(meta.ArgNames) {
-			argName = meta.ArgNames[idx-1] // subtract 1 for receiver
+		log.Printf("method %s arg %d: %s", method.Name, idx, tsTypeName)
+		if idx-idxOffset < len(meta.ArgNames) {
+			argName = meta.ArgNames[idx-idxOffset] // subtract 1 for receiver
 		} else {
 			argName = fmt.Sprintf("arg%d", idx)
 		}


### PR DESCRIPTION
Before, if a method in a service had `context.Context` as its first argument, the argument names that were generated in `services.ts` would be off by one index. Now, the offset can be moved when we skip an argument such as context in the generator.