### PR TITLE
Remove separate docs group in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,24 +24,8 @@ updates:
           electron:
               patterns:
                   - "*electron*"
-    - package-ecosystem: "npm"
-      directory: "docs/"
-      schedule:
-          interval: "weekly"
-          day: "friday"
-          time: "09:00"
-          timezone: "America/Los_Angeles"
-      groups:
-          docsite-dev-dependencies:
-              dependency-type: "development"
-              exclude-patterns:
-                  - "*docusaurus*"
-          docsite-docusaurus:
+          docusaurus:
               patterns:
-                  - "*docusaurus*"
-          docsite-prod-dependencies:
-              dependency-type: "production"
-              exclude-patterns:
                   - "*docusaurus*"
     - package-ecosystem: "gomod"
       directory: "/"


### PR DESCRIPTION
Until we split up the rest of the codebase into workspaces, having a separate dependabot group for docsite won't work since the root rule will always conflict