### PR TITLE
Fix tab flicker in a less convoluted way

### DIFF
--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -43,9 +43,6 @@ function setPlatform(platform: NodeJS.Platform) {
     PLATFORM = platform;
 }
 
-// Used to override the tab id when switching tabs to prevent flicker in the tab bar.
-const overrideStaticTabAtom = atom(null) as PrimitiveAtom<string>;
-
 function initGlobalAtoms(initOpts: GlobalInitOptions) {
     const windowIdAtom = atom(initOpts.windowId) as PrimitiveAtom<string>;
     const clientIdAtom = atom(initOpts.clientId) as PrimitiveAtom<string>;
@@ -659,8 +656,6 @@ function createTab() {
 
 function setActiveTab(tabId: string) {
     // We use this hack to prevent a flicker of the previously-hovered tab when this view was last active. This class is set in setActiveTab in global.ts. See tab.scss for where this class is used.
-    // Also overrides the staticTabAtom to the new tab id so that the active tab is set correctly.
-    globalStore.set(overrideStaticTabAtom, tabId);
     document.body.classList.add("nohover");
     getApi().setActiveTab(tabId);
 }
@@ -688,7 +683,6 @@ export {
     isDev,
     loadConnStatus,
     openLink,
-    overrideStaticTabAtom,
     PLATFORM,
     pushFlashError,
     pushNotification,

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -134,19 +134,22 @@ const TabBar = memo(({ workspace }: TabBarProps) => {
     const updateStatusButtonRef = useRef<HTMLButtonElement>(null);
     const configErrorButtonRef = useRef<HTMLElement>(null);
     const prevAllLoadedRef = useRef<boolean>(false);
+    const isFullScreen = useAtomValue(atoms.isFullScreen);
+    const settings = useAtomValue(atoms.settingsAtom);
+
+    // Logic to update the highlighted tab. This is eventually consistent with the workspace's active tab.
+    // When a user selects a new tab to switch to, the local state is updated immediately. Once the workspace
+    // object gets updated, the local state is updated to reflect the workspace's active tab. This prevents
+    // the previously-active tab from being highlighted when switching tabs.
     const [selectedTabId, setSelectedTabId] = useState<string>();
     const staticTabId = useAtomValue(atoms.staticTabId);
     const activeTabId = selectedTabId ?? staticTabId;
-    const isFullScreen = useAtomValue(atoms.isFullScreen);
-
-    const settings = useAtomValue(atoms.settingsAtom);
-
-    let prevDelta: number;
-    let prevDragDirection: string;
-
     useLayoutEffect(() => {
         setSelectedTabId(workspace.activetabid);
     }, [workspace.activetabid]);
+
+    let prevDelta: number;
+    let prevDragDirection: string;
 
     // Update refs when tabIds change
     useEffect(() => {

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -9,7 +9,7 @@ import { atoms, createTab, getApi, globalStore, isDev, PLATFORM, setActiveTab } 
 import { fireAndForget } from "@/util/util";
 import { useAtomValue } from "jotai";
 import { OverlayScrollbars } from "overlayscrollbars";
-import { createRef, memo, useCallback, useEffect, useRef, useState } from "react";
+import { createRef, memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { debounce } from "throttle-debounce";
 import { WorkspaceService } from "../store/services";
 import { Tab } from "./tab";
@@ -134,13 +134,19 @@ const TabBar = memo(({ workspace }: TabBarProps) => {
     const updateStatusButtonRef = useRef<HTMLButtonElement>(null);
     const configErrorButtonRef = useRef<HTMLElement>(null);
     const prevAllLoadedRef = useRef<boolean>(false);
-    const activeTabId = useAtomValue(atoms.staticTabId);
+    const [selectedTabId, setSelectedTabId] = useState<string>();
+    const staticTabId = useAtomValue(atoms.staticTabId);
+    const activeTabId = selectedTabId ?? staticTabId;
     const isFullScreen = useAtomValue(atoms.isFullScreen);
 
     const settings = useAtomValue(atoms.settingsAtom);
 
     let prevDelta: number;
     let prevDragDirection: string;
+
+    useLayoutEffect(() => {
+        setSelectedTabId(workspace.activetabid);
+    }, [workspace.activetabid]);
 
     // Update refs when tabIds change
     useEffect(() => {
@@ -537,6 +543,7 @@ const TabBar = memo(({ workspace }: TabBarProps) => {
 
     const handleSelectTab = (tabId: string) => {
         if (!draggingTabDataRef.current.dragged) {
+            setSelectedTabId(tabId);
             setActiveTab(tabId);
         }
     };

--- a/frontend/wave.ts
+++ b/frontend/wave.ts
@@ -22,7 +22,6 @@ import {
     initGlobal,
     initGlobalWaveEventSubs,
     loadConnStatus,
-    overrideStaticTabAtom,
     pushFlashError,
     pushNotification,
     removeNotificationById,
@@ -90,8 +89,6 @@ async function reinitWave() {
     getApi().sendLog("Reinit Wave");
 
     // We use this hack to prevent a flicker of the previously-hovered tab when this view was last active. This class is set in setActiveTab in global.ts. See tab.scss for where this class is used.
-    // Also overrides the staticTabAtom to the new tab id so that the active tab is set correctly.
-    globalStore.set(overrideStaticTabAtom, savedInitOpts.tabId);
     requestAnimationFrame(() =>
         setTimeout(() => {
             document.body.classList.remove("nohover");


### PR DESCRIPTION
Remove overrideStaticTabIdAtom, replace with a local state in the tabBar that gets set to whatever tabId the user selects. This handles changing the selected tab before the tab actually switches. Once the new tab view gets loaded, the workspace active tab id will update and the selected tab will reflect that new value (which should be the same). This makes it so there's no more flicker between the current and previously-selected tabs when switching tab views.