### PR TITLE
Fix escape getting eaten by global event handler

### DIFF
--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -279,7 +279,7 @@ electron.ipcMain.on("webview-focus", (event: Electron.IpcMainEvent, focusedId: n
         hasBeforeInputRegisteredMap.set(focusedId, true);
         webviewWc.on("before-input-event", (e, input) => {
             let waveEvent = keyutil.adaptFromElectronKeyEvent(input);
-            console.log(`WEB ${focusedId}`, waveEvent.type, waveEvent.code);
+            // console.log(`WEB ${focusedId}`, waveEvent.type, waveEvent.code);
             handleCtrlShiftState(parentWc, waveEvent);
             if (webviewFocusId != focusedId) {
                 return;
@@ -289,7 +289,7 @@ electron.ipcMain.on("webview-focus", (event: Electron.IpcMainEvent, focusedId: n
             }
             for (let keyDesc of webviewKeys) {
                 if (keyutil.checkKeyPressed(waveEvent, keyDesc)) {
-                    // e.preventDefault();
+                    e.preventDefault();
                     parentWc.send("reinject-key", waveEvent);
                     console.log("webview reinject-key", keyDesc);
                     return;

--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -279,7 +279,7 @@ electron.ipcMain.on("webview-focus", (event: Electron.IpcMainEvent, focusedId: n
         hasBeforeInputRegisteredMap.set(focusedId, true);
         webviewWc.on("before-input-event", (e, input) => {
             let waveEvent = keyutil.adaptFromElectronKeyEvent(input);
-            // console.log(`WEB ${focusedId}`, waveEvent.type, waveEvent.code);
+            console.log(`WEB ${focusedId}`, waveEvent.type, waveEvent.code);
             handleCtrlShiftState(parentWc, waveEvent);
             if (webviewFocusId != focusedId) {
                 return;
@@ -289,7 +289,7 @@ electron.ipcMain.on("webview-focus", (event: Electron.IpcMainEvent, focusedId: n
             }
             for (let keyDesc of webviewKeys) {
                 if (keyutil.checkKeyPressed(waveEvent, keyDesc)) {
-                    e.preventDefault();
+                    // e.preventDefault();
                     parentWc.send("reinject-key", waveEvent);
                     console.log("webview reinject-key", keyDesc);
                     return;

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -364,7 +364,6 @@ function getAllGlobalKeyBindings(): string[] {
 
 // these keyboard events happen *anywhere*, even if you have focus in an input or somewhere else.
 function handleGlobalWaveKeyboardEvents(waveEvent: WaveKeyboardEvent): boolean {
-    console.log("handleGlobalWaveKeyboardEvents", waveEvent);
     for (const key of globalKeyMap.keys()) {
         if (keyutil.checkKeyPressed(waveEvent, key)) {
             const handler = globalKeyMap.get(key);

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -188,7 +188,7 @@ let lastHandledEvent: KeyboardEvent | null = null;
 
 function appHandleKeyDown(waveEvent: WaveKeyboardEvent): boolean {
     const nativeEvent = (waveEvent as any).nativeEvent;
-    if (lastHandledEvent != null && nativeEvent != null && lastHandledEvent.timeStamp == nativeEvent.timeStamp) {
+    if (lastHandledEvent != null && nativeEvent != null && lastHandledEvent === nativeEvent) {
         return false;
     }
     lastHandledEvent = nativeEvent;
@@ -364,6 +364,7 @@ function getAllGlobalKeyBindings(): string[] {
 
 // these keyboard events happen *anywhere*, even if you have focus in an input or somewhere else.
 function handleGlobalWaveKeyboardEvents(waveEvent: WaveKeyboardEvent): boolean {
+    console.log("handleGlobalWaveKeyboardEvents", waveEvent);
     for (const key of globalKeyMap.keys()) {
         if (keyutil.checkKeyPressed(waveEvent, key)) {
             const handler = globalKeyMap.get(key);

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -184,7 +184,14 @@ async function handleCmdN() {
     await createBlock(termBlockDef);
 }
 
+let lastHandledEvent: KeyboardEvent | null = null;
+
 function appHandleKeyDown(waveEvent: WaveKeyboardEvent): boolean {
+    const nativeEvent = (waveEvent as any).nativeEvent;
+    if (lastHandledEvent != null && nativeEvent != null && lastHandledEvent.timeStamp == nativeEvent.timeStamp) {
+        return false;
+    }
+    lastHandledEvent = nativeEvent;
     const handled = handleGlobalWaveKeyboardEvents(waveEvent);
     if (handled) {
         return true;
@@ -357,6 +364,7 @@ function getAllGlobalKeyBindings(): string[] {
 
 // these keyboard events happen *anywhere*, even if you have focus in an input or somewhere else.
 function handleGlobalWaveKeyboardEvents(waveEvent: WaveKeyboardEvent): boolean {
+    console.log("handleGlobalWaveKeyboardEvents", waveEvent);
     for (const key of globalKeyMap.keys()) {
         if (keyutil.checkKeyPressed(waveEvent, key)) {
             const handler = globalKeyMap.get(key);
@@ -366,6 +374,7 @@ function handleGlobalWaveKeyboardEvents(waveEvent: WaveKeyboardEvent): boolean {
             return handler(waveEvent);
         }
     }
+    return false;
 }
 
 export {

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -4,7 +4,7 @@
 import { Block, SubBlock } from "@/app/block/block";
 import { BlockNodeModel } from "@/app/block/blocktypes";
 import { Search, useSearch } from "@/app/element/search";
-import { getAllGlobalKeyBindings } from "@/app/store/keymodel";
+import { appHandleKeyDown } from "@/app/store/keymodel";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { makeFeBlockRouteId } from "@/app/store/wshrouter";
@@ -434,11 +434,11 @@ class TermViewModel implements ViewModel {
             this.forceRestartController();
             return false;
         }
-        const globalKeys = getAllGlobalKeyBindings();
-        for (const key of globalKeys) {
-            if (keyutil.checkKeyPressed(waveEvent, key)) {
-                return false;
-            }
+        const appHandled = appHandleKeyDown(waveEvent);
+        if (appHandled) {
+            event.preventDefault();
+            event.stopPropagation();
+            return false;
         }
         return true;
     }

--- a/frontend/util/keyutil.ts
+++ b/frontend/util/keyutil.ts
@@ -210,6 +210,7 @@ function adaptFromReactOrNativeKeyEvent(event: React.KeyboardEvent | KeyboardEve
     rtn.code = event.code;
     rtn.key = event.key;
     rtn.location = event.location;
+    (rtn as any).nativeEvent = event;
     if (event.type == "keydown" || event.type == "keyup" || event.type == "keypress") {
         rtn.type = event.type;
     } else {

--- a/frontend/util/keyutil.ts
+++ b/frontend/util/keyutil.ts
@@ -78,9 +78,6 @@ function parseKeyDescription(keyDescription: string): KeyPressDecl {
                 rtn.mods.Option = true;
             }
             rtn.mods.Meta = true;
-        } else if (key == "Esc") {
-            rtn.key = "Escape";
-            rtn.keyType = KeyTypeKey;
         } else {
             let { key: parsedKey, type: keyType } = parseKey(key);
             rtn.key = parsedKey;


### PR DESCRIPTION
The terminal keydown handler was set to filter out all key bindings that have a registered global handler, regardless of whether they actually propagated or not. This allowed the global handlers to still work despite the terminal input having precedence, but it also meant that global key bindings that were invalid for the current context would still get eaten and not sent to stdin.

Now, the terminal keydown handler will directly call the global handlers so we can actually see whether or not the global key binding is valid. If the global handler is valid, it'll be processed immediately and stdin won't receive the input. If it's not handled, we'll let xterm pass it to stdin. Because anything xterm doesn't handle gets sent to the globally-registered version of the handler, we need to make sure we don't do extra work to process an input we've already checked. We'll store the last-handled keydown event as a static variable so we can dedupe later calls for the same event to prevent doing double work. 