### PR TITLE
Delete a tab when it's out of blocks, cascade to window

### DIFF
--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -39,6 +39,7 @@ import {
     getAllWaveWindows,
     getWaveWindowById,
     getWaveWindowByWebContentsId,
+    getWaveWindowByWorkspaceId,
     WaveBrowserWindow,
 } from "./emain-window";
 import { ElectronWshClient, initElectronWshClient } from "./emain-wsh";
@@ -125,6 +126,14 @@ function handleWSEvent(evtMsg: WSEventType) {
             if (ww != null) {
                 ww.destroy(); // bypass the "are you sure?" dialog
             }
+        } else if (evtMsg.eventtype == "electron:updateactivetab") {
+            const activeTabUpdate: { workspaceid: string; newactivetabid: string } = evtMsg.data;
+            console.log("electron:updateactivetab", activeTabUpdate);
+            const ww = getWaveWindowByWorkspaceId(activeTabUpdate.workspaceid);
+            if (ww == null) {
+                return;
+            }
+            await ww.setActiveTab(activeTabUpdate.newactivetabid, false);
         } else {
             console.log("unhandled electron ws eventtype", evtMsg.eventtype);
         }

--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	WSEvent_ElectronNewWindow   = "electron:newwindow"
-	WSEvent_ElectronCloseWindow = "electron:closewindow"
-	WSEvent_Rpc                 = "rpc"
+	WSEvent_ElectronNewWindow       = "electron:newwindow"
+	WSEvent_ElectronCloseWindow     = "electron:closewindow"
+	WSEvent_ElectronUpdateActiveTab = "electron:updateactivetab"
+	WSEvent_Rpc                     = "rpc"
 )
 
 type WSEventType struct {

--- a/pkg/service/workspaceservice/workspaceservice.go
+++ b/pkg/service/workspaceservice/workspaceservice.go
@@ -175,15 +175,7 @@ func (svc *WorkspaceService) CloseTab(ctx context.Context, workspaceId string, t
 	}
 	rtn := &CloseTabRtnType{}
 	if newActiveTabId == "" {
-		windowId, err := wstore.DBFindWindowForWorkspaceId(ctx, workspaceId)
-		if err != nil {
-			return rtn, nil, fmt.Errorf("unable to find window for workspace id %v: %w", workspaceId, err)
-		}
 		rtn.CloseWindow = true
-		err = wcore.CloseWindow(ctx, windowId, fromElectron)
-		if err != nil {
-			return rtn, nil, err
-		}
 	} else {
 		rtn.NewActiveTabId = newActiveTabId
 	}

--- a/pkg/waveobj/wtype.go
+++ b/pkg/waveobj/wtype.go
@@ -159,6 +159,11 @@ type WorkspaceListEntry struct {
 
 type WorkspaceList []*WorkspaceListEntry
 
+type ActiveTabUpdate struct {
+	WorkspaceId    string `json:"workspaceid"`
+	NewActiveTabId string `json:"newactivetabid"`
+}
+
 type Workspace struct {
 	OID         string      `json:"oid"`
 	Version     int         `json:"version"`


### PR DESCRIPTION
Updates `DeleteBlock` to close its parent tab if the tab has no more blocks. This will also cascade to close the workspace if it no longer has any tabs, same for window.

I had to move some block-related functionality around on the backend.