### PR TITLE
Use window destroy instead of forceClose

### DIFF
--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -237,7 +237,13 @@ export class WaveBrowserWindow extends BaseWindow {
                 console.log("win removing window from backend DB", this.waveWindowId);
                 fireAndForget(async () => await WindowService.CloseWindow(this.waveWindowId, true));
             }
-            this.destroy();
+            for (const tabView of this.allTabViews.values()) {
+                tabView?.destroy();
+            }
+            waveWindowMap.delete(this.waveWindowId);
+            if (focusedWaveWindow == this) {
+                focusedWaveWindow = null;
+            }
         });
         waveWindowMap.set(waveWindow.oid, this);
     }
@@ -311,13 +317,6 @@ export class WaveBrowserWindow extends BaseWindow {
             }
             this.allTabViews.delete(tabId);
         }
-    }
-
-    forceClose() {
-        console.log("forceClose window", this.waveWindowId);
-        this.canClose = true;
-        this.deleteAllowed = true;
-        this.close();
     }
 
     async setTabViewIntoWindow(tabView: WaveTabView, tabInitialized: boolean) {
@@ -459,13 +458,7 @@ export class WaveBrowserWindow extends BaseWindow {
 
     destroy() {
         console.log("destroy win", this.waveWindowId);
-        for (const tabView of this.allTabViews.values()) {
-            tabView?.destroy();
-        }
-        waveWindowMap.delete(this.waveWindowId);
-        if (focusedWaveWindow == this) {
-            focusedWaveWindow = null;
-        }
+        this.deleteAllowed = true;
         super.destroy();
     }
 }
@@ -565,6 +558,6 @@ ipcMain.on("delete-workspace", async (event, workspaceId) => {
     console.log("delete-workspace done", workspaceId, ww?.waveWindowId);
     if (ww?.workspaceId == workspaceId) {
         console.log("delete-workspace closing window", workspaceId, ww?.waveWindowId);
-        ww.forceClose();
+        ww.destroy();
     }
 });


### PR DESCRIPTION
`destroy` bypasses the `close` event and forces the window to close. This means that we can use it instead of `forceClose` and we don't need to call it in the `closed` event.