### PR TITLE
fix: unquote zdotdir for starting zsh in wsl

### DIFF
--- a/pkg/shellexec/shellexec.go
+++ b/pkg/shellexec/shellexec.go
@@ -215,7 +215,7 @@ func StartWslShellProc(ctx context.Context, termSize waveobj.TermSize, cmdStr st
 	}
 
 	if isZshShell(shellPath) {
-		shellOpts = append(shellOpts, fmt.Sprintf(`ZDOTDIR="%s/.waveterm/%s"`, homeDir, shellutil.ZshIntegrationDir))
+		shellOpts = append(shellOpts, fmt.Sprintf(`ZDOTDIR=%s/.waveterm/%s`, homeDir, shellutil.ZshIntegrationDir))
 	}
 	shellOpts = append(shellOpts, shellPath)
 	shellOpts = append(shellOpts, subShellOpts...)


### PR DESCRIPTION
Due to the way this command is run, the quotes are not being handled by the shell. Removing them allows them to be interpreted correctly in most cases. This resolves #1569 