### PR TITLE
fix: do not error out if ssh config is empty

### DIFF
--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -710,10 +710,8 @@ func GetConnectionsList() ([]string, error) {
 
 	fromInternal := GetConnectionsFromInternalConfig()
 
-	fromConfig, err := GetConnectionsFromConfig()
-	if err != nil {
-		return nil, err
-	}
+	fromConfig, _ := GetConnectionsFromConfig()
+	// ignore the error and continue with an empty slice
 
 	// sort into one final list and remove duplicates
 	alreadyUsed := make(map[string]struct{})

--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -710,8 +710,11 @@ func GetConnectionsList() ([]string, error) {
 
 	fromInternal := GetConnectionsFromInternalConfig()
 
-	fromConfig, _ := GetConnectionsFromConfig()
-	// ignore the error and continue with an empty slice
+	fromConfig, err := GetConnectionsFromConfig()
+	if err != nil {
+		// this is not a fatal error. do not return
+		log.Printf("warning: no connections from ssh config found: %v", err)
+	}
 
 	// sort into one final list and remove duplicates
 	alreadyUsed := make(map[string]struct{})


### PR DESCRIPTION
As connections can now be stored in the internal connection, a missing or invalid ssh config should not cause the entire list of connections to be empty. This change ignores the error from the ssh config and proceeds to construct the list without it.