### PR TITLE
Synchronize workspace edits across windows, close window when workspace is deleted

### DIFF
--- a/frontend/app/tab/workspaceeditor.scss
+++ b/frontend/app/tab/workspaceeditor.scss
@@ -1,0 +1,70 @@
+.workspace-editor {
+    width: 100%;
+    .input {
+        margin: 5px 0 10px;
+    }
+
+    .color-selector {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(15px, 15px)); // Ensures each color circle has a fixed 14px size
+        grid-gap: 18.5px; // Space between items
+        justify-content: center;
+        align-items: center;
+        margin-top: 5px;
+        padding-bottom: 15px;
+        border-bottom: 1px solid var(--modal-border-color);
+
+        .color-circle {
+            width: 15px;
+            height: 15px;
+            border-radius: 50%;
+            cursor: pointer;
+            position: relative;
+
+            // Border offset outward
+            &:before {
+                content: "";
+                position: absolute;
+                top: -3px;
+                left: -3px;
+                right: -3px;
+                bottom: -3px;
+                border-radius: 50%;
+                border: 1px solid transparent;
+            }
+
+            &.selected:before {
+                border-color: var(--main-text-color); // Highlight for the selected circle
+            }
+        }
+    }
+
+    .icon-selector {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(16px, 16px)); // Ensures each color circle has a fixed 14px size
+        grid-column-gap: 17.5px; // Space between items
+        grid-row-gap: 13px; // Space between items
+        justify-content: center;
+        align-items: center;
+        margin-top: 15px;
+
+        .icon-item {
+            font-size: 15px;
+            color: oklch(from var(--modal-bg-color) calc(l * 1.5) c h);
+            cursor: pointer;
+            transition: color 0.3s ease;
+
+            &.selected,
+            &:hover {
+                color: var(--main-text-color);
+            }
+        }
+    }
+
+    .delete-ws-btn-wrapper {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-top: 10px;
+    }
+}

--- a/frontend/app/tab/workspaceeditor.tsx
+++ b/frontend/app/tab/workspaceeditor.tsx
@@ -1,0 +1,125 @@
+import { fireAndForget, makeIconClass } from "@/util/util";
+import clsx from "clsx";
+import { memo, useEffect, useRef, useState } from "react";
+import { Button } from "../element/button";
+import { Input } from "../element/input";
+import { WorkspaceService } from "../store/services";
+import "./workspaceeditor.scss";
+
+interface ColorSelectorProps {
+    colors: string[];
+    selectedColor?: string;
+    onSelect: (color: string) => void;
+    className?: string;
+}
+
+const ColorSelector = memo(({ colors, selectedColor, onSelect, className }: ColorSelectorProps) => {
+    const handleColorClick = (color: string) => {
+        onSelect(color);
+    };
+
+    return (
+        <div className={clsx("color-selector", className)}>
+            {colors.map((color) => (
+                <div
+                    key={color}
+                    className={clsx("color-circle", { selected: selectedColor === color })}
+                    style={{ backgroundColor: color }}
+                    onClick={() => handleColorClick(color)}
+                />
+            ))}
+        </div>
+    );
+});
+
+interface IconSelectorProps {
+    icons: string[];
+    selectedIcon?: string;
+    onSelect: (icon: string) => void;
+    className?: string;
+}
+
+const IconSelector = memo(({ icons, selectedIcon, onSelect, className }: IconSelectorProps) => {
+    const handleIconClick = (icon: string) => {
+        onSelect(icon);
+    };
+
+    return (
+        <div className={clsx("icon-selector", className)}>
+            {icons.map((icon) => {
+                const iconClass = makeIconClass(icon, true);
+                return (
+                    <i
+                        key={icon}
+                        className={clsx(iconClass, "icon-item", { selected: selectedIcon === icon })}
+                        onClick={() => handleIconClick(icon)}
+                    />
+                );
+            })}
+        </div>
+    );
+});
+
+interface WorkspaceEditorProps {
+    title: string;
+    icon: string;
+    color: string;
+    focusInput: boolean;
+    onTitleChange: (newTitle: string) => void;
+    onColorChange: (newColor: string) => void;
+    onIconChange: (newIcon: string) => void;
+    onDeleteWorkspace: () => void;
+}
+const WorkspaceEditorComponent = ({
+    title,
+    icon,
+    color,
+    focusInput,
+    onTitleChange,
+    onColorChange,
+    onIconChange,
+    onDeleteWorkspace,
+}: WorkspaceEditorProps) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const [colors, setColors] = useState<string[]>([]);
+    const [icons, setIcons] = useState<string[]>([]);
+
+    useEffect(() => {
+        fireAndForget(async () => {
+            const colors = await WorkspaceService.GetColors();
+            const icons = await WorkspaceService.GetIcons();
+            setColors(colors);
+            setIcons(icons);
+        });
+    }, []);
+
+    useEffect(() => {
+        if (focusInput && inputRef.current) {
+            inputRef.current.focus();
+            inputRef.current.select();
+        }
+    }, [focusInput]);
+
+    return (
+        <div className="workspace-editor">
+            <Input
+                ref={inputRef}
+                className={clsx("vertical-padding-3", { error: title === "" })}
+                onChange={onTitleChange}
+                value={title}
+                autoFocus
+                autoSelect
+            />
+            <ColorSelector selectedColor={color} colors={colors} onSelect={onColorChange} />
+            <IconSelector selectedIcon={icon} icons={icons} onSelect={onIconChange} />
+            <div className="delete-ws-btn-wrapper">
+                <Button className="ghost red font-size-12 bold" onClick={onDeleteWorkspace}>
+                    Delete workspace
+                </Button>
+            </div>
+        </div>
+    );
+};
+
+export const WorkspaceEditor = memo(WorkspaceEditorComponent) as typeof WorkspaceEditorComponent;

