### PR TITLE
Create workspace will always create a saved workspace

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -69,7 +69,6 @@ jobs:
                       corepack enable
                       yarn install
                   timeout_minutes: 5
-                  retry_on: error
                   max_attempts: 3
             - name: Install Task
               uses: arduino/setup-task@v2

--- a/.github/workflows/testdriver.yml
+++ b/.github/workflows/testdriver.yml
@@ -53,7 +53,6 @@ jobs:
                       corepack enable
                       yarn install
                   timeout_minutes: 5
-                  retry_on: error
                   max_attempts: 3
             - name: Install Task
               uses: arduino/setup-task@v2

--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -304,20 +304,9 @@ export class WaveBrowserWindow extends BaseWindow {
         if (!workspaceList?.find((wse) => wse.workspaceid === workspaceId)?.windowid) {
             const curWorkspace = await WorkspaceService.GetWorkspace(this.workspaceId);
             if (showCloseConfirmDialog(curWorkspace)) {
-                const choice = dialog.showMessageBoxSync(this, {
-                    type: "question",
-                    buttons: ["Cancel", "Open in New Window", "Switch Workspace"],
-                    title: "Confirm",
-                    message: "Window has unsaved tabs, switching workspaces will delete existing tabs.\n\nContinue?",
-                });
-                if (choice === 0) {
-                    console.log("user cancelled switch workspace", this.waveWindowId);
-                    return;
-                } else if (choice === 1) {
-                    console.log("user chose open in new window", this.waveWindowId);
-                    await createWindowForWorkspace(workspaceId);
-                    return;
-                }
+                console.log("user chose open in new window", this.waveWindowId);
+                await createWindowForWorkspace(workspaceId);
+                return;
             }
         }
         await this._queueActionInternal({ op: "switchworkspace", workspaceId });

--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -315,14 +315,7 @@ export class WaveBrowserWindow extends BaseWindow {
                     return;
                 } else if (choice === 1) {
                     console.log("user chose open in new window", this.waveWindowId);
-                    const newWin = await WindowService.CreateWindow(null, workspaceId);
-                    if (!newWin) {
-                        console.log("error creating new window", this.waveWindowId);
-                    }
-                    const newBwin = await createBrowserWindow(newWin, await FileService.GetFullConfig(), {
-                        unamePlatform,
-                    });
-                    newBwin.show();
+                    await createWindowForWorkspace(workspaceId);
                     return;
                 }
             }
@@ -605,6 +598,17 @@ export function getAllWaveWindows(): WaveBrowserWindow[] {
     return Array.from(waveWindowMap.values());
 }
 
+export async function createWindowForWorkspace(workspaceId: string) {
+    const newWin = await WindowService.CreateWindow(null, workspaceId);
+    if (!newWin) {
+        console.log("error creating new window", this.waveWindowId);
+    }
+    const newBwin = await createBrowserWindow(newWin, await FileService.GetFullConfig(), {
+        unamePlatform,
+    });
+    newBwin.show();
+}
+
 // note, this does not *show* the window.
 // to show, await win.readyPromise and then win.show()
 export async function createBrowserWindow(
@@ -667,12 +671,13 @@ ipcMain.on("switch-workspace", (event, workspaceId) => {
 });
 
 export async function createWorkspace(window: WaveBrowserWindow) {
-    if (!window) {
-        return;
-    }
-    const newWsId = await WorkspaceService.CreateWorkspace();
+    const newWsId = await WorkspaceService.CreateWorkspace("", "", "", true);
     if (newWsId) {
-        await window.switchWorkspace(newWsId);
+        if (window) {
+            await window.switchWorkspace(newWsId);
+        } else {
+            await createWindowForWorkspace(newWsId);
+        }
     }
 }
 

--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -312,7 +312,6 @@ export class WaveBrowserWindow extends BaseWindow {
                 });
                 if (choice === 0) {
                     console.log("user cancelled switch workspace", this.waveWindowId);
-                    await WorkspaceService.DeleteWorkspace(workspaceId);
                     return;
                 } else if (choice === 1) {
                     console.log("user chose open in new window", this.waveWindowId);

--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -58,7 +58,7 @@ type WindowActionQueueEntry =
           workspaceId: string;
       };
 
