### PR TITLE
Remove child views before switching workspaces

### DIFF
--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -333,6 +333,7 @@ export class WaveBrowserWindow extends BaseWindow {
         this.activeTabView = tabView;
         this.allTabViews.set(tabView.waveTabId, tabView);
         if (!tabInitialized) {
+            console.log("initializing a new tab");
             await tabView.initPromise;
             this.contentView.addChildView(tabView);
             const initOpts = {

--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -321,7 +321,6 @@ export class WaveBrowserWindow extends BaseWindow {
     }
 
     async setTabViewIntoWindow(tabView: WaveTabView, tabInitialized: boolean) {
-        console.log("setTabViewIntoWindow", tabView.waveTabId, this.waveWindowId);
         const clientData = await ClientService.GetClientData();
         if (this.activeTabView == tabView) {
             return;
@@ -334,20 +333,8 @@ export class WaveBrowserWindow extends BaseWindow {
         this.activeTabView = tabView;
         this.allTabViews.set(tabView.waveTabId, tabView);
         if (!tabInitialized) {
-            console.log("initializing a new tab");
-            try {
-                await tabView.initPromise;
-            } catch (e) {
-                console.error("error waiting for tabView.initPromise", e);
-                throw e;
-            }
-
-            try {
-                this.contentView.addChildView(tabView);
-            } catch (e) {
-                console.error("error adding child view", e);
-                throw e;
-            }
+            await tabView.initPromise;
+            this.contentView.addChildView(tabView);
             const initOpts = {
                 tabId: tabView.waveTabId,
                 clientId: clientData.oid,

--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -274,6 +274,7 @@ export class WaveBrowserWindow extends BaseWindow {
         console.log("switchWorkspace newWs", newWs);
         if (this.allTabViews.size) {
             for (const tab of this.allTabViews.values()) {
+                this.contentView.removeChildView(tab);
                 tab?.destroy();
             }
         }
@@ -320,6 +321,7 @@ export class WaveBrowserWindow extends BaseWindow {
     }
 
     async setTabViewIntoWindow(tabView: WaveTabView, tabInitialized: boolean) {
+        console.log("setTabViewIntoWindow", tabView.waveTabId, this.waveWindowId);
         const clientData = await ClientService.GetClientData();
         if (this.activeTabView == tabView) {
             return;
@@ -333,8 +335,19 @@ export class WaveBrowserWindow extends BaseWindow {
         this.allTabViews.set(tabView.waveTabId, tabView);
         if (!tabInitialized) {
             console.log("initializing a new tab");
-            await tabView.initPromise;
-            this.contentView.addChildView(tabView);
+            try {
+                await tabView.initPromise;
+            } catch (e) {
+                console.error("error waiting for tabView.initPromise", e);
+                throw e;
+            }
+
+            try {
+                this.contentView.addChildView(tabView);
+            } catch (e) {
+                console.error("error adding child view", e);
+                throw e;
+            }
             const initOpts = {
                 tabId: tabView.waveTabId,
                 clientId: clientData.oid,

--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -674,8 +674,6 @@ async function relaunchBrowserWindows(): Promise<void> {
 }
 
 async function appMain() {
-    console.log(electron.app.getPath("crashDumps"));
-    electron.crashReporter.start({ submitURL: "", uploadToServer: false });
     // Set disableHardwareAcceleration as early as possible, if required.
     const launchSettings = getLaunchSettings();
     if (launchSettings?.["window:disablehardwareacceleration"]) {

--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -674,6 +674,8 @@ async function relaunchBrowserWindows(): Promise<void> {
 }
 
 async function appMain() {
+    console.log(electron.app.getPath("crashDumps"));
+    electron.crashReporter.start({ submitURL: "", uploadToServer: false });
     // Set disableHardwareAcceleration as early as possible, if required.
     const launchSettings = getLaunchSettings();
     if (launchSettings?.["window:disablehardwareacceleration"]) {


### PR DESCRIPTION
This was causing a crash on Windows because we were destroying a TabView that was still parented to the window. Not sure why I couldn't repro this on Mac...