### PR TITLE
Fix `XDG_*_DIR` paths for snap installations

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -104,6 +104,10 @@ const config = {
         confinement: "classic",
         allowNativeWayland: true,
         artifactName: "${name}_${version}_${arch}.${ext}",
+        environment: {
+            XDG_CONFIG_HOME: "$XDG_CONFIG_HOME",
+            XDG_DATA_HOME: "$XDG_DATA_HOME",
+        },
     },
     publish: {
         provider: "generic",

--- a/emain/emain-wavesrv.ts
+++ b/emain/emain-wavesrv.ts
@@ -104,6 +104,11 @@ export function runWaveSrv(handleWSEvent: (evtMsg: WSEventType) => void): Promis
             }
             process.env[WSServerEndpointVarName] = startParams[1];
             process.env[WebServerEndpointVarName] = startParams[2];
+            delete process.env.XDG_DATA_HOME;
+            delete process.env.XDG_CONFIG_HOME;
+            delete process.env.XDG_RUNTIME_DIR;
+            delete process.env.XDG_CACHE_HOME;
+            delete process.env.XDG_STATE_HOME;
             WaveVersion = startParams[3];
             WaveBuildTime = parseInt(startParams[4]);
             waveSrvReadyResolve(true);

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -168,11 +168,11 @@ function readXdgConfigDirs(): Record<string, string> {
 function correctSnapXdgVars() {
     console.log("Correcting XDG_* variables for Snap", process.env.SNAP);
     if (process.env.SNAP) {
-        if (!process.env[WaveConfigHomeVarName]) {
+        if (!process.env[WaveConfigHomeVarName] && process.env.XDG_CONFIG_HOME) {
             process.env[WaveConfigHomeVarName] = path.join(process.env.XDG_CONFIG_HOME, waveDirName);
             process.env.XDG_CONFIG_HOME = "";
         }
-        if (!process.env[WaveDataHomeVarName]) {
+        if (!process.env[WaveDataHomeVarName] && process.env.XDG_DATA_HOME) {
             process.env[WaveDataHomeVarName] = path.join(process.env.XDG_DATA_HOME, waveDirName);
             process.env.XDG_DATA_HOME = "";
         }

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -168,11 +168,11 @@ function readXdgConfigDirs(): Record<string, string> {
 function correctSnapXdgVars() {
     if (process.env.SNAP) {
         if (!process.env[WaveConfigHomeVarName]) {
-            process.env[WaveConfigHomeVarName] = process.env.XDG_CONFIG_HOME;
+            process.env[WaveConfigHomeVarName] = path.join(process.env.XDG_CONFIG_HOME, waveDirName);
             process.env.XDG_CONFIG_HOME = "";
         }
         if (!process.env[WaveDataHomeVarName]) {
-            process.env[WaveDataHomeVarName] = process.env.XDG_DATA_HOME;
+            process.env[WaveDataHomeVarName] = path.join(process.env.XDG_DATA_HOME, waveDirName);
             process.env.XDG_DATA_HOME = "";
         }
         const xdgDirs = readXdgConfigDirs();

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -157,7 +157,7 @@ function readXdgConfigDirs(): Record<string, string> {
         const dirs: Record<string, string> = {};
         for (const line of lines) {
             console.log("Reading XDG_* line", line);
-            const match = line.match(/^(XDG_[[:upper:]]+_DIR)="(.*)"/);
+            const match = line.match(/^(XDG_\w+_DIR)="(.*)"/);
             if (match) {
                 dirs[match[1]] = match[2];
             }

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -155,7 +155,7 @@ function readXdgConfigDirs(): Record<string, string> {
         const lines = xdgConfig.split("\n");
         const dirs: Record<string, string> = {};
         for (const line of lines) {
-            const match = line.match(/^XDG_([[:upper:]]+)_DIR="(.*)"$/);
+            const match = line.match(/^XDG_([[:upper:]]+)_DIR="(.*)"/);
             if (match) {
                 dirs[match[1]] = match[2];
             }

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -4,7 +4,7 @@
 import { fireAndForget } from "@/util/util";
 import { app, dialog, ipcMain, shell } from "electron";
 import envPaths from "env-paths";
-import { existsSync, mkdirSync, readFileSync } from "fs";
+import { existsSync, mkdirSync } from "fs";
 import os from "os";
 import path from "path";
 import { WaveDevVarName, WaveDevViteVarName } from "../frontend/util/isdev";
@@ -146,44 +146,6 @@ function getWaveDataDir(): string {
         retVal = paths.data;
     }
     return ensurePathExists(retVal);
-}
-
-function readXdgConfigDirs(): Record<string, string> {
-    const xdgConfigPath = path.join(app.getPath("home"), ".config", "user-dirs.dirs");
-    if (existsSync(xdgConfigPath)) {
-        console.log("Reading XDG_* variables from", xdgConfigPath);
-        const xdgConfig = readFileSync(xdgConfigPath, "utf8");
-        const lines = xdgConfig.split("\n");
-        const dirs: Record<string, string> = {};
-        for (const line of lines) {
-            console.log("Reading XDG_* line", line);
-            const match = line.match(/^(XDG_\w+_DIR)="(.*)"/);
-            if (match) {
-                dirs[match[1]] = match[2];
-            }
-        }
-        return dirs;
-    }
-    return {};
-}
-
-function correctSnapXdgVars() {
-    if (process.env.SNAP) {
-        console.log("Correcting XDG_* variables for Snap", process.env.SNAP);
-        if (!process.env[WaveConfigHomeVarName] && process.env.XDG_CONFIG_HOME) {
-            process.env[WaveConfigHomeVarName] = path.join(process.env.XDG_CONFIG_HOME, waveDirName);
-            process.env.XDG_CONFIG_HOME = "";
-        }
-        if (!process.env[WaveDataHomeVarName] && process.env.XDG_DATA_HOME) {
-            process.env[WaveDataHomeVarName] = path.join(process.env.XDG_DATA_HOME, waveDirName);
-            process.env.XDG_DATA_HOME = "";
-        }
-        const xdgDirs = readXdgConfigDirs();
-        console.log("Corrected XDG_* variables", xdgDirs);
-        for (const dir in xdgDirs) {
-            process.env[dir] = xdgDirs[dir];
-        }
-    }
 }
 
 function getElectronAppBasePath(): string {

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -228,8 +228,9 @@ ipcMain.on("get-config-dir", (event) => {
     event.returnValue = getWaveConfigDir();
 });
 
+correctSnapXdgVars();
+
 export {
-    correctSnapXdgVars,
     getElectronAppBasePath,
     getElectronAppUnpackedBasePath,
     getWaveConfigDir,

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -166,6 +166,7 @@ function readXdgConfigDirs(): Record<string, string> {
 }
 
 function correctSnapXdgVars() {
+    console.log("Correcting XDG_* variables for Snap", process.env.SNAP);
     if (process.env.SNAP) {
         if (!process.env[WaveConfigHomeVarName]) {
             process.env[WaveConfigHomeVarName] = path.join(process.env.XDG_CONFIG_HOME, waveDirName);

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -151,10 +151,12 @@ function getWaveDataDir(): string {
 function readXdgConfigDirs(): Record<string, string> {
     const xdgConfigPath = path.join(app.getPath("home"), ".config", "user-dirs.dirs");
     if (existsSync(xdgConfigPath)) {
+        console.log("Reading XDG_* variables from", xdgConfigPath);
         const xdgConfig = readFileSync(xdgConfigPath, "utf8");
         const lines = xdgConfig.split("\n");
         const dirs: Record<string, string> = {};
         for (const line of lines) {
+            console.log("Reading XDG_* line", line);
             const match = line.match(/^XDG_([[:upper:]]+)_DIR="(.*)"/);
             if (match) {
                 dirs[match[1]] = match[2];

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -157,7 +157,7 @@ function readXdgConfigDirs(): Record<string, string> {
         const dirs: Record<string, string> = {};
         for (const line of lines) {
             console.log("Reading XDG_* line", line);
-            const match = line.match(/^XDG_([[:upper:]]+)_DIR="(.*)"/);
+            const match = line.match(/^(XDG_[[:upper:]]+_DIR)="(.*)"/);
             if (match) {
                 dirs[match[1]] = match[2];
             }

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -166,8 +166,8 @@ function readXdgConfigDirs(): Record<string, string> {
 }
 
 function correctSnapXdgVars() {
-    console.log("Correcting XDG_* variables for Snap", process.env.SNAP);
     if (process.env.SNAP) {
+        console.log("Correcting XDG_* variables for Snap", process.env.SNAP);
         if (!process.env[WaveConfigHomeVarName] && process.env.XDG_CONFIG_HOME) {
             process.env[WaveConfigHomeVarName] = path.join(process.env.XDG_CONFIG_HOME, waveDirName);
             process.env.XDG_CONFIG_HOME = "";

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -232,8 +232,6 @@ ipcMain.on("get-config-dir", (event) => {
     event.returnValue = getWaveConfigDir();
 });
 
-correctSnapXdgVars();
-
 export {
     getElectronAppBasePath,
     getElectronAppUnpackedBasePath,

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -177,6 +177,7 @@ function correctSnapXdgVars() {
             process.env.XDG_DATA_HOME = "";
         }
         const xdgDirs = readXdgConfigDirs();
+        console.log("Corrected XDG_* variables", xdgDirs);
         for (const dir in xdgDirs) {
             process.env[dir] = xdgDirs[dir];
         }


### PR DESCRIPTION
This PR corrects the XDG directory path variables to match the host configuration while maintaining the spirit of the Snap isolation by continuing to use the Snap user directory for Wave-specific configuration files. This should also ensure that there's no breaking changes for users' existing configurations.

closes #1696 