### PR TITLE
Workspace app menu

### DIFF
--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -1,14 +1,21 @@
 // Copyright 2024, Command Line Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ClientService, FileService, WindowService, WorkspaceService } from "@/app/store/services";
+import { ClientService, FileService, ObjectService, WindowService, WorkspaceService } from "@/app/store/services";
 import { fireAndForget } from "@/util/util";
 import { BaseWindow, BaseWindowConstructorOptions, dialog, ipcMain, screen } from "electron";
 import path from "path";
 import { debounce } from "throttle-debounce";
-import { getGlobalIsQuitting, getGlobalIsRelaunching, setWasActive, setWasInFg } from "./emain-activity";
+import {
+    getGlobalIsQuitting,
+    getGlobalIsRelaunching,
+    setGlobalIsRelaunching,
+    setWasActive,
+    setWasInFg,
+} from "./emain-activity";
 import { getOrCreateWebViewForTab, getWaveTabViewByWebContentsId, WaveTabView } from "./emain-tabview";
 import { delay, ensureBoundsAreVisible } from "./emain-util";
+import { log } from "./log";
 import { getElectronAppBasePath, unamePlatform } from "./platform";
 import { updater } from "./updater";
 export type WindowOpts = {
@@ -272,6 +279,10 @@ export class WaveBrowserWindow extends BaseWindow {
 
     async switchWorkspace(workspaceId: string) {
         console.log("switchWorkspace", workspaceId, this.waveWindowId);
+        if (workspaceId == this.workspaceId) {
+            console.log("switchWorkspace already on this workspace", this.waveWindowId);
+            return;
+        }
         const curWorkspace = await WorkspaceService.GetWorkspace(this.workspaceId);
         if (curWorkspace.tabids.length > 1 && (!curWorkspace.name || !curWorkspace.icon)) {
             const choice = dialog.showMessageBoxSync(this, {
@@ -619,3 +630,62 @@ ipcMain.on("delete-workspace", async (event, workspaceId) => {
         ww.destroy();
     }
 });
+
+export async function createNewWaveWindow() {
+    log("createNewWaveWindow");
+    const clientData = await ClientService.GetClientData();
+    const fullConfig = await FileService.GetFullConfig();
+    let recreatedWindow = false;
+    const allWindows = getAllWaveWindows();
+    if (allWindows.length === 0 && clientData?.windowids?.length >= 1) {
+        console.log("no windows, but clientData has windowids, recreating first window");
+        // reopen the first window
+        const existingWindowId = clientData.windowids[0];
+        const existingWindowData = (await ObjectService.GetObject("window:" + existingWindowId)) as WaveWindow;
+        if (existingWindowData != null) {
+            const win = await createBrowserWindow(existingWindowData, fullConfig, { unamePlatform });
+            await win.waveReadyPromise;
+            win.show();
+            recreatedWindow = true;
+        }
+    }
+    if (recreatedWindow) {
+        console.log("recreated window, returning");
+        return;
+    }
+    console.log("creating new window");
+    const newBrowserWindow = await createBrowserWindow(null, fullConfig, { unamePlatform });
+    await newBrowserWindow.waveReadyPromise;
+    newBrowserWindow.show();
+}
+
+export async function relaunchBrowserWindows() {
+    console.log("relaunchBrowserWindows");
+    setGlobalIsRelaunching(true);
+    const windows = getAllWaveWindows();
+    for (const window of windows) {
+        console.log("relaunch -- closing window", window.waveWindowId);
+        window.close();
+    }
+    setGlobalIsRelaunching(false);
+
+    const clientData = await ClientService.GetClientData();
+    const fullConfig = await FileService.GetFullConfig();
+    const wins: WaveBrowserWindow[] = [];
+    for (const windowId of clientData.windowids.slice().reverse()) {
+        const windowData: WaveWindow = await WindowService.GetWindow(windowId);
+        if (windowData == null) {
+            console.log("relaunch -- window data not found, closing window", windowId);
+            await WindowService.CloseWindow(windowId, true);
+            continue;
+        }
+        console.log("relaunch -- creating window", windowId, windowData);
+        const win = await createBrowserWindow(windowData, fullConfig, { unamePlatform });
+        wins.push(win);
+    }
+    for (const win of wins) {
+        await win.waveReadyPromise;
+        console.log("show window", win.waveWindowId);
+        win.show();
+    }
+}

--- a/emain/emain-wsh.ts
+++ b/emain/emain-wsh.ts
@@ -55,6 +55,16 @@ export class ElectronWshClientType extends WshClient {
         }
         ww.focus();
     }
+
+    // async handle_workspaceupdate(rh: RpcResponseHelper) {
+    //     console.log("workspaceupdate");
+    //     fireAndForget(async () => {
+    //         console.log("workspace menu clicked");
+    //         const updatedWorkspaceMenu = await getWorkspaceMenu();
+    //         const workspaceMenu = Menu.getApplicationMenu().getMenuItemById("workspace-menu");
+    //         workspaceMenu.submenu = Menu.buildFromTemplate(updatedWorkspaceMenu);
+    //     });
+    // }
 }
 
 export let ElectronWshClient: ElectronWshClientType;

--- a/emain/log.ts
+++ b/emain/log.ts
@@ -1,0 +1,31 @@
+import path from "path";
+import { format } from "util";
+import winston from "winston";
+import { getWaveDataDir, isDev } from "./platform";
+
+const oldConsoleLog = console.log;
+
+const loggerTransports: winston.transport[] = [
+    new winston.transports.File({ filename: path.join(getWaveDataDir(), "waveapp.log"), level: "info" }),
+];
+if (isDev) {
+    loggerTransports.push(new winston.transports.Console());
+}
+const loggerConfig = {
+    level: "info",
+    format: winston.format.combine(
+        winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss.SSS" }),
+        winston.format.printf((info) => `${info.timestamp} ${info.message}`)
+    ),
+    transports: loggerTransports,
+};
+const logger = winston.createLogger(loggerConfig);
+function log(...msg: any[]) {
+    try {
+        logger.info(format(...msg));
+    } catch (e) {
+        oldConsoleLog(...msg);
+    }
+}
+
+export { log };

--- a/emain/menu.ts
+++ b/emain/menu.ts
@@ -1,10 +1,13 @@
 // Copyright 2024, Command Line Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { waveEventSubscribe } from "@/app/store/wps";
+import { RpcApi } from "@/app/store/wshclientapi";
 import * as electron from "electron";
 import { fireAndForget } from "../frontend/util/util";
 import { clearTabCache } from "./emain-tabview";
-import { focusedWaveWindow, WaveBrowserWindow } from "./emain-window";
+import { createNewWaveWindow, focusedWaveWindow, relaunchBrowserWindows, WaveBrowserWindow } from "./emain-window";
+import { ElectronWshClient } from "./emain-wsh";
 import { unamePlatform } from "./platform";
 import { updater } from "./updater";
 
@@ -27,7 +30,22 @@ function getWindowWebContents(window: electron.BaseWindow): electron.WebContents
     return null;
 }
 
-function getAppMenu(callbacks: AppMenuCallbacks): Electron.Menu {
+async function getWorkspaceMenu(): Promise<Electron.MenuItemConstructorOptions[]> {
+    const workspaceList = await RpcApi.WorkspaceListCommand(ElectronWshClient);
+    console.log("workspaceList:", workspaceList);
+    const workspaceMenu: Electron.MenuItemConstructorOptions[] = workspaceList.map((workspace) => {
+        return {
+            label: `Switch to ${workspace.workspacedata.name} (${workspace.workspacedata.oid.slice(0, 5)})`,
+            click: (_, window) => {
+                const ww = window as WaveBrowserWindow;
+                ww.switchWorkspace(workspace.workspacedata.oid);
+            },
+        };
+    });
+    return workspaceMenu;
+}
+
+async function getAppMenu(callbacks: AppMenuCallbacks): Promise<Electron.Menu> {
     const fileMenu: Electron.MenuItemConstructorOptions[] = [
         {
             label: "New Window",
@@ -224,6 +242,9 @@ function getAppMenu(callbacks: AppMenuCallbacks): Electron.Menu {
             role: "togglefullscreen",
         },
     ];
+
+    const workspaceMenu = await getWorkspaceMenu();
+
     const windowMenu: Electron.MenuItemConstructorOptions[] = [
         { role: "minimize", accelerator: "" },
         { role: "zoom" },
@@ -250,11 +271,35 @@ function getAppMenu(callbacks: AppMenuCallbacks): Electron.Menu {
             submenu: viewMenu,
         },
         {
+            label: "Workspace",
+            id: "workspace-menu",
+            submenu: workspaceMenu,
+        },
+        {
             role: "windowMenu",
             submenu: windowMenu,
         },
     ];
     return electron.Menu.buildFromTemplate(menuTemplate);
 }
+
+export function instantiateAppMenu(): Promise<electron.Menu> {
+    return getAppMenu({
+        createNewWaveWindow,
+        relaunchBrowserWindows,
+    });
+}
+
+export function makeAppMenu() {
+    fireAndForget(async () => {
+        const menu = await instantiateAppMenu();
+        electron.Menu.setApplicationMenu(menu);
+    });
+}
+
+waveEventSubscribe({
+    eventType: "workspace:update",
+    handler: makeAppMenu,
+});
 
 export { getAppMenu };

--- a/emain/preload.ts
+++ b/emain/preload.ts
@@ -40,6 +40,7 @@ contextBridge.exposeInMainWorld("api", {
     registerGlobalWebviewKeys: (keys) => ipcRenderer.send("register-global-webview-keys", keys),
     onControlShiftStateUpdate: (callback) =>
         ipcRenderer.on("control-shift-state-update", (_event, state) => callback(state)),
+    createWorkspace: () => ipcRenderer.send("create-workspace"),
     switchWorkspace: (workspaceId) => ipcRenderer.send("switch-workspace", workspaceId),
     deleteWorkspace: (workspaceId) => ipcRenderer.send("delete-workspace", workspaceId),
     setActiveTab: (tabId) => ipcRenderer.send("set-active-tab", tabId),

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -183,6 +183,11 @@ class WorkspaceServiceType {
         return WOS.callBackendService("workspace", "CreateTab", Array.from(arguments))
     }
 
+    // @returns workspaceId
+    CreateWorkspace(): Promise<string> {
+        return WOS.callBackendService("workspace", "CreateWorkspace", Array.from(arguments))
+    }
+
     // @returns object updates
     DeleteWorkspace(workspaceId: string): Promise<void> {
         return WOS.callBackendService("workspace", "DeleteWorkspace", Array.from(arguments))

--- a/frontend/app/tab/workspaceswitcher.tsx
+++ b/frontend/app/tab/workspaceswitcher.tsx
@@ -235,16 +235,23 @@ const WorkspaceSwitcher = () => {
                     </ExpandableMenu>
                 </OverlayScrollbarsComponent>
 
-                {!isActiveWorkspaceSaved && (
-                    <div className="actions">
+                <div className="actions">
+                    {isActiveWorkspaceSaved ? (
+                        <ExpandableMenuItem onClick={() => getApi().createWorkspace()}>
+                            <ExpandableMenuItemLeftElement>
+                                <i className="fa-sharp fa-solid fa-plus"></i>
+                            </ExpandableMenuItemLeftElement>
+                            <div className="content">Create new workspace</div>
+                        </ExpandableMenuItem>
+                    ) : (
                         <ExpandableMenuItem onClick={() => saveWorkspace()}>
                             <ExpandableMenuItemLeftElement>
                                 <i className="fa-sharp fa-solid fa-floppy-disk"></i>
                             </ExpandableMenuItemLeftElement>
                             <div className="content">Save workspace</div>
                         </ExpandableMenuItem>
-                    </div>
-                )}
+                    )}
+                </div>
             </PopoverContent>
         </Popover>
     );

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -89,6 +89,7 @@ declare global {
         setWebviewFocus: (focusedId: number) => void; // focusedId si the getWebContentsId of the webview
         registerGlobalWebviewKeys: (keys: string[]) => void;
         onControlShiftStateUpdate: (callback: (state: boolean) => void) => void;
+        createWorkspace: () => void;
         switchWorkspace: (workspaceId: string) => void;
         deleteWorkspace: (workspaceId: string) => void;
         setActiveTab: (tabId: string) => void;

--- a/pkg/service/objectservice/objectservice.go
+++ b/pkg/service/objectservice/objectservice.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/tsgen/tsgenmeta"
 	"github.com/wavetermdev/waveterm/pkg/waveobj"
 	"github.com/wavetermdev/waveterm/pkg/wcore"
+	"github.com/wavetermdev/waveterm/pkg/wps"
 	"github.com/wavetermdev/waveterm/pkg/wstore"
 )
 
@@ -173,6 +174,10 @@ func (svc *ObjectService) UpdateObject(uiContext waveobj.UIContext, waveObj wave
 	err = wstore.DBUpdate(ctx, waveObj)
 	if err != nil {
 		return nil, fmt.Errorf("error updating object: %w", err)
+	}
+	if (waveObj.GetOType() == waveobj.OType_Workspace) && (waveObj.(*waveobj.Workspace).Name != "") {
+		wps.Broker.Publish(wps.WaveEvent{
+			Event: wps.Event_WorkspaceUpdate})
 	}
 	if returnUpdates {
 		return waveobj.ContextGetUpdatesRtn(ctx), nil

--- a/pkg/service/windowservice/windowservice.go
+++ b/pkg/service/windowservice/windowservice.go
@@ -50,23 +50,14 @@ func (svc *WindowService) CreateWindow(ctx context.Context, winSize *waveobj.Win
 	if err != nil {
 		return nil, fmt.Errorf("error creating window: %w", err)
 	}
+
 	ws, err := wcore.GetWorkspace(ctx, window.WorkspaceId)
 	if err != nil {
-		return nil, fmt.Errorf("error getting workspace: %w", err)
+		return window, fmt.Errorf("error getting workspace: %w", err)
 	}
-	if len(ws.TabIds) == 0 {
-		_, err = wcore.CreateTab(ctx, ws.OID, "", true, false)
-		if err != nil {
-			return window, fmt.Errorf("error creating tab: %w", err)
-		}
-		ws, err = wcore.GetWorkspace(ctx, window.WorkspaceId)
-		if err != nil {
-			return nil, fmt.Errorf("error getting updated workspace: %w", err)
-		}
-		err = wlayout.BootstrapNewWorkspaceLayout(ctx, ws)
-		if err != nil {
-			return window, fmt.Errorf("error bootstrapping new workspace layout: %w", err)
-		}
+	err = wlayout.BootstrapNewWorkspaceLayout(ctx, ws)
+	if err != nil {
+		return window, fmt.Errorf("error bootstrapping new workspace layout: %w", err)
 	}
 	return window, nil
 }

--- a/pkg/service/workspaceservice/workspaceservice.go
+++ b/pkg/service/workspaceservice/workspaceservice.go
@@ -20,6 +20,25 @@ const DefaultTimeout = 2 * time.Second
 
 type WorkspaceService struct{}
 
+func (svc *WorkspaceService) CreateWorkspace_Meta() tsgenmeta.MethodMeta {
+	return tsgenmeta.MethodMeta{
+		ReturnDesc: "workspaceId",
+	}
+}
+
+func (svc *WorkspaceService) CreateWorkspace(ctx context.Context) (string, error) {
+	newWS, err := wcore.CreateWorkspace(ctx, "", "", "")
+	if err != nil {
+		return "", fmt.Errorf("error creating workspace: %w", err)
+	}
+
+	err = wlayout.BootstrapNewWorkspaceLayout(ctx, newWS)
+	if err != nil {
+		return newWS.OID, fmt.Errorf("error bootstrapping new workspace layout: %w", err)
+	}
+	return newWS.OID, nil
+}
+
 func (svc *WorkspaceService) GetWorkspace_Meta() tsgenmeta.MethodMeta {
 	return tsgenmeta.MethodMeta{
 		ArgNames: []string{"workspaceId"},

--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -11,6 +11,7 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/telemetry"
 	"github.com/wavetermdev/waveterm/pkg/util/utilfn"
 	"github.com/wavetermdev/waveterm/pkg/waveobj"
+	"github.com/wavetermdev/waveterm/pkg/wps"
 	"github.com/wavetermdev/waveterm/pkg/wshrpc"
 	"github.com/wavetermdev/waveterm/pkg/wstore"
 )
@@ -26,6 +27,8 @@ func CreateWorkspace(ctx context.Context, name string, icon string, color string
 		Color:        color,
 	}
 	wstore.DBInsert(ctx, ws)
+	wps.Broker.Publish(wps.WaveEvent{
+		Event: wps.Event_WorkspaceUpdate})
 	return ws, nil
 }
 
@@ -56,6 +59,8 @@ func DeleteWorkspace(ctx context.Context, workspaceId string, force bool) (bool,
 		return false, fmt.Errorf("error deleting workspace: %w", err)
 	}
 	log.Printf("deleted workspace %s\n", workspaceId)
+	wps.Broker.Publish(wps.WaveEvent{
+		Event: wps.Event_WorkspaceUpdate})
 	return true, nil
 }
 

--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -41,7 +41,7 @@ func DeleteWorkspace(ctx context.Context, workspaceId string, force bool) (bool,
 	if err != nil {
 		return false, fmt.Errorf("error getting workspace: %w", err)
 	}
-	if workspace.Name != "" && workspace.Icon != "" && !force && len(workspace.TabIds) > 0 && len(workspace.PinnedTabIds) > 0 {
+	if workspace.Name != "" && workspace.Icon != "" && !force && (len(workspace.TabIds) > 0 || len(workspace.PinnedTabIds) > 0) {
 		log.Printf("Ignoring DeleteWorkspace for workspace %s as it is named\n", workspaceId)
 		return false, nil
 	}
@@ -168,7 +168,7 @@ func DeleteTab(ctx context.Context, workspaceId string, tabId string, recursive 
 	wstore.DBDelete(ctx, waveobj.OType_LayoutState, tab.LayoutState)
 
 	// if no tabs remaining, close window
-	if newActiveTabId == "" && recursive {
+	if recursive && newActiveTabId == "" {
 		log.Printf("no tabs remaining in workspace %s, closing window\n", workspaceId)
 		windowId, err := wstore.DBFindWindowForWorkspaceId(ctx, workspaceId)
 		if err != nil {

--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -26,7 +26,19 @@ func CreateWorkspace(ctx context.Context, name string, icon string, color string
 		Icon:         icon,
 		Color:        color,
 	}
-	wstore.DBInsert(ctx, ws)
+	err := wstore.DBInsert(ctx, ws)
+	if err != nil {
+		return nil, fmt.Errorf("error inserting workspace: %w", err)
+	}
+
+	_, err = CreateTab(ctx, ws.OID, "", true, false)
+	if err != nil {
+		return nil, fmt.Errorf("error creating tab: %w", err)
+	}
+	ws, err = GetWorkspace(ctx, ws.OID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting updated workspace: %w", err)
+	}
 	wps.Broker.Publish(wps.WaveEvent{
 		Event: wps.Event_WorkspaceUpdate})
 	return ws, nil

--- a/pkg/wps/wpstypes.go
+++ b/pkg/wps/wpstypes.go
@@ -12,6 +12,7 @@ const (
 	Event_Config           = "config"
 	Event_UserInput        = "userinput"
 	Event_RouteGone        = "route:gone"
+	Event_WorkspaceUpdate  = "workspace:update"
 )
 
 type WaveEvent struct {


### PR DESCRIPTION
Adds a new app menu for creating a new workspace or switching to an existing one. This required adding a new WPS event any time a workspace gets updated, since the Electron app menus are static. 

This also fixes a bug where closing a workspace could delete it if it didn't have both a pinned and an unpinned tab.