### PR TITLE
Move wlayout to wcore, create new tab layout for all new tabs

### DIFF
--- a/pkg/service/clientservice/clientservice.go
+++ b/pkg/service/clientservice/clientservice.go
@@ -14,7 +14,6 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/wcloud"
 	"github.com/wavetermdev/waveterm/pkg/wconfig"
 	"github.com/wavetermdev/waveterm/pkg/wcore"
-	"github.com/wavetermdev/waveterm/pkg/wlayout"
 	"github.com/wavetermdev/waveterm/pkg/wshrpc"
 	"github.com/wavetermdev/waveterm/pkg/wsl"
 	"github.com/wavetermdev/waveterm/pkg/wstore"
@@ -64,7 +63,7 @@ func (cs *ClientService) AgreeTos(ctx context.Context) (waveobj.UpdatesRtnType, 
 	if err != nil {
 		return nil, fmt.Errorf("error updating client data: %w", err)
 	}
-	wlayout.BootstrapStarterLayout(ctx)
+	wcore.BootstrapStarterLayout(ctx)
 	return waveobj.ContextGetUpdatesRtn(ctx), nil
 }
 

--- a/pkg/service/windowservice/windowservice.go
+++ b/pkg/service/windowservice/windowservice.go
@@ -14,7 +14,6 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/tsgen/tsgenmeta"
 	"github.com/wavetermdev/waveterm/pkg/waveobj"
 	"github.com/wavetermdev/waveterm/pkg/wcore"
-	"github.com/wavetermdev/waveterm/pkg/wlayout"
 	"github.com/wavetermdev/waveterm/pkg/wps"
 	"github.com/wavetermdev/waveterm/pkg/wstore"
 )
@@ -49,15 +48,6 @@ func (svc *WindowService) CreateWindow(ctx context.Context, winSize *waveobj.Win
 	window, err := wcore.CreateWindow(ctx, winSize, workspaceId)
 	if err != nil {
 		return nil, fmt.Errorf("error creating window: %w", err)
-	}
-
-	ws, err := wcore.GetWorkspace(ctx, window.WorkspaceId)
-	if err != nil {
-		return window, fmt.Errorf("error getting workspace: %w", err)
-	}
-	err = wlayout.BootstrapNewWorkspaceLayout(ctx, ws)
-	if err != nil {
-		return window, fmt.Errorf("error bootstrapping new workspace layout: %w", err)
 	}
 	return window, nil
 }
