### PR TITLE
fix: add leading slash to default remote shell

### DIFF
--- a/cmd/wsh/cmd/wshcmd-shell-unix.go
+++ b/cmd/wsh/cmd/wshcmd-shell-unix.go
@@ -58,5 +58,5 @@ func shellCmdInner() string {
 		}
 	}
 	// none found
-	return "bin/bash\n"
+	return "/bin/bash\n"
 }


### PR DESCRIPTION
Adds a leading slash to `/bin/bash` as the default shell if no other shell has been found