### PR TITLE
Fix errors in loading of help view

### DIFF
--- a/frontend/app/view/helpview/helpview.tsx
+++ b/frontend/app/view/helpview/helpview.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BlockNodeModel } from "@/app/block/blocktypes";
-import { getApi } from "@/app/store/global";
+import { getApi, globalStore } from "@/app/store/global";
 import { WebView, WebViewModel } from "@/app/view/webview/webview";
 import { fireAndForget } from "@/util/util";
 import { atom, useAtomValue } from "jotai";
@@ -39,7 +39,12 @@ class HelpViewModel extends WebViewModel {
                 },
             ];
         });
-        this.homepageUrl = atom(getApi().getDocsiteUrl());
+        const startUrl = getApi().getDocsiteUrl();
+        const url = globalStore.get(this.url);
+        const metaUrl = globalStore.get(this.blockAtom)?.meta?.url;
+        console.log("help-view-model-ctor", url, metaUrl, startUrl);
+        this.url = atom(url ?? metaUrl ?? startUrl);
+        this.homepageUrl = atom(startUrl);
         this.viewType = "help";
         this.viewIcon = atom("circle-question");
         this.viewName = atom("Help");
@@ -54,6 +59,7 @@ class HelpViewModel extends WebViewModel {
             const strippedDocsiteUrl = getApi().getDocsiteUrl().replace(baseUrlRegex, "");
             const strippedCurUrl = url.replace(baseUrlRegex, "").replace(strippedDocsiteUrl, "");
             const newUrl = docsiteWebUrl + strippedCurUrl;
+            console.log("modify-external-url", url, newUrl, strippedDocsiteUrl, strippedCurUrl);
             return newUrl;
         };
     }
@@ -97,7 +103,6 @@ function HelpView({ model }: { model: HelpViewModel }) {
                 // Correct the base URL of the current page, if necessary
                 const newBaseUrl = baseUrlRegex.exec(newDocsiteUrl)?.[0];
                 const curBaseUrl = baseUrlRegex.exec(url)?.[0];
-                console.log("fix-docsite-url", url, newDocsiteUrl, homepageUrl, curBaseUrl, newBaseUrl);
                 if (curBaseUrl && newBaseUrl && curBaseUrl !== newBaseUrl) {
                     model.loadUrl(url.replace(curBaseUrl, newBaseUrl), "fix-fail-load");
                 }

--- a/frontend/app/view/helpview/helpview.tsx
+++ b/frontend/app/view/helpview/helpview.tsx
@@ -54,7 +54,7 @@ class HelpViewModel extends WebViewModel {
             const strippedDocsiteUrl = getApi().getDocsiteUrl().replace(baseUrlRegex, "");
             const strippedCurUrl = url.replace(baseUrlRegex, "").replace(strippedDocsiteUrl, "");
             const newUrl = docsiteWebUrl + strippedCurUrl;
-            console.log("modify-external-url", url, newUrl, strippedDocsiteUrl, strippedCurUrl);
+            console.log("modify-external-url", url, newUrl);
             return newUrl;
         };
     }

--- a/frontend/app/view/helpview/helpview.tsx
+++ b/frontend/app/view/helpview/helpview.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BlockNodeModel } from "@/app/block/blocktypes";
-import { getApi, globalStore } from "@/app/store/global";
+import { getApi } from "@/app/store/global";
 import { WebView, WebViewModel } from "@/app/view/webview/webview";
 import { fireAndForget } from "@/util/util";
 import { atom, useAtomValue } from "jotai";
@@ -39,12 +39,7 @@ class HelpViewModel extends WebViewModel {
                 },
             ];
         });
-        const startUrl = getApi().getDocsiteUrl();
-        const url = globalStore.get(this.url);
-        const metaUrl = globalStore.get(this.blockAtom)?.meta?.url;
-        console.log("help-view-model-ctor", url, metaUrl, startUrl);
-        this.url = atom(url ?? metaUrl ?? startUrl);
-        this.homepageUrl = atom(startUrl);
+        this.homepageUrl = atom(getApi().getDocsiteUrl());
         this.viewType = "help";
         this.viewIcon = atom("circle-question");
         this.viewName = atom("Help");

