### PR TITLE
Prevent crashes when user spams Cmd:T

### DIFF
--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -351,9 +351,7 @@ export class WaveBrowserWindow extends BaseWindow {
             let startTime = Date.now();
             tabView.webContents.send("wave-init", initOpts);
             console.log("before wave ready");
-
             await tabView.waveReadyPromise;
-
             // positionTabOnScreen(tabView, this.getContentBounds());
             console.log("wave-ready init time", Date.now() - startTime + "ms");
             // positionTabOffScreen(oldActiveView, this.getContentBounds());

--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -351,7 +351,9 @@ export class WaveBrowserWindow extends BaseWindow {
             let startTime = Date.now();
             tabView.webContents.send("wave-init", initOpts);
             console.log("before wave ready");
+
             await tabView.waveReadyPromise;
+
             // positionTabOnScreen(tabView, this.getContentBounds());
             console.log("wave-ready init time", Date.now() - startTime + "ms");
             // positionTabOffScreen(oldActiveView, this.getContentBounds());


### PR DESCRIPTION
When a user spams Cmd:T, a WaveTabView might be created but never end up getting mounted to the window, since another will come along before it can. In these cases, the WaveTabView is essentially in a bad state and attempting to switch to it will result in the window becoming unresponsive. While we could recover it by running waveInit again, it's easier to just dispose of it and treat it as an unloaded tab next time it gets switched to.

This adds a timeout to each WaveTabView where once it gets assigned a tab ID, it has 1 second to respond "ready" or it will be destroyed. This should help prevent resource leakages for these dead views.