@@ -137,12 +127,12 @@ func (svc *WindowService) MoveBlockToNewWindow(ctx context.Context, currentTabId
 	if !windowCreated {
 		return nil, fmt.Errorf("new window not created")
 	}
-	wlayout.QueueLayoutActionForTab(ctx, currentTabId, waveobj.LayoutActionData{
-		ActionType: wlayout.LayoutActionDataType_Remove,
+	wcore.QueueLayoutActionForTab(ctx, currentTabId, waveobj.LayoutActionData{
+		ActionType: wcore.LayoutActionDataType_Remove,
 		BlockId:    blockId,
 	})
-	wlayout.QueueLayoutActionForTab(ctx, ws.ActiveTabId, waveobj.LayoutActionData{
-		ActionType: wlayout.LayoutActionDataType_Insert,
+	wcore.QueueLayoutActionForTab(ctx, ws.ActiveTabId, waveobj.LayoutActionData{
+		ActionType: wcore.LayoutActionDataType_Insert,
 		BlockId:    blockId,
 		Focused:    true,
 	})

--- a/pkg/service/workspaceservice/workspaceservice.go
+++ b/pkg/service/workspaceservice/workspaceservice.go
@@ -11,7 +11,6 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/tsgen/tsgenmeta"
 	"github.com/wavetermdev/waveterm/pkg/waveobj"
 	"github.com/wavetermdev/waveterm/pkg/wcore"
-	"github.com/wavetermdev/waveterm/pkg/wlayout"
 	"github.com/wavetermdev/waveterm/pkg/wps"
 	"github.com/wavetermdev/waveterm/pkg/wstore"
 )
@@ -32,7 +31,7 @@ func (svc *WorkspaceService) CreateWorkspace(ctx context.Context) (string, error
 		return "", fmt.Errorf("error creating workspace: %w", err)
 	}
 
-	err = wlayout.BootstrapNewWorkspaceLayout(ctx, newWS)
+	err = wcore.BootstrapNewWorkspaceLayout(ctx, newWS)
 	if err != nil {
 		return newWS.OID, fmt.Errorf("error bootstrapping new workspace layout: %w", err)
 	}
@@ -100,10 +99,6 @@ func (svc *WorkspaceService) CreateTab(workspaceId string, tabName string, activ
 	tabId, err := wcore.CreateTab(ctx, workspaceId, tabName, activateTab, pinned)
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating tab: %w", err)
-	}
-	err = wlayout.ApplyPortableLayout(ctx, tabId, wlayout.GetNewTabLayout())
-	if err != nil {
-		return "", nil, fmt.Errorf("error applying new tab layout: %w", err)
 	}
 	updates := waveobj.ContextGetUpdatesRtn(ctx)
 	go func() {

--- a/pkg/service/workspaceservice/workspaceservice.go
+++ b/pkg/service/workspaceservice/workspaceservice.go
@@ -26,7 +26,7 @@ func (svc *WorkspaceService) CreateWorkspace_Meta() tsgenmeta.MethodMeta {
 }
 
 func (svc *WorkspaceService) CreateWorkspace(ctx context.Context) (string, error) {
-	newWS, err := wcore.CreateWorkspace(ctx, "", "", "")
+	newWS, err := wcore.CreateWorkspace(ctx, "", "", "", false)
 	if err != nil {
 		return "", fmt.Errorf("error creating workspace: %w", err)
 	}

--- a/pkg/service/workspaceservice/workspaceservice.go
+++ b/pkg/service/workspaceservice/workspaceservice.go
@@ -96,7 +96,7 @@ func (svc *WorkspaceService) CreateTab(workspaceId string, tabName string, activ
 	ctx, cancelFn := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancelFn()
 	ctx = waveobj.ContextWithUpdates(ctx)
-	tabId, err := wcore.CreateTab(ctx, workspaceId, tabName, activateTab, pinned)
+	tabId, err := wcore.CreateTab(ctx, workspaceId, tabName, activateTab, pinned, false)
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating tab: %w", err)
 	}

--- a/pkg/wcore/layout.go
+++ b/pkg/wcore/layout.go
@@ -1,7 +1,7 @@
 // Copyright 2024, Command Line Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package wlayout
+package wcore
 
 import (
 	"context"
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/wavetermdev/waveterm/pkg/waveobj"
-	"github.com/wavetermdev/waveterm/pkg/wcore"
 	"github.com/wavetermdev/waveterm/pkg/wstore"
 )
 
@@ -131,7 +130,7 @@ func ApplyPortableLayout(ctx context.Context, tabId string, layout PortableLayou
 	for i := 0; i < len(layout); i++ {
 		layoutAction := layout[i]
 
-		blockData, err := wcore.CreateBlock(ctx, tabId, layoutAction.BlockDef, &waveobj.RuntimeOpts{})
+		blockData, err := CreateBlock(ctx, tabId, layoutAction.BlockDef, &waveobj.RuntimeOpts{})
 		if err != nil {
 			return fmt.Errorf("unable to create block to apply portable layout to tab %s: %w", tabId, err)
 		}

--- a/pkg/wcore/wcore.go
+++ b/pkg/wcore/wcore.go
@@ -54,13 +54,9 @@ func EnsureInitialData() error {
 		return nil
 	}
 	log.Println("client has no windows, creating starter workspace")
-	starterWs, err := CreateWorkspace(ctx, "Starter workspace", "circle", "green")
+	starterWs, err := CreateWorkspace(ctx, "Starter workspace", "circle", "green", true)
 	if err != nil {
 		return fmt.Errorf("error creating starter workspace: %w", err)
-	}
-	_, err = CreateTab(ctx, starterWs.OID, "", true, true)
-	if err != nil {
-		return fmt.Errorf("error creating tab: %w", err)
 	}
 	_, err = CreateWindow(ctx, nil, starterWs.OID)
 	if err != nil {

--- a/pkg/wcore/window.go
+++ b/pkg/wcore/window.go
@@ -185,7 +185,7 @@ func CheckAndFixWindow(ctx context.Context, windowId string) *waveobj.Window {
 	}
 	if len(ws.TabIds) == 0 {
 		log.Printf("fixing workspace with no tabs %q (in checkAndFixWindow)\n", ws.OID)
-		_, err = CreateTab(ctx, ws.OID, "", true, false)
+		_, err = CreateTab(ctx, ws.OID, "", true, false, false)
 		if err != nil {
 			log.Printf("error creating tab (in checkAndFixWindow): %v\n", err)
 		}

--- a/pkg/wcore/window.go
+++ b/pkg/wcore/window.go
@@ -80,6 +80,15 @@ func CreateWindow(ctx context.Context, winSize *waveobj.WinSize, workspaceId str
 			return nil, fmt.Errorf("error creating workspace: %w", err)
 		}
 		ws = ws1
+		err = BootstrapNewWorkspaceLayout(ctx, ws)
+		if err != nil {
+			errStr := fmt.Errorf("error bootstrapping new workspace layout: %w", err)
+			_, err = DeleteWorkspace(ctx, ws.OID, true)
+			if err != nil {
+				errStr = fmt.Errorf("%s\nerror deleting workspace: %w", errStr, err)
+			}
+			return nil, errStr
+		}
 	} else {
 		ws1, err := GetWorkspace(ctx, workspaceId)
 		if err != nil {

--- a/pkg/wcore/window.go
+++ b/pkg/wcore/window.go
@@ -75,7 +75,7 @@ func CreateWindow(ctx context.Context, winSize *waveobj.WinSize, workspaceId str
 	log.Printf("CreateWindow %v %v\n", winSize, workspaceId)
 	var ws *waveobj.Workspace
 	if workspaceId == "" {
-		ws1, err := CreateWorkspace(ctx, "", "", "")
+		ws1, err := CreateWorkspace(ctx, "", "", "", false)
 		if err != nil {
 			return nil, fmt.Errorf("error creating workspace: %w", err)
 		}

--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -99,6 +99,11 @@ func CreateTab(ctx context.Context, workspaceId string, tabName string, activate
 			return "", fmt.Errorf("error setting active tab: %w", err)
 		}
 	}
+
+	err = ApplyPortableLayout(ctx, tab.OID, GetNewTabLayout())
+	if err != nil {
+		return tab.OID, fmt.Errorf("error applying new tab layout: %w", err)
+	}
 	telemetry.GoUpdateActivityWrap(wshrpc.ActivityUpdate{NewTab: 1}, "createtab")
 	return tab.OID, nil
 }

--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -16,7 +16,7 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/wstore"
 )
 
-func CreateWorkspace(ctx context.Context, name string, icon string, color string, pinInitialTab bool) (*waveobj.Workspace, error) {
+func CreateWorkspace(ctx context.Context, name string, icon string, color string, isInitialLaunch bool) (*waveobj.Workspace, error) {
 	log.Println("CreateWorkspace")
 	ws := &waveobj.Workspace{
 		OID:          uuid.NewString(),
@@ -31,7 +31,7 @@ func CreateWorkspace(ctx context.Context, name string, icon string, color string
 		return nil, fmt.Errorf("error inserting workspace: %w", err)
 	}
 
-	_, err = CreateTab(ctx, ws.OID, "", true, pinInitialTab)
+	_, err = CreateTab(ctx, ws.OID, "", true, isInitialLaunch)
 	if err != nil {
 		return nil, fmt.Errorf("error creating tab: %w", err)
 	}
@@ -81,7 +81,7 @@ func GetWorkspace(ctx context.Context, wsID string) (*waveobj.Workspace, error) 
 }
 
 // returns tabid
-func CreateTab(ctx context.Context, workspaceId string, tabName string, activateTab bool, pinned bool) (string, error) {
+func CreateTab(ctx context.Context, workspaceId string, tabName string, activateTab bool, isInitialLaunch bool) (string, error) {
 	if tabName == "" {
 		ws, err := GetWorkspace(ctx, workspaceId)
 		if err != nil {
@@ -89,7 +89,9 @@ func CreateTab(ctx context.Context, workspaceId string, tabName string, activate
 		}
 		tabName = "T" + fmt.Sprint(len(ws.TabIds)+len(ws.PinnedTabIds)+1)
 	}
-	tab, err := createTabObj(ctx, workspaceId, tabName, pinned)
+
+	// The initial tab for the initial launch should be pinned
+	tab, err := createTabObj(ctx, workspaceId, tabName, isInitialLaunch)
 	if err != nil {
 		return "", fmt.Errorf("error creating tab: %w", err)
 	}
@@ -100,9 +102,12 @@ func CreateTab(ctx context.Context, workspaceId string, tabName string, activate
 		}
 	}
 
-	err = ApplyPortableLayout(ctx, tab.OID, GetNewTabLayout())
-	if err != nil {
-		return tab.OID, fmt.Errorf("error applying new tab layout: %w", err)
+	// No need to apply an initial layout for the initial launch, since the starter layout will get applied after TOS modal dismissal
+	if !isInitialLaunch {
+		err = ApplyPortableLayout(ctx, tab.OID, GetNewTabLayout())
+		if err != nil {
+			return tab.OID, fmt.Errorf("error applying new tab layout: %w", err)
+		}
 	}
 	telemetry.GoUpdateActivityWrap(wshrpc.ActivityUpdate{NewTab: 1}, "createtab")
 	return tab.OID, nil

--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -31,7 +31,7 @@ func CreateWorkspace(ctx context.Context, name string, icon string, color string
 		return nil, fmt.Errorf("error inserting workspace: %w", err)
 	}
 
-	_, err = CreateTab(ctx, ws.OID, "", true, isInitialLaunch)
+	_, err = CreateTab(ctx, ws.OID, "", true, false, isInitialLaunch)
 	if err != nil {
 		return nil, fmt.Errorf("error creating tab: %w", err)
 	}
@@ -81,7 +81,7 @@ func GetWorkspace(ctx context.Context, wsID string) (*waveobj.Workspace, error) 
 }
 
 // returns tabid
-func CreateTab(ctx context.Context, workspaceId string, tabName string, activateTab bool, isInitialLaunch bool) (string, error) {
+func CreateTab(ctx context.Context, workspaceId string, tabName string, activateTab bool, pinned bool, isInitialLaunch bool) (string, error) {
 	if tabName == "" {
 		ws, err := GetWorkspace(ctx, workspaceId)
 		if err != nil {
@@ -91,7 +91,7 @@ func CreateTab(ctx context.Context, workspaceId string, tabName string, activate
 	}
 
 	// The initial tab for the initial launch should be pinned
-	tab, err := createTabObj(ctx, workspaceId, tabName, isInitialLaunch)
+	tab, err := createTabObj(ctx, workspaceId, tabName, pinned || isInitialLaunch)
 	if err != nil {
 		return "", fmt.Errorf("error creating tab: %w", err)
 	}

--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -16,7 +16,7 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/wstore"
 )
 
-func CreateWorkspace(ctx context.Context, name string, icon string, color string) (*waveobj.Workspace, error) {
+func CreateWorkspace(ctx context.Context, name string, icon string, color string, pinInitialTab bool) (*waveobj.Workspace, error) {
 	log.Println("CreateWorkspace")
 	ws := &waveobj.Workspace{
 		OID:          uuid.NewString(),
@@ -31,7 +31,7 @@ func CreateWorkspace(ctx context.Context, name string, icon string, color string
 		return nil, fmt.Errorf("error inserting workspace: %w", err)
 	}
 
-	_, err = CreateTab(ctx, ws.OID, "", true, false)
+	_, err = CreateTab(ctx, ws.OID, "", true, pinInitialTab)
 	if err != nil {
 		return nil, fmt.Errorf("error creating tab: %w", err)
 	}

--- a/pkg/wshrpc/wshserver/wshserver.go
+++ b/pkg/wshrpc/wshserver/wshserver.go
@@ -29,7 +29,6 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/waveobj"
 	"github.com/wavetermdev/waveterm/pkg/wconfig"
 	"github.com/wavetermdev/waveterm/pkg/wcore"
-	"github.com/wavetermdev/waveterm/pkg/wlayout"
 	"github.com/wavetermdev/waveterm/pkg/wps"
 	"github.com/wavetermdev/waveterm/pkg/wshrpc"
 	"github.com/wavetermdev/waveterm/pkg/wshutil"
@@ -180,8 +179,8 @@ func (ws *WshServer) CreateBlockCommand(ctx context.Context, data wshrpc.Command
 	if err != nil {
 		return nil, fmt.Errorf("error creating block: %w", err)
 	}
-	err = wlayout.QueueLayoutActionForTab(ctx, tabId, waveobj.LayoutActionData{
-		ActionType: wlayout.LayoutActionDataType_Insert,
+	err = wcore.QueueLayoutActionForTab(ctx, tabId, waveobj.LayoutActionData{
+		ActionType: wcore.LayoutActionDataType_Insert,
 		BlockId:    blockData.OID,
 		Magnified:  data.Magnified,
 		Focused:    true,
@@ -506,8 +505,8 @@ func (ws *WshServer) DeleteBlockCommand(ctx context.Context, data wshrpc.Command
 	if err != nil {
 		return fmt.Errorf("error deleting block: %w", err)
 	}
-	wlayout.QueueLayoutActionForTab(ctx, tabId, waveobj.LayoutActionData{
-		ActionType: wlayout.LayoutActionDataType_Remove,
+	wcore.QueueLayoutActionForTab(ctx, tabId, waveobj.LayoutActionData{
+		ActionType: wcore.LayoutActionDataType_Remove,
 		BlockId:    data.BlockId,
 	})
 	updates := waveobj.ContextGetUpdatesRtn(ctx)


### PR DESCRIPTION
Moves the wlayout package contents to wcore to prevent import cycles. Moves the layout calls to other wcore functions instead of being handled by the services. Removes redundant CreateTab in EnsureInitialData and adds a isInitialLaunch flag to the CreateTab and CreateWorkspace functions to ensure that the initial tab is pinned and does not have the initial tab layout (since the starter layout gets applied later)