### PR TITLE
Fix Preview for Uninitialized Connections

### DIFF
--- a/docs/docs/releasenotes.mdx
+++ b/docs/docs/releasenotes.mdx
@@ -24,6 +24,7 @@ Wave Terminal v0.10.0 introduces workspaces, making it easier to manage multiple
 - [bugfix] Fixed tab flickering issues during tab switches
 - [bugfix] Corrected WaveAI text area resize behavior
 - [bugfix] Fixed concurrent block controller start issues
+- [bugfix] Fixed Preview Blocks for uninitialized connections
 - Upgraded Go toolchain to 1.23.4
 - Other bug fixes, performance improvements, and dependency updates
 


### PR DESCRIPTION
If a connection had not been previously initialized, selecting it in the preview dropdown was bug-prone. This ensures the connection is complete before checking the mimetype and selecting the type of preview.