--- a/frontend/app/tab/workspaceswitcher.scss
+++ b/frontend/app/tab/workspaceswitcher.scss
@@ -26,25 +26,6 @@
     }
 }
 
-.icon-left,
-.icon-right {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 20px;
-}
-
-.divider {
-    width: 1px;
-    height: 20px;
-    background: rgba(255, 255, 255, 0.08);
-}
-
-.scrollable {
-    max-height: 400px;
-    width: 100%;
-}
-
 .workspace-switcher-content {
     min-height: auto;
     display: flex;
@@ -54,6 +35,25 @@
     align-items: center;
     border-radius: 8px;
     box-shadow: 0px 8px 24px 0px var(--modal-shadow-color);
+
+    .icon-left,
+    .icon-right {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 20px;
+    }
+
+    .divider {
+        width: 1px;
+        height: 20px;
+        background: rgba(255, 255, 255, 0.08);
+    }
+
+    .scrollable {
+        max-height: 400px;
+        width: 100%;
+    }
 
     .title {
         font-size: 12px;
@@ -142,83 +142,6 @@
     .expandable-menu-item-group-title {
         height: 29px;
         padding: 0;
-    }
-
-    .workspace-editor {
-        width: 100%;
-        .input {
-            margin: 5px 0 10px;
-        }
-
-        .color-selector {
-            display: grid;
-            grid-template-columns: repeat(
-                auto-fit,
-                minmax(15px, 15px)
-            ); // Ensures each color circle has a fixed 14px size
-            grid-gap: 18.5px; // Space between items
-            justify-content: center;
-            align-items: center;
-            margin-top: 5px;
-            padding-bottom: 15px;
-            border-bottom: 1px solid var(--modal-border-color);
-
-            .color-circle {
-                width: 15px;
-                height: 15px;
-                border-radius: 50%;
-                cursor: pointer;
-                position: relative;
-
-                // Border offset outward
-                &:before {
-                    content: "";
-                    position: absolute;
-                    top: -3px;
-                    left: -3px;
-                    right: -3px;
-                    bottom: -3px;
-                    border-radius: 50%;
-                    border: 1px solid transparent;
-                }
-
-                &.selected:before {
-                    border-color: var(--main-text-color); // Highlight for the selected circle
-                }
-            }
-        }
-
-        .icon-selector {
-            display: grid;
-            grid-template-columns: repeat(
-                auto-fit,
-                minmax(16px, 16px)
-            ); // Ensures each color circle has a fixed 14px size
-            grid-column-gap: 17.5px; // Space between items
-            grid-row-gap: 13px; // Space between items
-            justify-content: center;
-            align-items: center;
-            margin-top: 15px;
-
-            .icon-item {
-                font-size: 15px;
-                color: oklch(from var(--modal-bg-color) calc(l * 1.5) c h);
-                cursor: pointer;
-                transition: color 0.3s ease;
-
-                &.selected,
-                &:hover {
-                    color: var(--main-text-color);
-                }
-            }
-        }
-
-        .delete-ws-btn-wrapper {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin-top: 10px;
-        }
     }
 
     .actions {

--- a/pkg/service/workspaceservice/workspaceservice.go
+++ b/pkg/service/workspaceservice/workspaceservice.go
@@ -50,6 +50,9 @@ func (svc *WorkspaceService) UpdateWorkspace(ctx context.Context, workspaceId st
 		return nil, fmt.Errorf("error updating workspace: %w", err)
 	}
 
+	wps.Broker.Publish(wps.WaveEvent{
+		Event: wps.Event_WorkspaceUpdate})
+
 	updates := waveobj.ContextGetUpdatesRtn(ctx)
 	go func() {
 		defer panichandler.PanicHandler("WorkspaceService:UpdateWorkspace:SendUpdateEvents")

--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -122,6 +122,7 @@ func DeleteWorkspace(ctx context.Context, workspaceId string, force bool) (bool,
 			return false, fmt.Errorf("error closing tab: %w", err)
 		}
 	}
+	windowId, err := wstore.DBFindWindowForWorkspaceId(ctx, workspaceId)
 	err = wstore.DBDelete(ctx, waveobj.OType_Workspace, workspaceId)
 	if err != nil {
 		return false, fmt.Errorf("error deleting workspace: %w", err)
@@ -129,6 +130,12 @@ func DeleteWorkspace(ctx context.Context, workspaceId string, force bool) (bool,
 	log.Printf("deleted workspace %s\n", workspaceId)
 	wps.Broker.Publish(wps.WaveEvent{
 		Event: wps.Event_WorkspaceUpdate})
+	if windowId != "" {
+		err = CloseWindow(ctx, windowId, false)
+		if err != nil {
+			return false, fmt.Errorf("error closing window: %w", err)
+		}
+	}
 	return true, nil
 }
 


### PR DESCRIPTION
Also breaks WorkspaceEditor into its own file and fixes a bug where closing a workspace would cause the window with the switcher open to go blank.

Also Electron will now close a window if its workspace is closed.