### PR TITLE
Fix zombie tab context menus

### DIFF
--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -574,12 +574,15 @@ const TabBar = memo(({ workspace }: TabBarProps) => {
         deleteLayoutModelForTab(tabId);
     };
 
-    const handlePinChange = (tabId: string, pinned: boolean) => {
-        console.log("handlePinChange", tabId, pinned);
-        fireAndForget(async () => {
-            await WorkspaceService.ChangeTabPinning(workspace.oid, tabId, pinned);
-        });
-    };
+    const handlePinChange = useCallback(
+        (tabId: string, pinned: boolean) => {
+            console.log("handlePinChange", tabId, pinned);
+            fireAndForget(async () => {
+                await WorkspaceService.ChangeTabPinning(workspace.oid, tabId, pinned);
+            });
+        },
+        [workspace]
+    );
 
     const handleTabLoaded = useCallback((tabId: string) => {
         setTabsLoaded((prev) => {


### PR DESCRIPTION
The memoizing of the tabs was causing the callbacks for handleContextMenu to become dead ends. This makes more of the callbacks into memoized callbacks and makes the handleContextMenu function itself a memoized callback to ensure it's properly updated when its upstream callbacks change.