--- a/frontend/app/view/webview/webview.tsx
+++ b/frontend/app/view/webview/webview.tsx
@@ -293,7 +293,6 @@ export class WebViewModel implements ViewModel {
      * @param url The URL that has been navigated to.
      */
     handleNavigate(url: string) {
-        console.log("webview handleNavigate", url);
         fireAndForget(() => ObjectService.UpdateObjectMeta(WOS.makeORef("block", this.blockId), { url }));
         globalStore.set(this.url, url);
     }
@@ -353,11 +352,7 @@ export class WebViewModel implements ViewModel {
             return;
         }
         if (this.webviewRef.current.getURL() != nextUrl) {
-            console.log("webview loadURL", nextUrl);
-            fireAndForget(async () => {
-                await this.webviewRef.current.loadURL(nextUrl);
-                console.log("webview loadURL done", nextUrl);
-            });
+            fireAndForget(() => this.webviewRef.current.loadURL(nextUrl));
         }
         if (newUrl != nextUrl) {
             globalStore.set(this.url, nextUrl);

--- a/frontend/app/view/webview/webview.tsx
+++ b/frontend/app/view/webview/webview.tsx
@@ -339,15 +339,7 @@ export class WebViewModel implements ViewModel {
         const defaultSearchAtom = getSettingsKeyAtom("web:defaultsearch");
         const searchTemplate = globalStore.get(defaultSearchAtom);
         const nextUrl = this.ensureUrlScheme(newUrl, searchTemplate);
-        console.log(
-            "webview loadUrl",
-            reason,
-            nextUrl,
-            newUrl,
-            "cur=",
-            this.webviewRef?.current.getURL(),
-            this.webviewRef.current
-        );
+        console.log("webview loadUrl", reason, nextUrl, "cur=", this.webviewRef?.current.getURL());
         if (!this.webviewRef.current) {
             return;
         }

--- a/pkg/service/objectservice/objectservice.go
+++ b/pkg/service/objectservice/objectservice.go
@@ -6,6 +6,7 @@ package objectservice
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -136,6 +137,7 @@ func (svc *ObjectService) UpdateObjectMeta_Meta() tsgenmeta.MethodMeta {
 }
 
 func (svc *ObjectService) UpdateObjectMeta(uiContext waveobj.UIContext, orefStr string, meta waveobj.MetaMapType) (waveobj.UpdatesRtnType, error) {
+	log.Printf("UpdateObjectMeta: %s %v\n", orefStr, meta)
 	ctx, cancelFn := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancelFn()
 	ctx = waveobj.ContextWithUpdates(ctx)

--- a/pkg/service/objectservice/objectservice.go
+++ b/pkg/service/objectservice/objectservice.go
@@ -6,7 +6,6 @@ package objectservice
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -137,7 +136,6 @@ func (svc *ObjectService) UpdateObjectMeta_Meta() tsgenmeta.MethodMeta {
 }
 
 func (svc *ObjectService) UpdateObjectMeta(uiContext waveobj.UIContext, orefStr string, meta waveobj.MetaMapType) (waveobj.UpdatesRtnType, error) {
-	log.Printf("UpdateObjectMeta: %s %v\n", orefStr, meta)
 	ctx, cancelFn := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancelFn()
 	ctx = waveobj.ContextWithUpdates(ctx)
@@ -147,7 +145,7 @@ func (svc *ObjectService) UpdateObjectMeta(uiContext waveobj.UIContext, orefStr 
 	}
 	err = wstore.UpdateObjectMeta(ctx, *oref, meta, false)
 	if err != nil {
-		return nil, fmt.Errorf("error updateing %q meta: %w", orefStr, err)
+		return nil, fmt.Errorf("error updating %q meta: %w", orefStr, err)
 	}
 	return waveobj.ContextGetUpdatesRtn(ctx), nil
 }


### PR DESCRIPTION
When clicking on one of the cards from the home page of the docsite and when initially loading the home page of the docsite, the webviewTag was emitting a `did-frame-navigate` event, which we weren't tracking. This meant that we were not properly recording that a navigation had occurred. This caused three separate issues:

- We were never setting the meta url for the block, which meant that when you navigated to a different tab or reloaded the app, you'd lose what page you were last on.
- The site would reload after we fixed a broken docsite url, but we wouldn't remove the error text that blocks the broken site.
- Clicking on the "open in external browser" button wouldn't do anything.

