### PR TITLE
fix: remove context from wsl connection struct

### DIFF
--- a/pkg/shellexec/shellexec.go
+++ b/pkg/shellexec/shellexec.go
@@ -148,12 +148,10 @@ func (pp *PipePty) WriteString(s string) (n int, err error) {
 }
 
 func StartWslShellProc(ctx context.Context, termSize waveobj.TermSize, cmdStr string, cmdOpts CommandOptsType, conn *wsl.WslConn) (*ShellProc, error) {
-	shellProcCtx, cancelFn := context.WithCancel(ctx)
-	defer cancelFn()
 	client := conn.GetClient()
 	shellPath := cmdOpts.ShellPath
 	if shellPath == "" {
-		remoteShellPath, err := wsl.DetectShell(shellProcCtx, client)
+		remoteShellPath, err := wsl.DetectShell(ctx, client)
 		if err != nil {
 			return nil, err
 		}
@@ -162,13 +160,13 @@ func StartWslShellProc(ctx context.Context, termSize waveobj.TermSize, cmdStr st
 	var shellOpts []string
 	log.Printf("detected shell: %s", shellPath)
 
-	err := wsl.InstallClientRcFiles(shellProcCtx, client)
+	err := wsl.InstallClientRcFiles(ctx, client)
 	if err != nil {
 		log.Printf("error installing rc files: %v", err)
 		return nil, err
 	}
 
-	homeDir := wsl.GetHomeDir(shellProcCtx, client)
+	homeDir := wsl.GetHomeDir(ctx, client)
 	shellOpts = append(shellOpts, "~", "-d", client.Name())
 
 	var subShellOpts []string

--- a/pkg/shellexec/shellexec.go
+++ b/pkg/shellexec/shellexec.go
@@ -148,10 +148,12 @@ func (pp *PipePty) WriteString(s string) (n int, err error) {
 }
 
 func StartWslShellProc(ctx context.Context, termSize waveobj.TermSize, cmdStr string, cmdOpts CommandOptsType, conn *wsl.WslConn) (*ShellProc, error) {
+	utilCtx, cancelFn := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelFn()
 	client := conn.GetClient()
 	shellPath := cmdOpts.ShellPath
 	if shellPath == "" {
-		remoteShellPath, err := wsl.DetectShell(ctx, client)
+		remoteShellPath, err := wsl.DetectShell(utilCtx, client)
 		if err != nil {
 			return nil, err
 		}
@@ -160,13 +162,13 @@ func StartWslShellProc(ctx context.Context, termSize waveobj.TermSize, cmdStr st
 	var shellOpts []string
 	log.Printf("detected shell: %s", shellPath)
 
-	err := wsl.InstallClientRcFiles(ctx, client)
+	err := wsl.InstallClientRcFiles(utilCtx, client)
 	if err != nil {
 		log.Printf("error installing rc files: %v", err)
 		return nil, err
 	}
 
-	homeDir := wsl.GetHomeDir(ctx, client)
+	homeDir := wsl.GetHomeDir(utilCtx, client)
 	shellOpts = append(shellOpts, "~", "-d", client.Name())
 
 	var subShellOpts []string

--- a/pkg/shellexec/shellexec.go
+++ b/pkg/shellexec/shellexec.go
@@ -148,10 +148,12 @@ func (pp *PipePty) WriteString(s string) (n int, err error) {
 }
 
 func StartWslShellProc(ctx context.Context, termSize waveobj.TermSize, cmdStr string, cmdOpts CommandOptsType, conn *wsl.WslConn) (*ShellProc, error) {
+	shellProcCtx, cancelFn := context.WithCancel(ctx)
+	defer cancelFn()
 	client := conn.GetClient()
 	shellPath := cmdOpts.ShellPath
 	if shellPath == "" {
-		remoteShellPath, err := wsl.DetectShell(conn.Context, client)
+		remoteShellPath, err := wsl.DetectShell(shellProcCtx, client)
 		if err != nil {
 			return nil, err
 		}
@@ -160,13 +162,13 @@ func StartWslShellProc(ctx context.Context, termSize waveobj.TermSize, cmdStr st
 	var shellOpts []string
 	log.Printf("detected shell: %s", shellPath)
 
-	err := wsl.InstallClientRcFiles(conn.Context, client)
+	err := wsl.InstallClientRcFiles(shellProcCtx, client)
 	if err != nil {
 		log.Printf("error installing rc files: %v", err)
 		return nil, err
 	}
 
-	homeDir := wsl.GetHomeDir(conn.Context, client)
+	homeDir := wsl.GetHomeDir(shellProcCtx, client)
 	shellOpts = append(shellOpts, "~", "-d", client.Name())
 
 	var subShellOpts []string

--- a/pkg/wsl/wsl.go
+++ b/pkg/wsl/wsl.go
@@ -187,7 +187,7 @@ func (conn *WslConn) OpenDomainSocketListener() error {
 }
 
 func (conn *WslConn) StartConnServer() error {
-	utilCtx, cancelFn := context.WithTimeout(context.Background(), 2*time.Second)
+	utilCtx, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelFn()
 	var allowed bool
 	conn.WithLock(func() {


### PR DESCRIPTION
This fixes a WSL bug where disconnecting the controller does not allow the controller to restart until the app reboots.