### PR TITLE
fix: default en_US.UTF-8 if lang has problems

### DIFF
--- a/pkg/wavebase/wavebase.go
+++ b/pkg/wavebase/wavebase.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/wavetermdev/waveterm/pkg/util/utilfn"
 )
 
 // set by main-server.go
@@ -199,21 +201,41 @@ func TryMkdirs(dirName string, perm os.FileMode, dirDesc string) error {
 	return nil
 }
 
+func listValidLangs(ctx context.Context) []string {
+	out, err := exec.CommandContext(ctx, "locale", "-a").CombinedOutput()
+	if err != nil {
+		log.Printf("error running 'locale -a': %s\n", err)
+		return []string{}
+	}
+	// don't bother with CRLF line endings
+	// this command doesn't work on windows
+	return strings.Split(string(out), "\n")
+}
+
 var osLangOnce = &sync.Once{}
 var osLang string
 
 func determineLang() string {
+	defaultLang := "en_US.UTF-8"
 	ctx, cancelFn := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancelFn()
 	if runtime.GOOS == "darwin" {
 		out, err := exec.CommandContext(ctx, "defaults", "read", "-g", "AppleLocale").CombinedOutput()
 		if err != nil {
-			log.Printf("error executing 'defaults read -g AppleLocale': %v\n", err)
-			return ""
+			log.Printf("error executing 'defaults read -g AppleLocale', will use default 'en_US.UTF-8': %v\n", err)
+			return defaultLang
 		}
 		strOut := string(out)
 		truncOut := strings.Split(strOut, "@")[0]
-		return strings.TrimSpace(truncOut) + ".UTF-8"
+		preferredLang := strings.TrimSpace(truncOut) + ".UTF-8"
+		validLangs := listValidLangs(ctx)
+
+		if !utilfn.ContainsStr(validLangs, preferredLang) {
+			log.Printf("unable to use desired lang %s, will use default 'en_US.UTF-8'\n", preferredLang)
+			return defaultLang
+		}
+
+		return preferredLang
 	} else if runtime.GOOS == "win32" {
 		out, err := exec.CommandContext(ctx, "Get-Culture", "|", "select", "-exp", "Name").CombinedOutput()
 		if err != nil {

--- a/pkg/wavebase/wavebase.go
+++ b/pkg/wavebase/wavebase.go
@@ -236,13 +236,6 @@ func determineLang() string {
 		}
 
 		return preferredLang
-	} else if runtime.GOOS == "win32" {
-		out, err := exec.CommandContext(ctx, "Get-Culture", "|", "select", "-exp", "Name").CombinedOutput()
-		if err != nil {
-			log.Printf("error executing 'Get-Culture | select -exp Name': %v\n", err)
-			return ""
-		}
-		return strings.TrimSpace(string(out)) + ".UTF-8"
 	} else {
 		// this is specifically to get the wavesrv LANG so waveshell
 		// on a remote uses the same LANG


### PR DESCRIPTION
Mac's `defaults read -g AppleLocale` command can return locales that don't have a language in /usr/share/locale. This prevents those locales from using a language with UTF-8 support. This will use en_US.UTF-8 as a default to cover those cases if there are problems. As per usual, if LANG is already set, that value will be used instead.