### PR TITLE
fix: smarter connection typeahead arrows

### DIFF
--- a/frontend/app/modals/typeaheadmodal.tsx
+++ b/frontend/app/modals/typeaheadmodal.tsx
@@ -63,7 +63,8 @@ const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
                             </div>
                         );
                     }
-                    return renderItem(item as SuggestionBaseItem, index);
+                    fullIndex += 1;
+                    return renderItem(item as SuggestionBaseItem, fullIndex);
                 })}
             </div>
         );


### PR DESCRIPTION
This changes the order of typeahead options to be more user friendly. Additionally, it moves the selected element to the top after a non-arrow keypress.