### PR TITLE
Remove workspace oid from menu

### DIFF
--- a/emain/menu.ts
+++ b/emain/menu.ts
@@ -63,7 +63,7 @@ async function getWorkspaceMenu(ww?: WaveBrowserWindow): Promise<Electron.MenuIt
             { type: "separator" },
             ...workspaceList.map<Electron.MenuItemConstructorOptions>((workspace, i) => {
                 return {
-                    label: `Switch to ${workspace.workspacedata.name} (${workspace.workspacedata.oid.slice(0, 5)})`,
+                    label: `Switch to ${workspace.workspacedata.name}`,
                     click: (_, window) => {
                         ((window as WaveBrowserWindow) ?? ww)?.switchWorkspace(workspace.workspacedata.oid);
                     },


### PR DESCRIPTION
Now that new workspace has this already in the name, it looks weird to have it added after

![image](https://github.com/user-attachments/assets/405d2111-25e5-4ef4-a467-fae6acb55e11)
