### PR TITLE
Allow TestDriver to run on outside contributions

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -23,4 +23,4 @@ jobs:
               uses: upsidr/merge-gatekeeper@v1
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  ignored: Test Onboarding, Analyze (go), Analyze (javascript-typescript), License Compliance, CodeRabbit
+                  ignored: Run TestDriver.ai, Analyze (go), Analyze (javascript-typescript), License Compliance, CodeRabbit

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -23,4 +23,4 @@ jobs:
               uses: upsidr/merge-gatekeeper@v1
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  ignored: Run TestDriver.ai, Analyze (go), Analyze (javascript-typescript), License Compliance, CodeRabbit
+                  ignored: Build for TestDriver.ai, Analyze (go), Analyze (javascript-typescript), License Compliance, CodeRabbit

--- a/.github/workflows/testdriver-build.yml
+++ b/.github/workflows/testdriver-build.yml
@@ -25,8 +25,6 @@ on:
 env:
     GO_VERSION: "1.23"
     NODE_VERSION: 22
-    GITHUB_TOKEN: "" # Unset the GITHUB_TOKEN so that it cannot be leaked to external code
-    ACTIONS_RUNTIME_TOKEN: "" # Unset the ACTIONS_RUNTIME_TOKEN so that it cannot be leaked to external code
 
 permissions:
     contents: read # To allow the action to read repository contents

--- a/.github/workflows/testdriver-build.yml
+++ b/.github/workflows/testdriver-build.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
     build_and_upload:
-        name: Build and Upload
+        name: Build for TestDriver.ai
         runs-on: windows-latest
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/testdriver-build.yml
+++ b/.github/workflows/testdriver-build.yml
@@ -6,7 +6,7 @@ on:
             - main
         tags:
             - "v[0-9]+.[0-9]+.[0-9]+*"
-    pull_request_target:
+    pull_request:
         branches:
             - main
         paths-ignore:

--- a/.github/workflows/testdriver-build.yml
+++ b/.github/workflows/testdriver-build.yml
@@ -1,0 +1,76 @@
+name: TestDriver.ai Build
+
+on:
+    push:
+        branches:
+            - main
+        tags:
+            - "v[0-9]+.[0-9]+.[0-9]+*"
+    pull_request_target:
+        branches:
+            - main
+        paths-ignore:
+            - "docs/**"
+            - ".storybook/**"
+            - ".vscode/**"
+            - ".editorconfig"
+            - ".gitignore"
+            - ".prettierrc"
+            - ".eslintrc.js"
+            - "**/*.md"
+    schedule:
+        - cron: 0 21 * * *
+    workflow_dispatch: null
+
+env:
+    GO_VERSION: "1.23"
+    NODE_VERSION: 22
+    GITHUB_TOKEN: "" # Unset the GITHUB_TOKEN so that it cannot be leaked to external code
+    ACTIONS_RUNTIME_TOKEN: "" # Unset the ACTIONS_RUNTIME_TOKEN so that it cannot be leaked to external code
+
+permissions:
+    contents: read # To allow the action to read repository contents
+    pull-requests: write # To allow the action to create/update pull request comments
+
+jobs:
+    build_and_upload:
+        name: Build and Upload
+        runs-on: windows-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            # General build dependencies
+            - uses: actions/setup-go@v5
+              with:
+                  go-version: ${{env.GO_VERSION}}
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: ${{env.NODE_VERSION}}
+            - name: Install Yarn
+              uses: nick-fields/retry@v3
+              with:
+                  command: |
+                      corepack enable
+                      yarn install
+                  timeout_minutes: 5
+                  max_attempts: 3
+            - name: Install Task
+              uses: arduino/setup-task@v2
+              with:
+                  version: 3.x
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build
+              run: task package
+              env:
+                  USE_SYSTEM_FPM: true # Ensure that the installed version of FPM is used rather than the bundled one.
+                  CSC_IDENTITY_AUTO_DISCOVERY: false # disable codesign
+              shell: powershell # electron-builder's Windows code signing package has some compatibility issues with pwsh, so we need to use Windows Powershell
+
+            # Upload .exe as an artifact
+            - name: Upload .exe artifact
+              id: upload
+              uses: actions/upload-artifact@v4
+              with:
+                  name: windows-exe
+                  path: make/*.exe

--- a/.github/workflows/testdriver.yml
+++ b/.github/workflows/testdriver.yml
@@ -1,26 +1,10 @@
-name: TestDriver.ai
+name: TestDriver.ai Run
 
 on:
-    push:
-        branches:
-            - main
-        tags:
-            - "v[0-9]+.[0-9]+.[0-9]+*"
-    pull_request_target:
-        branches:
-            - main
-        paths-ignore:
-            - "docs/**"
-            - ".storybook/**"
-            - ".vscode/**"
-            - ".editorconfig"
-            - ".gitignore"
-            - ".prettierrc"
-            - ".eslintrc.js"
-            - "**/*.md"
-    schedule:
-        - cron: 0 21 * * *
-    workflow_dispatch: null
+    workflow_run:
+        workflows: ["TestDriver.ai Build"]
+        types:
+            - completed
 
 env:
     GO_VERSION: "1.23"
