### PR TITLE
Allow empty workspace name while editing workspace

### DIFF
--- a/frontend/app/tab/workspaceswitcher.tsx
+++ b/frontend/app/tab/workspaceswitcher.tsx
@@ -153,6 +153,7 @@ const WorkspaceSwitcherItem = ({
     const isCurrentWorkspace = activeWorkspace.oid === workspace.oid;
 
     const setWorkspace = useCallback((newWorkspace: Workspace) => {
+        setWorkspaceEntry({ ...workspaceEntry, workspace: newWorkspace });
         if (newWorkspace.name != "") {
             fireAndForget(() =>
                 WorkspaceService.UpdateWorkspace(

--- a/pkg/service/workspaceservice/workspaceservice.go
+++ b/pkg/service/workspaceservice/workspaceservice.go
@@ -45,9 +45,12 @@ func (svc *WorkspaceService) UpdateWorkspace_Meta() tsgenmeta.MethodMeta {
 
 func (svc *WorkspaceService) UpdateWorkspace(ctx context.Context, workspaceId string, name string, icon string, color string, applyDefaults bool) (waveobj.UpdatesRtnType, error) {
 	ctx = waveobj.ContextWithUpdates(ctx)
-	_, err := wcore.UpdateWorkspace(ctx, workspaceId, name, icon, color, applyDefaults)
+	_, updated, err := wcore.UpdateWorkspace(ctx, workspaceId, name, icon, color, applyDefaults)
 	if err != nil {
 		return nil, fmt.Errorf("error updating workspace: %w", err)
+	}
+	if !updated {
+		return nil, nil
 	}
 
 	wps.Broker.Publish(wps.WaveEvent{


### PR DESCRIPTION
Fixes a bug where if you deleted all but one character in the workspace name, you couldn't delete the final character. To fix this, I have made the workspace editor save a separate entry from the backend. The backend will also only update its DB value and notify the frontend if something was actually edited. If you delete all the characters in the name and don't put anything new in, though, the name will be whatever the last character you had was, since the name of a saved workspace cannot be empty.