### PR TITLE
fix: add manual escape handler in term block

### DIFF
--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -409,6 +409,12 @@ class TermViewModel implements ViewModel {
             return false;
         }
         // deal with terminal specific keybindings
+        if (keyutil.checkKeyPressed(waveEvent, "Escape")) {
+            this.termRef.current?.terminal.paste("\x1b");
+            event.preventDefault();
+            event.stopPropagation();
+            return false;
+        }
         if (keyutil.checkKeyPressed(waveEvent, "Ctrl:Shift:v")) {
             const p = navigator.clipboard.readText();
             p.then((text) => {


### PR DESCRIPTION
Adding escape as a global key binding means that it no longer automatically propogates to xterm. This adds a manual case to ensure it is forwarded.