### PR TITLE
Add recursive flag to prevent unwanted deletion of parents while they're already being deleted

### DIFF
--- a/pkg/service/objectservice/objectservice.go
+++ b/pkg/service/objectservice/objectservice.go
@@ -121,7 +121,7 @@ func (svc *ObjectService) DeleteBlock(uiContext waveobj.UIContext, blockId strin
 	ctx, cancelFn := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancelFn()
 	ctx = waveobj.ContextWithUpdates(ctx)
-	err := wcore.DeleteBlock(ctx, blockId)
+	err := wcore.DeleteBlock(ctx, blockId, true)
 	if err != nil {
 		return nil, fmt.Errorf("error deleting block: %w", err)
 	}

--- a/pkg/service/windowservice/windowservice.go
+++ b/pkg/service/windowservice/windowservice.go
@@ -184,5 +184,5 @@ func (svc *WindowService) CloseWindow_Meta() tsgenmeta.MethodMeta {
 
 func (svc *WindowService) CloseWindow(ctx context.Context, windowId string, fromElectron bool) error {
 	ctx = waveobj.ContextWithUpdates(ctx)
-	return wcore.CloseWindow(ctx, windowId, fromElectron)
+	return wcore.CloseWindow(ctx, windowId, fromElectron, false)
 }

--- a/pkg/service/windowservice/windowservice.go
+++ b/pkg/service/windowservice/windowservice.go
@@ -184,5 +184,5 @@ func (svc *WindowService) CloseWindow_Meta() tsgenmeta.MethodMeta {
 
 func (svc *WindowService) CloseWindow(ctx context.Context, windowId string, fromElectron bool) error {
 	ctx = waveobj.ContextWithUpdates(ctx)
-	return wcore.CloseWindow(ctx, windowId, fromElectron, false)
+	return wcore.CloseWindow(ctx, windowId, fromElectron)
 }

--- a/pkg/service/workspaceservice/workspaceservice.go
+++ b/pkg/service/workspaceservice/workspaceservice.go
@@ -169,7 +169,7 @@ func (svc *WorkspaceService) CloseTab(ctx context.Context, workspaceId string, t
 			blockcontroller.StopBlockController(blockId)
 		}
 	}()
-	newActiveTabId, err := wcore.DeleteTab(ctx, workspaceId, tabId)
+	newActiveTabId, err := wcore.DeleteTab(ctx, workspaceId, tabId, true)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error closing tab: %w", err)
 	}

--- a/pkg/wcore/block.go
+++ b/pkg/wcore/block.go
@@ -99,7 +99,11 @@ func createBlockObj(ctx context.Context, tabId string, blockDef *waveobj.BlockDe
 	})
 }
 
