### PR TITLE
fix: pass missing config to setTimeout in getSpareTab

### DIFF
--- a/emain/emain-tabview.ts
+++ b/emain/emain-tabview.ts
@@ -263,7 +263,7 @@ export function ensureHotSpareTab(fullConfig: FullConfigType) {
 }
 
 export function getSpareTab(fullConfig: FullConfigType): WaveTabView {
-    setTimeout(ensureHotSpareTab, 500);
+    setTimeout(() => ensureHotSpareTab(fullConfig), 500);
     if (HotSpareTab != null) {
         const rtn = HotSpareTab;
         HotSpareTab = null;


### PR DESCRIPTION
- Fixed an issue where `fullConfig` was not passed to `setTimeout` in `getSpareTab`.
- Wrapped `ensureHotSpareTab` with an arrow function to ensure `fullConfig` is properly passed.

**When I use wave as my terminal, sometimes the setting does not work. I read the source code and found this issue**