### PR TITLE
fix: enhance background URL processing to support Windows file paths

### DIFF
--- a/frontend/app/app-bg.tsx
+++ b/frontend/app/app-bg.tsx
@@ -26,7 +26,7 @@ function processBackgroundUrls(cssText: string): string {
     }
     const attrRe = /^background(-image)?\s*:\s*/i;
     cssText = cssText.replace(attrRe, "");
-    const ast = parseCSS("background: " + cssText, {
+    const ast = parseCSS("background: " + cssText.replace(/\\/g, '\\\\'), {
         context: "declaration",
     });
     let hasUnsafeUrl = false;
@@ -54,7 +54,7 @@ function processBackgroundUrls(cssText: string): string {
                 return;
             }
             // allow absolute paths
-            if (originalUrl.startsWith("/") || originalUrl.startsWith("~/")) {
+            if (originalUrl.startsWith("/") || originalUrl.startsWith("~/") || /^[a-zA-Z]:\\/.test(originalUrl)) {
                 const newUrl = encodeFileURL(originalUrl);
                 node.value = newUrl;
                 return;


### PR DESCRIPTION
In processBackgroundUrls, made two changes -
1. replace backslashes with "\\\\", so css-tree reads it properly
2. added a check for windows like file paths `/^[a-zA-Z]:\\/.test(originalUrl)`

I tried a few other fixes but this one works the best with least changes to the codebase. Hopefully this is helpful.