### PR TITLE
Use Zig for Windows and ARM64 Linux

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -38,7 +38,11 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm squashfs-tools
                   sudo snap install snapcraft --classic
-                  sudo snap install zig --classic --beta # We use Zig instead of glibc for cgo compilation as it is more-easily statically linked
+                  sudo snap install zig --classic # We use Zig instead of glibc for cgo compilation as it is more-easily statically linked
+            - name: Install Windows Build Dependencies (Windows only)
+              if: matrix.platform == 'windows'
+              run: |
+                  choco install -y zig
 
             # The pre-installed version of the AWS CLI has a segfault problem so we'll install it via Homebrew instead.
             - name: Upgrade AWS CLI (Mac only)

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -38,11 +38,9 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm squashfs-tools
                   sudo snap install snapcraft --classic
-                  sudo snap install zig --classic --beta # We use Zig instead of glibc for cgo compilation as it is more-easily statically linked
-            - name: Install Windows Build Dependencies (Windows only)
-              if: matrix.platform == 'windows'
-              run: |
-                  choco install -y zig
+            - name: Install Zig (not Mac)
+              if: matrix.platform != 'darwin'
+              uses: mlugg/setup-zig@v1
 
             # The pre-installed version of the AWS CLI has a segfault problem so we'll install it via Homebrew instead.
             - name: Upgrade AWS CLI (Mac only)

--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -38,7 +38,7 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install --no-install-recommends -y libarchive-tools libopenjp2-tools rpm squashfs-tools
                   sudo snap install snapcraft --classic
-                  sudo snap install zig --classic # We use Zig instead of glibc for cgo compilation as it is more-easily statically linked
+                  sudo snap install zig --classic --beta # We use Zig instead of glibc for cgo compilation as it is more-easily statically linked
             - name: Install Windows Build Dependencies (Windows only)
               if: matrix.platform == 'windows'
               run: |

--- a/.github/workflows/testdriver-build.yml
+++ b/.github/workflows/testdriver-build.yml
@@ -57,6 +57,8 @@ jobs:
               with:
                   version: 3.x
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Install Zig
+              uses: mlugg/setup-zig@v1
 
             - name: Build
               run: task package

--- a/BUILD.md
+++ b/BUILD.md
@@ -20,7 +20,7 @@ Debian/Ubuntu:
 
 ```sh
 sudo apt install zip snapd
-sudo snap install zig --classic --beta
+sudo snap install zig --classic
 ```
 
 Fedora/RHEL:
@@ -50,11 +50,9 @@ For packaging, the following additional packages are required:
 
 #### Windows
 
-You will need the GNU build toolchain installed in order for Go to work on Windows. In most cases, this requires installing MinGW-w64.
+You will need the Zig [Zig](https://ziglang.org/) compiler for statically linking CGO.
 
-The easiest way to install this is using MSYS2: https://www.msys2.org/
-
-If you prefer an alternative method, you can find other methods here: https://www.mingw-w64.org/downloads/
+You can find installation instructions for Zig on Windows [here](https://ziglang.org/learn/getting-started/#managers).
 
 ### Task
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -20,7 +20,7 @@ Debian/Ubuntu:
 
 ```sh
 sudo apt install zip snapd
-sudo snap install zig --classic
+sudo snap install zig --classic --beta
 ```
 
 Fedora/RHEL:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -162,7 +162,7 @@ tasks:
                   ARCHS:
                       sh: echo {{if eq "arm" ARCH}}arm64{{else}}{{ARCH}}{{end}}
                   GO_ENV_VARS:
-                      sh: echo "{{if eq "amd64" ARCH}}CC=\"zig cc -target x86_64-linux-gnu.2.28\"{{end}}"
+                      sh: echo "{{if eq "amd64" ARCH}}CC=\"zig cc -target x86_64-linux-gnu.2.28\"{{else}}CC=\"zig cc -target aarch64-linux-gnu.2.28\"{{end}}"
 
     build:server:internal:
         requires:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -150,6 +150,8 @@ tasks:
               vars:
                   ARCHS:
                       sh: echo {{if eq "arm" ARCH}}arm64{{else}}{{ARCH}}{{end}}
+                  GO_ENV_VARS:
+                      sh: echo "{{if eq "amd64" ARCH}}CC=\"zig cc -target x86_64-windows-gnu\"{{else}}CC=\"zig cc -target aarch64-windows-gnu\"{{end}}"
 
     build:server:linux:
         desc: Build the wavesrv component for Linux platforms (only generates artifacts for the current architecture).


### PR DESCRIPTION
I'm making steps to simplify our build dependencies, consolidating our C compiler requirements so we only depend on Zig.

Before, we used Zig for x64 but not for arm64. This meant that users using an ARM dev machine would need to install `build-essentials` and Zig. We also required MinGW-w64 on Windows, which is a pain to install since it can be provided by a bunch of different tools, the smallest of which is like a 2GB install.