@@ -31,55 +15,15 @@ permissions:
     pull-requests: write # To allow the action to create/update pull request comments
 
 jobs:
-    build_and_upload:
-        name: Test Onboarding
+    run_testdriver:
+        name: Run TestDriver.ai
         runs-on: windows-latest
         steps:
-            - uses: actions/checkout@v4
-
-            # General build dependencies
-            - uses: actions/setup-go@v5
-              with:
-                  go-version: ${{env.GO_VERSION}}
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: ${{env.NODE_VERSION}}
-            - name: Install Yarn
-              uses: nick-fields/retry@v3
-              with:
-                  command: |
-                      corepack enable
-                      yarn install
-                  timeout_minutes: 5
-                  max_attempts: 3
-              env:
-                  GITHUB_TOKEN: ""
-            - name: Install Task
-              uses: arduino/setup-task@v2
-              with:
-                  version: 3.x
-                  repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Build
-              run: task package
-              env:
-                  USE_SYSTEM_FPM: true # Ensure that the installed version of FPM is used rather than the bundled one.
-                  CSC_IDENTITY_AUTO_DISCOVERY: false # disable codesign
-                  GITHUB_TOKEN: ""
-              shell: powershell # electron-builder's Windows code signing package has some compatibility issues with pwsh, so we need to use Windows Powershell
-
-            # Upload .exe as an artifact
-            - name: Upload .exe artifact
-              id: upload
-              uses: actions/upload-artifact@v4
-              with:
-                  name: windows-exe
-                  path: make/*.exe
-
             - uses: testdriverai/action@main
               id: testdriver
               env:
                   FORCE_COLOR: "3"
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   key: ${{ secrets.DASHCAM_API }}
                   prerun: |
@@ -103,7 +47,7 @@ jobs:
 
                       # Fetch the artifact upload URL
                       Write-Host "Fetching the artifact upload URL..."
-                      $artifactUrl = (Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" -Headers $headers).artifacts[0].archive_download_url
+                      $artifactUrl = (Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" -Headers $headers).artifacts[0].archive_download_url
 
                       if ($artifactUrl) {
                           Write-Host "Artifact URL successfully fetched: $artifactUrl"

--- a/.github/workflows/testdriver.yml
+++ b/.github/workflows/testdriver.yml
@@ -23,7 +23,6 @@ jobs:
               id: testdriver
               env:
                   FORCE_COLOR: "3"
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   key: ${{ secrets.DASHCAM_API }}
                   prerun: |

--- a/.github/workflows/testdriver.yml
+++ b/.github/workflows/testdriver.yml
@@ -6,7 +6,7 @@ on:
             - main
         tags:
             - "v[0-9]+.[0-9]+.[0-9]+*"
-    pull_request:
+    pull_request_target:
         branches:
             - main
         paths-ignore:
@@ -41,8 +41,6 @@ jobs:
             - uses: actions/setup-go@v5
               with:
                   go-version: ${{env.GO_VERSION}}
-                  cache-dependency-path: |
-                      go.sum
             - uses: actions/setup-node@v4
               with:
                   node-version: ${{env.NODE_VERSION}}
@@ -54,6 +52,8 @@ jobs:
                       yarn install
                   timeout_minutes: 5
                   max_attempts: 3
+              env:
+                  GITHUB_TOKEN: ""
             - name: Install Task
               uses: arduino/setup-task@v2
               with:
@@ -65,6 +65,7 @@ jobs:
               env:
                   USE_SYSTEM_FPM: true # Ensure that the installed version of FPM is used rather than the bundled one.
                   CSC_IDENTITY_AUTO_DISCOVERY: false # disable codesign
+                  GITHUB_TOKEN: ""
               shell: powershell # electron-builder's Windows code signing package has some compatibility issues with pwsh, so we need to use Windows Powershell
 
             # Upload .exe as an artifact


### PR DESCRIPTION
Discussed in #1621, the current setup for the TestDriver workflow doesn't allow it to run for PRs from outside contributors, since GitHub restricts secrets access for external PRs using the `pull_request` trigger.

This PR splits the TestDriver workflow into two separate workflows, a `pull_request`-triggered one which builds the artifact, and a `workflow_run`-triggered one which can access our secrets to upload the job to TestDriver.

resolves #1621 