### PR TITLE
Fix directory preview head width

### DIFF
--- a/frontend/app/view/preview/directorypreview.scss
+++ b/frontend/app/view/preview/directorypreview.scss
@@ -31,7 +31,7 @@
             position: sticky;
             top: 0;
             z-index: 10;
-            width: 100%;
+            width: fit-content;
             border-bottom: 1px solid var(--border-color);
 
             .dir-table-head-row {


### PR DESCRIPTION
The head was set to `100%`, which meant that it only was as wide as the viewport, rather than its contents, which can overflow. Now, the width is `fit-content`, which allows it to overflow with its contents so that the background and border extend the full width.