### PR TITLE
Improved Shell Detection

### DIFF
--- a/cmd/wsh/cmd/wshcmd-shell-unix.go
+++ b/cmd/wsh/cmd/wshcmd-shell-unix.go
@@ -6,9 +6,7 @@
 package cmd
 
 import (
-	"bufio"
 	"os"
-	"os/user"
 	"runtime"
 	"strings"
 
@@ -33,30 +31,10 @@ func shellCmdInner() string {
 	if runtime.GOOS == "darwin" {
 		return shellutil.GetMacUserShell() + "\n"
 	}
-	user, err := user.Current()
-	if err != nil {
+
+	shell := os.Getenv("SHELL")
+	if shell == "" {
 		return "/bin/bash\n"
 	}
-
-	passwd, err := os.Open("/etc/passwd")
-	if err != nil {
-		return "/bin/bash\n"
-	}
-
-	scanner := bufio.NewScanner(passwd)
-	for scanner.Scan() {
-		line := scanner.Text()
-		line = strings.TrimSpace(line)
-		parts := strings.Split(line, ":")
-
-		if len(parts) != 7 {
-			continue
-		}
-
-		if parts[0] == user.Username {
-			return parts[6] + "\n"
-		}
-	}
-	// none found
-	return "/bin/bash\n"
+	return strings.TrimSpace(shell)
 }

--- a/cmd/wsh/cmd/wshcmd-shell-unix.go
+++ b/cmd/wsh/cmd/wshcmd-shell-unix.go
@@ -36,5 +36,5 @@ func shellCmdInner() string {
 	if shell == "" {
 		return "/bin/bash\n"
 	}
-	return strings.TrimSpace(shell)
+	return strings.TrimSpace(shell) + "\n"
 }

--- a/pkg/util/utilfn/utilfn.go
+++ b/pkg/util/utilfn/utilfn.go
@@ -974,7 +974,9 @@ func FilterValidArch(arch string) (string, error) {
 	formatted := strings.TrimSpace(strings.ToLower(arch))
 	switch formatted {
 	case "amd64":
+		return "x64", nil
 	case "x86_64":
+		return "x64", nil
 	case "x64":
 		return "x64", nil
 	case "arm64":


### PR DESCRIPTION
Use the SHELL environment variable instead of the /etc/passwd file for determining the shell on Linux.