### PR TITLE
Retry the macOS builds in case of notarize failures

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -113,9 +113,15 @@ jobs:
               env:
                   USE_SYSTEM_FPM: true # Ensure that the installed version of FPM is used rather than the bundled one.
                   SNAPCRAFT_BUILD_ENVIRONMENT: host
-            - name: Build (Darwin)
+            # Retry Darwin build in case of notarization failures
+            - uses: nick-fields/retry@v3
+              name: Build (Darwin)
               if: matrix.platform == 'darwin'
-              run: task package
+              with:
+                  command: task package
+                  timeout_minutes: 120
+                  retry_on: error
+                  max_attempts: 3
               env:
                   USE_SYSTEM_FPM: true # Ensure that the installed version of FPM is used rather than the bundled one.
                   CSC_LINK: ${{ matrix.platform == 'darwin' && secrets.PROD_MACOS_CERTIFICATE_2}}


### PR DESCRIPTION
The notarize operation is flaky so I'm wrapping it in a retry