### PR TITLE
Simplify regex and fix tests for pamparse

### DIFF
--- a/pkg/shellexec/shellexec.go
+++ b/pkg/shellexec/shellexec.go
@@ -541,6 +541,8 @@ const etcEnvironmentPath = "/etc/environment"
 const etcSecurityPath = "/etc/security/pam_env.conf"
 const userEnvironmentPath = "~/.pam_environment"
 
+var pamParseOpts *pamparse.PamParseOpts = pamparse.ParsePasswdSafe()
+
 /*
 tryGetPamEnvVars tries to get the environment variables from /etc/environment,
 /etc/security/pam_env.conf, and ~/.pam_environment.
@@ -556,11 +558,11 @@ func tryGetPamEnvVars() map[string]string {
 	if err != nil {
 		log.Printf("error parsing %s: %v", etcEnvironmentPath, err)
 	}
-	envVars2, err := pamparse.ParseEnvironmentConfFile(etcSecurityPath)
+	envVars2, err := pamparse.ParseEnvironmentConfFile(etcSecurityPath, pamParseOpts)
 	if err != nil {
 		log.Printf("error parsing %s: %v", etcSecurityPath, err)
 	}
-	envVars3, err := pamparse.ParseEnvironmentConfFile(wavebase.ExpandHomeDirSafe(userEnvironmentPath))
+	envVars3, err := pamparse.ParseEnvironmentConfFile(wavebase.ExpandHomeDirSafe(userEnvironmentPath), pamParseOpts)
 	if err != nil {
 		log.Printf("error parsing %s: %v", userEnvironmentPath, err)
 	}

--- a/pkg/util/pamparse/pamparse_test.go
+++ b/pkg/util/pamparse/pamparse_test.go
@@ -78,14 +78,17 @@ FOO11="foo#bar"
 	}
 
 	// parse the file
-	got, err := pamparse.ParseEnvironmentConfFile(tempFile)
+	got, err := pamparse.ParseEnvironmentConfFile(tempFile, &pamparse.PamParseOpts{
+		Home:  "/home/user",
+		Shell: "/bin/bash"},
+	)
 	if err != nil {
 		t.Fatalf("failed to parse pam environment conf file: %v", err)
 	}
 
 	want := map[string]string{
-		"TEST":           "./config\\ s:@{HOME}/.config\\ state",
-		"FOO":            "@{HOME}/.config\\ s",
+		"TEST":           "./config\\ s:/home/user/.config\\ state",
+		"FOO":            "/home/user/.config\\ s",
 		"STRING":         "string",
 		"STRINGOVERRIDE": "string2:string",
 		"FOO11":          "foo",


### PR DESCRIPTION
Simplifies the regex so it doesn't have as many negations.

Adds an option to pass the `/etc/passwd` values needed for pamparse so that we can mock them for the tests. Also allows us to only grab those values once at launch, since they shouldn't change.