-func DeleteBlock(ctx context.Context, blockId string) error {
+// Must delete all blocks individually first.
+// Also deletes LayoutState.
+// cascadeClose: if true, will close parent tab if no blocks left, will cascade to close parent window/workspace of tab if no tabs left.
+// Returns new active tab id, error.
+func DeleteBlock(ctx context.Context, blockId string, cascadeClose bool) error {
 	block, err := wstore.DBMustGet[*waveobj.Block](ctx, blockId)
 	if err != nil {
 		return fmt.Errorf("error getting block: %w", err)
@@ -109,7 +113,7 @@ func DeleteBlock(ctx context.Context, blockId string) error {
 	}
 	if len(block.SubBlockIds) > 0 {
 		for _, subBlockId := range block.SubBlockIds {
-			err := DeleteBlock(ctx, subBlockId)
+			err := DeleteBlock(ctx, subBlockId, cascadeClose)
 			if err != nil {
 				return fmt.Errorf("error deleting subblock %s: %w", subBlockId, err)
 			}
@@ -123,14 +127,14 @@ func DeleteBlock(ctx context.Context, blockId string) error {
 	parentORef := waveobj.ParseORefNoErr(block.ParentORef)
 
 	if parentORef.OType == waveobj.OType_Tab {
-		if parentBlockCount == 0 {
+		if parentBlockCount == 0 && cascadeClose {
 			// if parent tab has no blocks, delete the tab
 			log.Printf("DeleteBlock: parent tab has no blocks, deleting tab %s", parentORef.OID)
 			parentWorkspaceId, err := wstore.DBFindWorkspaceForTabId(ctx, parentORef.OID)
 			if err != nil {
 				return fmt.Errorf("error finding workspace for tab to delete %s: %w", parentORef.OID, err)
 			}
-			newActiveTabId, err := DeleteTab(ctx, parentWorkspaceId, parentORef.OID)
+			newActiveTabId, err := DeleteTab(ctx, parentWorkspaceId, parentORef.OID, true)
 			if err != nil {
 				return fmt.Errorf("error deleting tab %s: %w", parentORef.OID, err)
 			}

--- a/pkg/wcore/window.go
+++ b/pkg/wcore/window.go
@@ -122,13 +122,12 @@ func CreateWindow(ctx context.Context, winSize *waveobj.WinSize, workspaceId str
 
 // CloseWindow closes a window and deletes its workspace if it is empty and not named.
 // If fromElectron is true, it does not send an event to Electron.
-// If force is true, it deletes the empty workspace even if it is named.
-func CloseWindow(ctx context.Context, windowId string, fromElectron bool, force bool) error {
+func CloseWindow(ctx context.Context, windowId string, fromElectron bool) error {
 	log.Printf("CloseWindow %s\n", windowId)
 	window, err := GetWindow(ctx, windowId)
 	if err == nil {
 		log.Printf("got window %s\n", windowId)
-		deleted, err := DeleteWorkspace(ctx, window.WorkspaceId, force)
+		deleted, err := DeleteWorkspace(ctx, window.WorkspaceId, false)
 		if err != nil {
 			log.Printf("error deleting workspace: %v\n", err)
 		}
@@ -172,7 +171,7 @@ func CheckAndFixWindow(ctx context.Context, windowId string) *waveobj.Window {
 	ws, err := GetWorkspace(ctx, window.WorkspaceId)
 	if err != nil {
 		log.Printf("error getting workspace %q (in checkAndFixWindow): %v\n", window.WorkspaceId, err)
-		CloseWindow(ctx, windowId, false, true)
+		CloseWindow(ctx, windowId, false)
 		return nil
 	}
 	if len(ws.TabIds) == 0 {

--- a/pkg/wcore/window.go
+++ b/pkg/wcore/window.go
@@ -120,12 +120,15 @@ func CreateWindow(ctx context.Context, winSize *waveobj.WinSize, workspaceId str
 	return GetWindow(ctx, windowId)
 }
 
-func CloseWindow(ctx context.Context, windowId string, fromElectron bool) error {
+// CloseWindow closes a window and deletes its workspace if it is empty and not named.
+// If fromElectron is true, it does not send an event to Electron.
+// If force is true, it deletes the empty workspace even if it is named.
+func CloseWindow(ctx context.Context, windowId string, fromElectron bool, force bool) error {
 	log.Printf("CloseWindow %s\n", windowId)
 	window, err := GetWindow(ctx, windowId)
 	if err == nil {
 		log.Printf("got window %s\n", windowId)
-		deleted, err := DeleteWorkspace(ctx, window.WorkspaceId, false)
+		deleted, err := DeleteWorkspace(ctx, window.WorkspaceId, force)
 		if err != nil {
 			log.Printf("error deleting workspace: %v\n", err)
 		}
@@ -169,7 +172,7 @@ func CheckAndFixWindow(ctx context.Context, windowId string) *waveobj.Window {
 	ws, err := GetWorkspace(ctx, window.WorkspaceId)
 	if err != nil {
 		log.Printf("error getting workspace %q (in checkAndFixWindow): %v\n", window.WorkspaceId, err)
-		CloseWindow(ctx, windowId, false)
+		CloseWindow(ctx, windowId, false, true)
 		return nil
 	}
 	if len(ws.TabIds) == 0 {

--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -106,9 +106,9 @@ func CreateTab(ctx context.Context, workspaceId string, tabName string, activate
 
 // Must delete all blocks individually first.
 // Also deletes LayoutState.
-// cascadeClose: if true, will close parent window/workspace if no blocks left.
+// recursive: if true, will recursively close parent window, workspace, if they are empty.
 // Returns new active tab id, error.
-func DeleteTab(ctx context.Context, workspaceId string, tabId string, cascadeClose bool) (string, error) {
+func DeleteTab(ctx context.Context, workspaceId string, tabId string, recursive bool) (string, error) {
 	ws, _ := wstore.DBGet[*waveobj.Workspace](ctx, workspaceId)
 	if ws == nil {
 		return "", fmt.Errorf("workspace not found: %q", workspaceId)
@@ -144,7 +144,7 @@ func DeleteTab(ctx context.Context, workspaceId string, tabId string, cascadeClo
 	wstore.DBDelete(ctx, waveobj.OType_Tab, tabId)
 	wstore.DBDelete(ctx, waveobj.OType_LayoutState, tab.LayoutState)
 
-	if newActiveTabId == "" && cascadeClose {
+	if newActiveTabId == "" && recursive {
 		windowId, err := wstore.DBFindWindowForWorkspaceId(ctx, workspaceId)
 		if err != nil {
 			return newActiveTabId, fmt.Errorf("unable to find window for workspace id %v: %w", workspaceId, err)

--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -29,6 +29,7 @@ func CreateWorkspace(ctx context.Context, name string, icon string, color string
 }
 
 // If force is true, it will delete even if workspace is named.
+// If workspace is empty, it will be deleted, even if it is named.
 // Returns true if workspace was deleted, false if it was not deleted.
 func DeleteWorkspace(ctx context.Context, workspaceId string, force bool) (bool, error) {
 	log.Printf("DeleteWorkspace %s\n", workspaceId)
@@ -36,7 +37,7 @@ func DeleteWorkspace(ctx context.Context, workspaceId string, force bool) (bool,
 	if err != nil {
 		return false, fmt.Errorf("error getting workspace: %w", err)
 	}
-	if workspace.Name != "" && workspace.Icon != "" && !force {
+	if workspace.Name != "" && workspace.Icon != "" && !force && len(workspace.TabIds) > 0 {
 		log.Printf("Ignoring DeleteWorkspace for workspace %s as it is named\n", workspaceId)
 		return false, nil
 	}
@@ -149,7 +150,7 @@ func DeleteTab(ctx context.Context, workspaceId string, tabId string, recursive 
 		if err != nil {
 			return newActiveTabId, fmt.Errorf("unable to find window for workspace id %v: %w", workspaceId, err)
 		}
-		err = CloseWindow(ctx, windowId, false, true)
+		err = CloseWindow(ctx, windowId, false)
 		if err != nil {
 			return newActiveTabId, err
 		}

--- a/pkg/wshrpc/wshserver/wshserver.go
+++ b/pkg/wshrpc/wshserver/wshserver.go
@@ -489,7 +489,7 @@ func (ws *WshServer) FileAppendIJsonCommand(ctx context.Context, data wshrpc.Com
 }
 
 func (ws *WshServer) DeleteSubBlockCommand(ctx context.Context, data wshrpc.CommandDeleteBlockData) error {
-	err := wcore.DeleteBlock(ctx, data.BlockId)
+	err := wcore.DeleteBlock(ctx, data.BlockId, false)
 	if err != nil {
 		return fmt.Errorf("error deleting block: %w", err)
 	}
@@ -505,7 +505,7 @@ func (ws *WshServer) DeleteBlockCommand(ctx context.Context, data wshrpc.Command
 	if tabId == "" {
 		return fmt.Errorf("no tab found for block")
 	}
-	err = wcore.DeleteBlock(ctx, data.BlockId)
+	err = wcore.DeleteBlock(ctx, data.BlockId, true)
 	if err != nil {
 		return fmt.Errorf("error deleting block: %w", err)
 	}


### PR DESCRIPTION
When a tab was being deleted, for instance, the last block that got deleted would cascade to delete its parent tab, even though the `DeleteTab` function was already going to do this. This would produce DB collisions that would put the app into a bad state. Now we pass a `recursive` flag that is used to determine whether to perform the recursive close of the parents.

Also updates `DeleteWorkspace` so that named workspaces will always be deleted if they're empty, even if `force` is false