### PR TITLE
fix: changes for nowsh compatibility with wsl

### DIFF
--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -714,8 +714,8 @@ const ChangeConnectionBlockModal = React.memo(
             }
             if (
                 conn.includes(connSelected) &&
-                connectionsConfig[conn]?.["display:hidden"] != true &&
-                (connectionsConfig[conn]?.["conn:wshenabled"] != false || !filterOutNowsh)
+                connectionsConfig?.[conn]?.["display:hidden"] != true &&
+                (connectionsConfig?.[conn]?.["conn:wshenabled"] != false || !filterOutNowsh)
                 // != false is necessary because of defaults
             ) {
                 filteredList.push(conn);
@@ -728,8 +728,8 @@ const ChangeConnectionBlockModal = React.memo(
             }
             if (
                 conn.includes(connSelected) &&
-                connectionsConfig[conn]?.["display:hidden"] != true &&
-                (connectionsConfig[conn]?.["conn:wshenabled"] != false || !filterOutNowsh)
+                connectionsConfig?.[conn]?.["display:hidden"] != true &&
+                (connectionsConfig?.[conn]?.["conn:wshenabled"] != false || !filterOutNowsh)
                 // != false is necessary because of defaults
             ) {
                 filteredWslList.push(conn);
@@ -842,8 +842,8 @@ const ChangeConnectionBlockModal = React.memo(
             (itemA: SuggestionConnectionItem, itemB: SuggestionConnectionItem) => {
                 const connNameA = itemA.value;
                 const connNameB = itemB.value;
-                const valueA = connectionsConfig[connNameA]?.["display:order"] ?? 0;
-                const valueB = connectionsConfig[connNameB]?.["display:order"] ?? 0;
+                const valueA = connectionsConfig?.[connNameA]?.["display:order"] ?? 0;
+                const valueB = connectionsConfig?.[connNameB]?.["display:order"] ?? 0;
                 return valueA - valueB;
             }
         );

--- a/pkg/wsl/wsl.go
+++ b/pkg/wsl/wsl.go
@@ -89,6 +89,7 @@ func (conn *WslConn) DeriveConnStatus() wshrpc.ConnStatus {
 	return wshrpc.ConnStatus{
 		Status:        conn.Status,
 		Connected:     conn.Status == Status_Connected,
+		WshEnabled:    true, // always use wsh for wsl connections (temporary)
 		Connection:    conn.GetName(),
 		HasConnected:  (conn.LastConnectTime > 0),
 		ActiveConnNum: conn.ActiveConnNum,


### PR DESCRIPTION
The wsl largely ignores most nowsh stuff, but there are some options that can be specified for wsl. This ensures that it will still work whether or not they are set.

Additionally if fixes the wsh not installed icon.