### PR TITLE
fix:  nil dereference in nowsh error messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/ubuntu/gowsl v0.0.0-20240906163211-049fd49bd93b
 	github.com/wavetermdev/htmltoken v0.2.0
 	golang.org/x/crypto v0.31.0
+	golang.org/x/mod v0.22.0
 	golang.org/x/sys v0.28.0
 	golang.org/x/term v0.27.0
 	google.golang.org/api v0.214.0
@@ -63,7 +64,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.29.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
-	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect

--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -553,8 +553,16 @@ func (conn *SSHConn) connectInternal(ctx context.Context, connFlags *wshrpc.Conn
 			}
 			if dsErr != nil || csErr != nil {
 				log.Print("attempting to run with nowsh instead")
+				var errmsgs []string
+				if dsErr != nil {
+					errmsgs = append(errmsgs, fmt.Sprintf("domain socket error: %s", dsErr.Error()))
+				}
+				if csErr != nil {
+					errmsgs = append(errmsgs, fmt.Sprintf("conn server error: %s", csErr.Error()))
+				}
+				combinedErr := fmt.Errorf("%s", strings.Join(errmsgs, " | "))
 				conn.WithLock(func() {
-					conn.WshError = csErr.Error()
+					conn.WshError = combinedErr.Error()
 				})
 				conn.WshEnabled.Store(false)
 			}


### PR DESCRIPTION
This showed up when the domain socket request failed but the connection request did not. With this fixed, this case correctly enters nowsh mode.