### PR TITLE
Allow users to close windows without confirming, delete last window

### DIFF
--- a/docs/docs/config.mdx
+++ b/docs/docs/config.mdx
@@ -76,9 +76,11 @@ wsh editconfig
 | window:showmenubar                   | bool     | set to use the OS-native menu bar (Windows and Linux only, requires app restart)                                                                                                                                                                              |
 | window:nativetitlebar                | bool     | set to use the OS-native title bar, rather than the overlay (Windows and Linux only, requires app restart)                                                                                                                                                    |
 | window:disablehardwareacceleration   | bool     | set to disable Chromium hardware acceleration to resolve graphical bugs (requires app restart)                                                                                                                                                                |
+| window:savelastwindow                | bool     | when `true`, the last window that is closed is preserved and is reopened the next time the app is launched (defaults to `true`)                                                                                                                               |
+| window:confirmonclose                | bool     | when `true`, a prompt will ask a user to confirm that they want to close a window if it has an unsaved workspace with more than one tab (defaults to `true`)                                                                                                  |
 | telemetry:enabled                    | bool     | set to enable/disable telemetry                                                                                                                                                                                                                               |
 
-For reference this is the current default configuration (v0.9.3):
+For reference this is the current default configuration (v0.10.4):
 
 ```json
 {
@@ -90,6 +92,7 @@ For reference this is the current default configuration (v0.9.3):
   "autoupdate:installonquit": true,
   "autoupdate:intervalms": 3600000,
   "conn:askbeforewshinstall": true,
+  "conn:wshenabled": true,
   "editor:minimapenabled": true,
   "web:defaulturl": "https://github.com/wavetermdev/waveterm",
   "web:defaultsearch": "https://www.google.com/search?q={query}",
@@ -100,6 +103,8 @@ For reference this is the current default configuration (v0.9.3):
   "window:magnifiedblocksize": 0.9,
   "window:magnifiedblockblurprimarypx": 10,
   "window:magnifiedblockblursecondarypx": 2,
+  "window:confirmclose": true,
+  "window:savelastwindow": true,
   "telemetry:enabled": true,
   "term:copyonselect": true
 }

--- a/docs/docs/config.mdx
+++ b/docs/docs/config.mdx
@@ -80,7 +80,7 @@ wsh editconfig
 | window:confirmonclose                | bool     | when `true`, a prompt will ask a user to confirm that they want to close a window if it has an unsaved workspace with more than one tab (defaults to `true`)                                                                                                  |
 | telemetry:enabled                    | bool     | set to enable/disable telemetry                                                                                                                                                                                                                               |
 
-For reference this is the current default configuration (v0.10.4):
+For reference, this is the current default configuration (v0.10.4):
 
 ```json
 {

--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -229,7 +229,11 @@ export class WaveBrowserWindow extends BaseWindow {
             e.preventDefault();
             fireAndForget(async () => {
                 const numWindows = waveWindowMap.size;
-                if (numWindows > 1) {
+                const fullConfig = await FileService.GetFullConfig();
+                if (
+                    fullConfig.settings["window:confirmonclose"] &&
+                    (numWindows > 1 || !fullConfig.settings["window:savelastwindowonclose"])
+                ) {
                     console.log("numWindows > 1", numWindows);
                     const workspace = await WorkspaceService.GetWorkspace(this.workspaceId);
                     console.log("workspace", workspace);

--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -230,24 +230,25 @@ export class WaveBrowserWindow extends BaseWindow {
             fireAndForget(async () => {
                 const numWindows = waveWindowMap.size;
                 const fullConfig = await FileService.GetFullConfig();
-                if (
-                    fullConfig.settings["window:confirmonclose"] &&
-                    (numWindows > 1 || !fullConfig.settings["window:savelastwindowonclose"])
-                ) {
-                    console.log("numWindows > 1", numWindows);
-                    const workspace = await WorkspaceService.GetWorkspace(this.workspaceId);
-                    console.log("workspace", workspace);
-                    if (isNonEmptyUnsavedWorkspace(workspace)) {
-                        console.log("workspace has no name, icon, and multiple tabs", workspace);
-                        const choice = dialog.showMessageBoxSync(this, {
-                            type: "question",
-                            buttons: ["Cancel", "Close Window"],
-                            title: "Confirm",
-                            message: "Window has unsaved tabs, closing window will delete existing tabs.\n\nContinue?",
-                        });
-                        if (choice === 0) {
-                            console.log("user cancelled close window", this.waveWindowId);
-                            return;
+                if (numWindows > 1 || !fullConfig.settings["window:savelastwindowonclose"]) {
+                    console.log("numWindows > 1 or user does not want last window saved", numWindows);
+                    if (fullConfig.settings["window:confirmclose"]) {
+                        console.log("confirmclose", this.waveWindowId);
+                        const workspace = await WorkspaceService.GetWorkspace(this.workspaceId);
+                        console.log("workspace", workspace);
+                        if (isNonEmptyUnsavedWorkspace(workspace)) {
+                            console.log("workspace has no name, icon, and multiple tabs", workspace);
+                            const choice = dialog.showMessageBoxSync(this, {
+                                type: "question",
+                                buttons: ["Cancel", "Close Window"],
+                                title: "Confirm",
+                                message:
+                                    "Window has unsaved tabs, closing window will delete existing tabs.\n\nContinue?",
+                            });
+                            if (choice === 0) {
+                                console.log("user cancelled close window", this.waveWindowId);
+                                return;
+                            }
                         }
                     }
                     console.log("deleteAllowed = true", this.waveWindowId);
@@ -272,11 +273,6 @@ export class WaveBrowserWindow extends BaseWindow {
             if (getGlobalIsRelaunching()) {
                 console.log("win relaunching", this.waveWindowId);
                 this.destroy();
-                return;
-            }
-            const numWindows = waveWindowMap.size;
-            if (numWindows == 0) {
-                console.log("win no windows left", this.waveWindowId);
                 return;
             }
             if (this.deleteAllowed) {

--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -230,7 +230,7 @@ export class WaveBrowserWindow extends BaseWindow {
             fireAndForget(async () => {
                 const numWindows = waveWindowMap.size;
                 const fullConfig = await FileService.GetFullConfig();
-                if (numWindows > 1 || !fullConfig.settings["window:savelastwindowonclose"]) {
+                if (numWindows > 1 || !fullConfig.settings["window:savelastwindow"]) {
                     console.log("numWindows > 1 or user does not want last window saved", numWindows);
                     if (fullConfig.settings["window:confirmclose"]) {
                         console.log("confirmclose", this.waveWindowId);

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -679,6 +679,8 @@ declare global {
         "window:magnifiedblocksize"?: number;
         "window:magnifiedblockblurprimarypx"?: number;
         "window:magnifiedblockblursecondarypx"?: number;
+        "window:confirmonclose"?: boolean;
+        "window:savelastwindowonclose"?: boolean;
         "telemetry:*"?: boolean;
         "telemetry:enabled"?: boolean;
         "conn:*"?: boolean;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -679,7 +679,7 @@ declare global {
         "window:magnifiedblocksize"?: number;
         "window:magnifiedblockblurprimarypx"?: number;
         "window:magnifiedblockblursecondarypx"?: number;
-        "window:confirmonclose"?: boolean;
+        "window:confirmclose"?: boolean;
         "window:savelastwindowonclose"?: boolean;
         "telemetry:*"?: boolean;
         "telemetry:enabled"?: boolean;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -680,7 +680,7 @@ declare global {
         "window:magnifiedblockblurprimarypx"?: number;
         "window:magnifiedblockblursecondarypx"?: number;
         "window:confirmclose"?: boolean;
-        "window:savelastwindowonclose"?: boolean;
+        "window:savelastwindow"?: boolean;
         "telemetry:*"?: boolean;
         "telemetry:enabled"?: boolean;
         "conn:*"?: boolean;

--- a/pkg/wconfig/defaultconfig/settings.json
+++ b/pkg/wconfig/defaultconfig/settings.json
@@ -19,7 +19,7 @@
     "window:magnifiedblockblurprimarypx": 10,
     "window:magnifiedblockblursecondarypx": 2,
     "window:confirmclose": true,
-    "window:savelastwindowonclose": true,
+    "window:savelastwindow": true,
     "telemetry:enabled": true,
     "term:copyonselect": true
 }

--- a/pkg/wconfig/defaultconfig/settings.json
+++ b/pkg/wconfig/defaultconfig/settings.json
@@ -7,7 +7,7 @@
     "autoupdate:installonquit": true,
     "autoupdate:intervalms": 3600000,
     "conn:askbeforewshinstall": true,
-	"conn:wshenabled": true,
+    "conn:wshenabled": true,
     "editor:minimapenabled": true,
     "web:defaulturl": "https://github.com/wavetermdev/waveterm",
     "web:defaultsearch": "https://www.google.com/search?q={query}",
@@ -18,6 +18,8 @@
     "window:magnifiedblocksize": 0.9,
     "window:magnifiedblockblurprimarypx": 10,
     "window:magnifiedblockblursecondarypx": 2,
+    "window:confirmonclose": true,
+    "window:savelastwindowonclose": true,
     "telemetry:enabled": true,
     "term:copyonselect": true
 }

--- a/pkg/wconfig/defaultconfig/settings.json
+++ b/pkg/wconfig/defaultconfig/settings.json
@@ -18,7 +18,7 @@
     "window:magnifiedblocksize": 0.9,
     "window:magnifiedblockblurprimarypx": 10,
     "window:magnifiedblockblursecondarypx": 2,
-    "window:confirmonclose": true,
+    "window:confirmclose": true,
     "window:savelastwindowonclose": true,
     "telemetry:enabled": true,
     "term:copyonselect": true

--- a/pkg/wconfig/metaconsts.go
+++ b/pkg/wconfig/metaconsts.go
@@ -80,7 +80,7 @@ const (
 	ConfigKey_WindowMagnifiedBlockBlurPrimaryPx = "window:magnifiedblockblurprimarypx"
 	ConfigKey_WindowMagnifiedBlockBlurSecondaryPx = "window:magnifiedblockblursecondarypx"
 	ConfigKey_WindowConfirmClose             = "window:confirmclose"
-	ConfigKey_WindowSaveLastWindowOnClose    = "window:savelastwindowonclose"
+	ConfigKey_WindowSaveLastWindow           = "window:savelastwindow"
 
 	ConfigKey_TelemetryClear                 = "telemetry:*"
 	ConfigKey_TelemetryEnabled               = "telemetry:enabled"

--- a/pkg/wconfig/metaconsts.go
+++ b/pkg/wconfig/metaconsts.go
@@ -79,7 +79,7 @@ const (
 	ConfigKey_WindowMagnifiedBlockSize       = "window:magnifiedblocksize"
 	ConfigKey_WindowMagnifiedBlockBlurPrimaryPx = "window:magnifiedblockblurprimarypx"
 	ConfigKey_WindowMagnifiedBlockBlurSecondaryPx = "window:magnifiedblockblursecondarypx"
-	ConfigKey_WindowConfirmOnClose           = "window:confirmonclose"
+	ConfigKey_WindowConfirmClose             = "window:confirmclose"
 	ConfigKey_WindowSaveLastWindowOnClose    = "window:savelastwindowonclose"
 
 	ConfigKey_TelemetryClear                 = "telemetry:*"

--- a/pkg/wconfig/metaconsts.go
+++ b/pkg/wconfig/metaconsts.go
@@ -79,6 +79,8 @@ const (
 	ConfigKey_WindowMagnifiedBlockSize       = "window:magnifiedblocksize"
 	ConfigKey_WindowMagnifiedBlockBlurPrimaryPx = "window:magnifiedblockblurprimarypx"
 	ConfigKey_WindowMagnifiedBlockBlurSecondaryPx = "window:magnifiedblockblursecondarypx"
+	ConfigKey_WindowConfirmOnClose           = "window:confirmonclose"
+	ConfigKey_WindowSaveLastWindowOnClose    = "window:savelastwindowonclose"
 
 	ConfigKey_TelemetryClear                 = "telemetry:*"
 	ConfigKey_TelemetryEnabled               = "telemetry:enabled"

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -106,6 +106,8 @@ type SettingsType struct {
 	WindowMagnifiedBlockSize            *float64 `json:"window:magnifiedblocksize,omitempty"`
 	WindowMagnifiedBlockBlurPrimaryPx   *int64   `json:"window:magnifiedblockblurprimarypx,omitempty"`
 	WindowMagnifiedBlockBlurSecondaryPx *int64   `json:"window:magnifiedblockblursecondarypx,omitempty"`
+	WindowConfirmOnClose                bool     `json:"window:confirmonclose,omitempty"`
+	WindowSaveLastWindowOnClose         bool     `json:"window:savelastwindowonclose,omitempty"`
 
 	TelemetryClear   bool `json:"telemetry:*,omitempty"`
 	TelemetryEnabled bool `json:"telemetry:enabled,omitempty"`

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -106,7 +106,7 @@ type SettingsType struct {
 	WindowMagnifiedBlockSize            *float64 `json:"window:magnifiedblocksize,omitempty"`
 	WindowMagnifiedBlockBlurPrimaryPx   *int64   `json:"window:magnifiedblockblurprimarypx,omitempty"`
 	WindowMagnifiedBlockBlurSecondaryPx *int64   `json:"window:magnifiedblockblursecondarypx,omitempty"`
-	WindowConfirmOnClose                bool     `json:"window:confirmonclose,omitempty"`
+	WindowConfirmClose                  bool     `json:"window:confirmclose,omitempty"`
 	WindowSaveLastWindowOnClose         bool     `json:"window:savelastwindowonclose,omitempty"`
 
 	TelemetryClear   bool `json:"telemetry:*,omitempty"`

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -107,7 +107,7 @@ type SettingsType struct {
 	WindowMagnifiedBlockBlurPrimaryPx   *int64   `json:"window:magnifiedblockblurprimarypx,omitempty"`
 	WindowMagnifiedBlockBlurSecondaryPx *int64   `json:"window:magnifiedblockblursecondarypx,omitempty"`
 	WindowConfirmClose                  bool     `json:"window:confirmclose,omitempty"`
-	WindowSaveLastWindowOnClose         bool     `json:"window:savelastwindowonclose,omitempty"`
+	WindowSaveLastWindow                bool     `json:"window:savelastwindow,omitempty"`
 
 	TelemetryClear   bool `json:"telemetry:*,omitempty"`
 	TelemetryEnabled bool `json:"telemetry:enabled,omitempty"`


### PR DESCRIPTION
Adds `window:savelastwindow` and `window:confirmclose` settings, which can be used to alter the default window close behavior. Both of these default to `true` to maintain the existing default behavior.

If `window:savelastwindow` is unset, the same logic will be used as if the user had more than one window remaining (see below).

If `window:confirmonclose` is unset, the user will no longer be prompted to confirm if they are closing a window whose workspace has unsaved changes (the workspace is not named and it has more than one tab).