### PR TITLE
Revert electron bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@types/ws": "^8",
         "@vitejs/plugin-react-swc": "^3.7.2",
         "@vitest/coverage-istanbul": "^2.1.6",
-        "electron": "^33.2.1",
+        "electron": "^33.2.0",
         "electron-builder": "^25.1.8",
         "electron-vite": "^2.3.0",
         "eslint": "^9.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10371,16 +10371,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^33.2.1":
-  version: 33.2.1
-  resolution: "electron@npm:33.2.1"
+"electron@npm:^33.2.0":
+  version: 33.2.0
+  resolution: "electron@npm:33.2.0"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^20.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/25111ab9b48bf95a24b916292c8d4f4d05309b12823d5e942636f377a8033c9c47d466f686895bfe4619b80d222470a439d9b0227516740c8e19fa14991b880b
+  checksum: 10c0/ad013bcc4fe65f6e0f40b77387452966347d4fb54acc8d8d7b0310244f73511a7ac87e03e1097970f83b94bcafc44e0b98a4c603daa9c95e11931d7c020ff155
   languageName: node
   linkType: hard
 
@@ -21741,7 +21741,7 @@ __metadata:
     css-tree: "npm:^3.0.1"
     dayjs: "npm:^1.11.13"
     debug: "npm:^4.3.7"
-    electron: "npm:^33.2.1"
+    electron: "npm:^33.2.0"
     electron-builder: "npm:^25.1.8"
     electron-updater: "npm:6.3.9"
     electron-vite: "npm:^2.3.0"


### PR DESCRIPTION
There's a bug that causes the app to crash on context menu show: https://github.com/electron/electron/issues/44898
This reverts commit 10250966fa22dc07b3b82ef438d7c048e3fb8998.