-function showCloseConfirmDialog(workspace: Workspace): boolean {
+function isNonEmptyUnsavedWorkspace(workspace: Workspace): boolean {
     return !workspace.name && !workspace.icon && (workspace.tabids?.length > 1 || workspace.pinnedtabids?.length > 1);
 }
 
@@ -233,7 +233,7 @@ export class WaveBrowserWindow extends BaseWindow {
                     console.log("numWindows > 1", numWindows);
                     const workspace = await WorkspaceService.GetWorkspace(this.workspaceId);
                     console.log("workspace", workspace);
-                    if (showCloseConfirmDialog(workspace)) {
+                    if (isNonEmptyUnsavedWorkspace(workspace)) {
                         console.log("workspace has no name, icon, and multiple tabs", workspace);
                         const choice = dialog.showMessageBoxSync(this, {
                             type: "question",
@@ -303,8 +303,10 @@ export class WaveBrowserWindow extends BaseWindow {
         const workspaceList = await WorkspaceService.ListWorkspaces();
         if (!workspaceList?.find((wse) => wse.workspaceid === workspaceId)?.windowid) {
             const curWorkspace = await WorkspaceService.GetWorkspace(this.workspaceId);
-            if (showCloseConfirmDialog(curWorkspace)) {
-                console.log("user chose open in new window", this.waveWindowId);
+            if (isNonEmptyUnsavedWorkspace(curWorkspace)) {
+                console.log(
+                    `existing unsaved workspace ${this.workspaceId} has content, opening workspace ${workspaceId} in new window`
+                );
                 await createWindowForWorkspace(workspaceId);
                 return;
             }

--- a/emain/menu.ts
+++ b/emain/menu.ts
@@ -42,10 +42,12 @@ async function getWorkspaceMenu(ww?: WaveBrowserWindow): Promise<Electron.MenuIt
     console.log("workspaceList:", workspaceList);
     const workspaceMenu: Electron.MenuItemConstructorOptions[] = [
         {
-            label: "Create New Workspace",
-            click: (_, window) => {
-                fireAndForget(() => createWorkspace((window as WaveBrowserWindow) ?? ww));
-            },
+            label: "Create Workspace",
+            click: (_, window) => fireAndForget(() => createWorkspace((window as WaveBrowserWindow) ?? ww)),
+        },
+        {
+            label: "Create Workspace in New Window",
+            click: () => fireAndForget(() => createWorkspace(null)),
         },
     ];
     function getWorkspaceSwitchAccelerator(i: number): string {

--- a/emain/menu.ts
+++ b/emain/menu.ts
@@ -45,10 +45,6 @@ async function getWorkspaceMenu(ww?: WaveBrowserWindow): Promise<Electron.MenuIt
             label: "Create Workspace",
             click: (_, window) => fireAndForget(() => createWorkspace((window as WaveBrowserWindow) ?? ww)),
         },
-        {
-            label: "Create Workspace in New Window",
-            click: () => fireAndForget(() => createWorkspace(null)),
-        },
     ];
     function getWorkspaceSwitchAccelerator(i: number): string {
         if (i < 9) {
@@ -60,7 +56,7 @@ async function getWorkspaceMenu(ww?: WaveBrowserWindow): Promise<Electron.MenuIt
             { type: "separator" },
             ...workspaceList.map<Electron.MenuItemConstructorOptions>((workspace, i) => {
                 return {
-                    label: `Switch to ${workspace.workspacedata.name}`,
+                    label: `${workspace.workspacedata.name}`,
                     click: (_, window) => {
                         ((window as WaveBrowserWindow) ?? ww)?.switchWorkspace(workspace.workspacedata.oid);
                     },

--- a/emain/menu.ts
+++ b/emain/menu.ts
@@ -52,7 +52,7 @@ async function getWorkspaceMenu(ww?: WaveBrowserWindow): Promise<Electron.MenuIt
     ];
     function getWorkspaceSwitchAccelerator(i: number): string {
         if (i < 9) {
-            return unamePlatform == "darwin" ? `Command+Control+${i}` : `Alt+Control+${i + 1}`;
+            return unamePlatform == "darwin" ? `Command+Control+${i + 1}` : `Alt+Control+${i + 1}`;
         }
     }
     workspaceList?.length &&

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -173,7 +173,7 @@ class WorkspaceServiceType {
         return WOS.callBackendService("workspace", "ChangeTabPinning", Array.from(arguments))
     }
 
-    // @returns object updates
+    // @returns CloseTabRtn (and object updates)
     CloseTab(workspaceId: string, tabId: string, fromElectron: boolean): Promise<CloseTabRtnType> {
         return WOS.callBackendService("workspace", "CloseTab", Array.from(arguments))
     }
@@ -184,7 +184,7 @@ class WorkspaceServiceType {
     }
 
     // @returns workspaceId
-    CreateWorkspace(): Promise<string> {
+    CreateWorkspace(name: string, icon: string, color: string, applyDefaults: boolean): Promise<string> {
         return WOS.callBackendService("workspace", "CreateWorkspace", Array.from(arguments))
     }
 
@@ -192,6 +192,18 @@ class WorkspaceServiceType {
     DeleteWorkspace(workspaceId: string): Promise<void> {
         return WOS.callBackendService("workspace", "DeleteWorkspace", Array.from(arguments))
     }
+
+    // @returns colors
+    GetColors(): Promise<string[]> {
+        return WOS.callBackendService("workspace", "GetColors", Array.from(arguments))
+    }
+
+    // @returns icons
+    GetIcons(): Promise<string[]> {
+        return WOS.callBackendService("workspace", "GetIcons", Array.from(arguments))
+    }
+
+    // @returns workspace
     GetWorkspace(workspaceId: string): Promise<Workspace> {
         return WOS.callBackendService("workspace", "GetWorkspace", Array.from(arguments))
     }
@@ -207,6 +219,11 @@ class WorkspaceServiceType {
     // @returns object updates
     UpdateTabIds(workspaceId: string, tabIds: string[], pinnedTabIds: string[]): Promise<void> {
         return WOS.callBackendService("workspace", "UpdateTabIds", Array.from(arguments))
+    }
+
+    // @returns object updates
+    UpdateWorkspace(workspaceId: string, name: string, icon: string, color: string, applyDefaults: boolean): Promise<void> {
+        return WOS.callBackendService("workspace", "UpdateWorkspace", Array.from(arguments))
     }
 }
 

--- a/pkg/wcore/wcore.go
+++ b/pkg/wcore/wcore.go
@@ -54,7 +54,7 @@ func EnsureInitialData() error {
 		return nil
 	}
 	log.Println("client has no windows, creating starter workspace")
-	starterWs, err := CreateWorkspace(ctx, "Starter workspace", "custom@wave-logo-solid", "#58C142", true)
+	starterWs, err := CreateWorkspace(ctx, "Starter workspace", "custom@wave-logo-solid", "#58C142", false, true)
 	if err != nil {
 		return fmt.Errorf("error creating starter workspace: %w", err)
 	}

--- a/pkg/wcore/window.go
+++ b/pkg/wcore/window.go
@@ -78,7 +78,7 @@ func CreateWindow(ctx context.Context, winSize *waveobj.WinSize, workspaceId str
 	log.Printf("CreateWindow %v %v\n", winSize, workspaceId)
 	var ws *waveobj.Workspace
 	if workspaceId == "" {
-		ws1, err := CreateWorkspace(ctx, "", "", "", false)
+		ws1, err := CreateWorkspace(ctx, "", "", "", false, false)
 		if err != nil {
 			return nil, fmt.Errorf("error creating workspace: %w", err)
 		}


### PR DESCRIPTION
Also moves icon and color definitions to the backend and makes it so the new workspaces get created with a different icon color for each index. 

If an ephemeral window has more than one tab, always create a new window when switching workspaces

Also fixes workspace accelerators on macOS