### PR TITLE
Update Go toolchain to 1.23.4

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -10,7 +10,7 @@ on:
             - "v[0-9]+.[0-9]+.[0-9]+*"
     workflow_dispatch:
 env:
-    GO_VERSION: "1.22"
+    GO_VERSION: "1.23"
     NODE_VERSION: 22
 jobs:
     build-app:

--- a/.github/workflows/testdriver.yml
+++ b/.github/workflows/testdriver.yml
@@ -23,7 +23,7 @@ on:
     workflow_dispatch: null
 
 env:
-    GO_VERSION: "1.22"
+    GO_VERSION: "1.23"
     NODE_VERSION: 22
 
 permissions:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wavetermdev/waveterm
 
-go 1.22.4
+go 1.23.4
 
 require (
 	github.com/alexflint/go-filemutex v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wavetermdev/waveterm
 
-go 1.23.4
+go 1.23
 
 require (
 	github.com/alexflint/go-filemutex v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wavetermdev/waveterm
 
-go 1.23
+go 1.23.4
 
 require (
 	github.com/alexflint/go-filemutex v1.3.0


### PR DESCRIPTION
Because Electron now has a macOS 11 minimum supported version, we have no blockers to adopting the latest Go toolchain. This also lets us use the new `range` features in Go, among other things.