### PR TITLE
Update Wsh Command

### DIFF
--- a/cmd/wsh/cmd/wshcmd-connserver.go
+++ b/cmd/wsh/cmd/wshcmd-connserver.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -191,13 +190,8 @@ func serverRunRouter() error {
 }
 
 func checkForUpdate() error {
-	updateInfo := wshrpc.UpdateInfo{
-		ConnName:      RpcContext.Conn,
-		ClientArch:    runtime.GOARCH,
-		ClientOs:      runtime.GOOS,
-		ClientVersion: wavebase.WaveVersion,
-	}
-	needsRestartRaw, err := RpcClient.SendRpcRequest(wshrpc.Command_ConnUpdateWsh, updateInfo, &wshrpc.RpcOpts{Timeout: 2000})
+	remoteInfo := wshutil.GetInfo(RpcContext)
+	needsRestartRaw, err := RpcClient.SendRpcRequest(wshrpc.Command_ConnUpdateWsh, remoteInfo, &wshrpc.RpcOpts{Timeout: 60000})
 	if err != nil {
 		return fmt.Errorf("could not update: %w", err)
 	}

--- a/cmd/wsh/cmd/wshcmd-connserver.go
+++ b/cmd/wsh/cmd/wshcmd-connserver.go
@@ -11,7 +11,9 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -33,9 +35,11 @@ var serverCmd = &cobra.Command{
 }
 
 var connServerRouter bool
+var singleServerRouter bool
 
 func init() {
 	serverCmd.Flags().BoolVar(&connServerRouter, "router", false, "run in local router mode")
+	serverCmd.Flags().BoolVar(&singleServerRouter, "single", false, "run in local single mode")
 	rootCmd.AddCommand(serverCmd)
 }
 
@@ -186,6 +190,44 @@ func serverRunRouter() error {
 	select {}
 }
 
+func checkForUpdate() error {
+	updateInfo := wshrpc.UpdateInfo{
+		ConnName:      RpcContext.Conn,
+		ClientArch:    runtime.GOARCH,
+		ClientOs:      runtime.GOOS,
+		ClientVersion: wavebase.WaveVersion,
+	}
+	needsRestartRaw, err := RpcClient.SendRpcRequest(wshrpc.Command_ConnUpdateWsh, updateInfo, &wshrpc.RpcOpts{Timeout: 2000})
+	if err != nil {
+		return fmt.Errorf("could not update: %w", err)
+	}
+	needsRestart, ok := needsRestartRaw.(bool)
+	if !ok {
+		return fmt.Errorf("wrong return type from update")
+	}
+	if needsRestart {
+		// run the restart command here
+		// how to get the correct path?
+		return syscall.Exec("~/.waveterm/bin/wsh", []string{"wsh", "connserver", "--single"}, []string{})
+	}
+	return nil
+}
+
+func serverRunSingle() error {
+	err := setupRpcClient(&wshremote.ServerImpl{LogWriter: os.Stdout})
+	if err != nil {
+		return err
+	}
+	WriteStdout("running wsh connserver (%s)\n", RpcContext.Conn)
+	err = checkForUpdate()
+	if err != nil {
+		return err
+	}
+
+	go wshremote.RunSysInfoLoop(RpcClient, RpcContext.Conn)
+	select {} // run forever
+}
+
 func serverRunNormal() error {
 	err := setupRpcClient(&wshremote.ServerImpl{LogWriter: os.Stdout})
 	if err != nil {
@@ -197,7 +239,9 @@ func serverRunNormal() error {
 }
 
 func serverRun(cmd *cobra.Command, args []string) error {
-	if connServerRouter {
+	if singleServerRouter {
+		return serverRunSingle()
+	} else if connServerRouter {
 		return serverRunRouter()
 	} else {
 		return serverRunNormal()

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -57,18 +57,14 @@ class RpcApiType {
         return client.wshRpcCall("connstatus", null, opts);
     }
 
-    // command "controllerappendoutput" [call]
-    ControllerAppendOutputCommand(
-        client: WshClient,
-        data: CommandControllerAppendOutputData,
-        opts?: RpcOpts
-    ): Promise<void> {
-        return client.wshRpcCall("controllerappendoutput", data, opts);
-    }
-
     // command "connupdatewsh" [call]
     ConnUpdateWshCommand(client: WshClient, data: UpdateInfo, opts?: RpcOpts): Promise<boolean> {
         return client.wshRpcCall("connupdatewsh", data, opts);
+    }
+
+    // command "controllerappendoutput" [call]
+    ControllerAppendOutputCommand(client: WshClient, data: CommandControllerAppendOutputData, opts?: RpcOpts): Promise<void> {
+        return client.wshRpcCall("controllerappendoutput", data, opts);
     }
 
     // command "controllerinput" [call]
@@ -122,11 +118,7 @@ class RpcApiType {
     }
 
     // command "eventreadhistory" [call]
-    EventReadHistoryCommand(
-        client: WshClient,
-        data: CommandEventReadHistoryData,
-        opts?: RpcOpts
-    ): Promise<WaveEvent[]> {
+    EventReadHistoryCommand(client: WshClient, data: CommandEventReadHistoryData, opts?: RpcOpts): Promise<WaveEvent[]> {
         return client.wshRpcCall("eventreadhistory", data, opts);
     }
 
@@ -256,16 +248,12 @@ class RpcApiType {
     }
 
     // command "remotestreamcpudata" [responsestream]
-    RemoteStreamCpuDataCommand(client: WshClient, opts?: RpcOpts): AsyncGenerator<TimeSeriesData, void, boolean> {
+	RemoteStreamCpuDataCommand(client: WshClient, opts?: RpcOpts): AsyncGenerator<TimeSeriesData, void, boolean> {
         return client.wshRpcStream("remotestreamcpudata", null, opts);
     }
 
     // command "remotestreamfile" [responsestream]
-    RemoteStreamFileCommand(
-        client: WshClient,
-        data: CommandRemoteStreamFileData,
-        opts?: RpcOpts
-    ): AsyncGenerator<CommandRemoteStreamFileRtnData, void, boolean> {
+	RemoteStreamFileCommand(client: WshClient, data: CommandRemoteStreamFileData, opts?: RpcOpts): AsyncGenerator<CommandRemoteStreamFileRtnData, void, boolean> {
         return client.wshRpcStream("remotestreamfile", data, opts);
     }
 
@@ -275,11 +263,7 @@ class RpcApiType {
     }
 
     // command "resolveids" [call]
-    ResolveIdsCommand(
-        client: WshClient,
-        data: CommandResolveIdsData,
-        opts?: RpcOpts
-    ): Promise<CommandResolveIdsRtnData> {
+    ResolveIdsCommand(client: WshClient, data: CommandResolveIdsData, opts?: RpcOpts): Promise<CommandResolveIdsRtnData> {
         return client.wshRpcCall("resolveids", data, opts);
     }
 
@@ -319,25 +303,17 @@ class RpcApiType {
     }
 
     // command "streamcpudata" [responsestream]
-    StreamCpuDataCommand(
-        client: WshClient,
-        data: CpuDataRequest,
-        opts?: RpcOpts
-    ): AsyncGenerator<TimeSeriesData, void, boolean> {
+	StreamCpuDataCommand(client: WshClient, data: CpuDataRequest, opts?: RpcOpts): AsyncGenerator<TimeSeriesData, void, boolean> {
         return client.wshRpcStream("streamcpudata", data, opts);
     }
 
     // command "streamtest" [responsestream]
-    StreamTestCommand(client: WshClient, opts?: RpcOpts): AsyncGenerator<number, void, boolean> {
+	StreamTestCommand(client: WshClient, opts?: RpcOpts): AsyncGenerator<number, void, boolean> {
         return client.wshRpcStream("streamtest", null, opts);
     }
 
     // command "streamwaveai" [responsestream]
-    StreamWaveAiCommand(
-        client: WshClient,
-        data: WaveAIStreamRequest,
-        opts?: RpcOpts
-    ): AsyncGenerator<WaveAIPacketType, void, boolean> {
+	StreamWaveAiCommand(client: WshClient, data: WaveAIStreamRequest, opts?: RpcOpts): AsyncGenerator<WaveAIPacketType, void, boolean> {
         return client.wshRpcStream("streamwaveai", data, opts);
     }
 
@@ -357,20 +333,12 @@ class RpcApiType {
     }
 
     // command "vdomrender" [responsestream]
-    VDomRenderCommand(
-        client: WshClient,
-        data: VDomFrontendUpdate,
-        opts?: RpcOpts
-    ): AsyncGenerator<VDomBackendUpdate, void, boolean> {
+	VDomRenderCommand(client: WshClient, data: VDomFrontendUpdate, opts?: RpcOpts): AsyncGenerator<VDomBackendUpdate, void, boolean> {
         return client.wshRpcStream("vdomrender", data, opts);
     }
 
     // command "vdomurlrequest" [responsestream]
-    VDomUrlRequestCommand(
-        client: WshClient,
-        data: VDomUrlRequestData,
-        opts?: RpcOpts
-    ): AsyncGenerator<VDomUrlRequestResponse, void, boolean> {
+	VDomUrlRequestCommand(client: WshClient, data: VDomUrlRequestData, opts?: RpcOpts): AsyncGenerator<VDomUrlRequestResponse, void, boolean> {
         return client.wshRpcStream("vdomurlrequest", data, opts);
     }
 
@@ -395,7 +363,7 @@ class RpcApiType {
     }
 
     // command "wshactivity" [call]
-    WshActivityCommand(client: WshClient, data: { [key: string]: number }, opts?: RpcOpts): Promise<void> {
+    WshActivityCommand(client: WshClient, data: {[key: string]: number}, opts?: RpcOpts): Promise<void> {
         return client.wshRpcCall("wshactivity", data, opts);
     }
 
@@ -413,6 +381,7 @@ class RpcApiType {
     WslStatusCommand(client: WshClient, opts?: RpcOpts): Promise<ConnStatus[]> {
         return client.wshRpcCall("wslstatus", null, opts);
     }
+
 }
 
 export const RpcApi = new RpcApiType();

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -57,6 +57,11 @@ class RpcApiType {
         return client.wshRpcCall("connstatus", null, opts);
     }
 
+    // command "connupdatewsh" [call]
+    ConnUpdateWshCommand(client: WshClient, data: UpdateInfo, opts?: RpcOpts): Promise<boolean> {
+        return client.wshRpcCall("connupdatewsh", data, opts);
+    }
+
     // command "controllerinput" [call]
     ControllerInputCommand(client: WshClient, data: CommandBlockInputData, opts?: RpcOpts): Promise<void> {
         return client.wshRpcCall("controllerinput", data, opts);

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -58,7 +58,7 @@ class RpcApiType {
     }
 
     // command "connupdatewsh" [call]
-    ConnUpdateWshCommand(client: WshClient, data: UpdateInfo, opts?: RpcOpts): Promise<boolean> {
+    ConnUpdateWshCommand(client: WshClient, data: RemoteInfo, opts?: RpcOpts): Promise<boolean> {
         return client.wshRpcCall("connupdatewsh", data, opts);
     }
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -558,7 +558,7 @@ declare global {
         host: string;
         clientarch: string;
         clientos: string;
-        string: string;
+        clientversion: string;
         shell: string;
     };
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -729,6 +729,14 @@ declare global {
         activetabid: string;
     };
 
+    // wshrpc.UpdateInfo
+    type UpdateInfo = {
+        host: string;
+        clientarch: string;
+        clientos: string;
+        string: string;
+    };
+
     // userinput.UserInputRequest
     type UserInputRequest = {
         requestid: string;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -553,6 +553,15 @@ declare global {
         y: number;
     };
 
+    // wshrpc.RemoteInfo
+    type RemoteInfo = {
+        host: string;
+        clientarch: string;
+        clientos: string;
+        string: string;
+        shell: string;
+    };
+
     // wshutil.RpcMessage
     type RpcMessage = {
         command?: string;
@@ -744,14 +753,6 @@ declare global {
     type UIContext = {
         windowid: string;
         activetabid: string;
-    };
-
-    // wshrpc.UpdateInfo
-    type UpdateInfo = {
-        host: string;
-        clientarch: string;
-        clientos: string;
-        string: string;
     };
 
     // userinput.UserInputRequest

--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -228,7 +228,7 @@ func (conn *SSHConn) OpenDomainSocketListener(ctx context.Context) error {
 // expects the output of `wsh version` which looks like `wsh v0.10.4` or "not-installed"
 // returns (up-to-date, semver, error)
 // if not up to date, or error, version might be ""
-func isWshVersionUpToDate(wshVersionLine string) (bool, string, error) {
+func IsWshVersionUpToDate(wshVersionLine string) (bool, string, error) {
 	wshVersionLine = strings.TrimSpace(wshVersionLine)
 	if wshVersionLine == "not-installed" {
 		return false, "", nil
@@ -290,7 +290,7 @@ func (conn *SSHConn) StartConnServer(ctx context.Context) (bool, string, error) 
 		return false, "", fmt.Errorf("error reading wsh version: %w", err)
 	}
 	conn.Infof(ctx, "got connserver version: %s\n", strings.TrimSpace(versionLine))
-	isUpToDate, clientVersion, err := isWshVersionUpToDate(versionLine)
+	isUpToDate, clientVersion, err := IsWshVersionUpToDate(versionLine)
 	if err != nil {
 		sshSession.Close()
 		return false, "", fmt.Errorf("error checking wsh version: %w", err)

--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -377,20 +377,13 @@ to ensure a seamless experience.
 Would you like to install them?
 `)
 
-func (conn *SSHConn) UpdateWsh(ctx context.Context, clientDisplayName string, opts *WshInstallOpts) error {
-	if opts == nil {
-		opts = &WshInstallOpts{}
-	}
+func (conn *SSHConn) UpdateWsh(ctx context.Context, clientDisplayName string, remoteInfo *wshrpc.RemoteInfo) error {
+	log.Printf("attempting to update wsh for connection %v", remoteInfo)
 	client := conn.GetClient()
 	if client == nil {
 		return fmt.Errorf("client is nil")
 	}
-	clientOs, clientArch, err := remote.GetClientPlatform(ctx, genconn.MakeSSHShellClient(client))
-	if err != nil {
-		return err
-	}
-	// should be able to GetClientPlatform in other ways, but this works for now
-	err = remote.CpWshToRemote(ctx, client, clientOs, clientArch)
+	err := remote.CpWshToRemote(ctx, client, remoteInfo.ClientOs, remoteInfo.ClientArch)
 	if err != nil {
 		return fmt.Errorf("error installing wsh to remote: %w", err)
 	}

--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -378,16 +378,17 @@ Would you like to install them?
 `)
 
 func (conn *SSHConn) UpdateWsh(ctx context.Context, clientDisplayName string, remoteInfo *wshrpc.RemoteInfo) error {
-	log.Printf("attempting to update wsh for connection %v", remoteInfo)
+	conn.Infof(ctx, "attempting to update wsh for connection %s (os:%s arch:%s version:%s)\n",
+		remoteInfo.ConnName, remoteInfo.ClientOs, remoteInfo.ClientArch, remoteInfo.ClientVersion)
 	client := conn.GetClient()
 	if client == nil {
-		return fmt.Errorf("client is nil")
+		return fmt.Errorf("cannot update wsh: ssh client is not connected")
 	}
 	err := remote.CpWshToRemote(ctx, client, remoteInfo.ClientOs, remoteInfo.ClientArch)
 	if err != nil {
 		return fmt.Errorf("error installing wsh to remote: %w", err)
 	}
-	log.Printf("successfully installed wsh on %s\n", conn.GetName())
+	conn.Infof(ctx, "successfully updated wsh on %s\n", conn.GetName())
 	return nil
 
 }

--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -307,6 +307,28 @@ func (wise *WshInstallSkipError) Error() string {
 	return "skipping wsh installation"
 }
 
+func (conn *SSHConn) UpdateWsh(ctx context.Context, clientDisplayName string, opts *WshInstallOpts) error {
+	if opts == nil {
+		opts = &WshInstallOpts{}
+	}
+	client := conn.GetClient()
+	if client == nil {
+		return fmt.Errorf("client is nil")
+	}
+	clientOs, clientArch, err := remote.GetClientPlatform(ctx, genconn.MakeSSHShellClient(client))
+	if err != nil {
+		return err
+	}
+	// should be able to GetClientPlatform in other ways, but this works for now
+	err = remote.CpWshToRemote(ctx, client, clientOs, clientArch)
+	if err != nil {
+		return fmt.Errorf("error installing wsh to remote: %w", err)
+	}
+	log.Printf("successfully installed wsh on %s\n", conn.GetName())
+	return nil
+
+}
+
 func (conn *SSHConn) CheckAndInstallWsh(ctx context.Context, clientDisplayName string, opts *WshInstallOpts) error {
 	if opts == nil {
 		opts = &WshInstallOpts{}

--- a/pkg/wshrpc/wshclient/wshclient.go
+++ b/pkg/wshrpc/wshclient/wshclient.go
@@ -73,16 +73,16 @@ func ConnStatusCommand(w *wshutil.WshRpc, opts *wshrpc.RpcOpts) ([]wshrpc.ConnSt
 	return resp, err
 }
 
-// command "controllerappendoutput", wshserver.ControllerAppendOutputCommand
-func ControllerAppendOutputCommand(w *wshutil.WshRpc, data wshrpc.CommandControllerAppendOutputData, opts *wshrpc.RpcOpts) error {
-	_, err := sendRpcRequestCallHelper[any](w, "controllerappendoutput", data, opts)
-	return err
-}
-
 // command "connupdatewsh", wshserver.ConnUpdateWshCommand
 func ConnUpdateWshCommand(w *wshutil.WshRpc, data wshrpc.UpdateInfo, opts *wshrpc.RpcOpts) (bool, error) {
 	resp, err := sendRpcRequestCallHelper[bool](w, "connupdatewsh", data, opts)
 	return resp, err
+}
+
+// command "controllerappendoutput", wshserver.ControllerAppendOutputCommand
+func ControllerAppendOutputCommand(w *wshutil.WshRpc, data wshrpc.CommandControllerAppendOutputData, opts *wshrpc.RpcOpts) error {
+	_, err := sendRpcRequestCallHelper[any](w, "controllerappendoutput", data, opts)
+	return err
 }
 
 // command "controllerinput", wshserver.ControllerInputCommand

--- a/pkg/wshrpc/wshclient/wshclient.go
+++ b/pkg/wshrpc/wshclient/wshclient.go
@@ -73,6 +73,12 @@ func ConnStatusCommand(w *wshutil.WshRpc, opts *wshrpc.RpcOpts) ([]wshrpc.ConnSt
 	return resp, err
 }
 
+// command "connupdatewsh", wshserver.ConnUpdateWshCommand
+func ConnUpdateWshCommand(w *wshutil.WshRpc, data wshrpc.UpdateInfo, opts *wshrpc.RpcOpts) (bool, error) {
+	resp, err := sendRpcRequestCallHelper[bool](w, "connupdatewsh", data, opts)
+	return resp, err
+}
+
 // command "controllerinput", wshserver.ControllerInputCommand
 func ControllerInputCommand(w *wshutil.WshRpc, data wshrpc.CommandBlockInputData, opts *wshrpc.RpcOpts) error {
 	_, err := sendRpcRequestCallHelper[any](w, "controllerinput", data, opts)

--- a/pkg/wshrpc/wshclient/wshclient.go
+++ b/pkg/wshrpc/wshclient/wshclient.go
@@ -74,7 +74,7 @@ func ConnStatusCommand(w *wshutil.WshRpc, opts *wshrpc.RpcOpts) ([]wshrpc.ConnSt
 }
 
 // command "connupdatewsh", wshserver.ConnUpdateWshCommand
-func ConnUpdateWshCommand(w *wshutil.WshRpc, data wshrpc.UpdateInfo, opts *wshrpc.RpcOpts) (bool, error) {
+func ConnUpdateWshCommand(w *wshutil.WshRpc, data wshrpc.RemoteInfo, opts *wshrpc.RpcOpts) (bool, error) {
 	resp, err := sendRpcRequestCallHelper[bool](w, "connupdatewsh", data, opts)
 	return resp, err
 }

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -164,7 +164,7 @@ type WshRpcInterface interface {
 	WslListCommand(ctx context.Context) ([]string, error)
 	WslDefaultDistroCommand(ctx context.Context) (string, error)
 	DismissWshFailCommand(ctx context.Context, connName string) error
-	ConnUpdateWshCommand(ctx context.Context, updateInfo RemoteInfo) (bool, error)
+	ConnUpdateWshCommand(ctx context.Context, remoteInfo RemoteInfo) (bool, error)
 
 	// eventrecv is special, it's handled internally by WshRpc with EventListener
 	EventRecvCommand(ctx context.Context, data wps.WaveEvent) error

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -164,7 +164,7 @@ type WshRpcInterface interface {
 	WslListCommand(ctx context.Context) ([]string, error)
 	WslDefaultDistroCommand(ctx context.Context) (string, error)
 	DismissWshFailCommand(ctx context.Context, connName string) error
-	ConnUpdateWshCommand(ctx context.Context, updateInfo UpdateInfo) (bool, error)
+	ConnUpdateWshCommand(ctx context.Context, updateInfo RemoteInfo) (bool, error)
 
 	// eventrecv is special, it's handled internally by WshRpc with EventListener
 	EventRecvCommand(ctx context.Context, data wps.WaveEvent) error
@@ -502,11 +502,12 @@ type ConnRequest struct {
 	LogBlockId string       `json:"logblockid,omitempty"`
 }
 
-type UpdateInfo struct {
+type RemoteInfo struct {
 	ConnName      string `json:"host"`
 	ClientArch    string `json:"clientarch"`
 	ClientOs      string `json:"clientos"`
 	ClientVersion string `json:"string"`
+	Shell         string `json:"shell"`
 }
 
 const (

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -506,7 +506,7 @@ type RemoteInfo struct {
 	ConnName      string `json:"host"`
 	ClientArch    string `json:"clientarch"`
 	ClientOs      string `json:"clientos"`
-	ClientVersion string `json:"string"`
+	ClientVersion string `json:"clientversion"`
 	Shell         string `json:"shell"`
 }
 

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -84,6 +84,7 @@ const (
 	Command_WslList          = "wsllist"
 	Command_WslDefaultDistro = "wsldefaultdistro"
 	Command_DismissWshFail   = "dismisswshfail"
+	Command_ConnUpdateWsh    = "updatewsh"
 
 	Command_WorkspaceList = "workspacelist"
 
@@ -162,6 +163,7 @@ type WshRpcInterface interface {
 	WslListCommand(ctx context.Context) ([]string, error)
 	WslDefaultDistroCommand(ctx context.Context) (string, error)
 	DismissWshFailCommand(ctx context.Context, connName string) error
+	ConnUpdateWshCommand(ctx context.Context, updateInfo UpdateInfo) (bool, error)
 
 	// eventrecv is special, it's handled internally by WshRpc with EventListener
 	EventRecvCommand(ctx context.Context, data wps.WaveEvent) error
@@ -490,6 +492,13 @@ type ConnKeywords struct {
 type ConnRequest struct {
 	Host     string       `json:"host"`
 	Keywords ConnKeywords `json:"keywords,omitempty"`
+}
+
+type UpdateInfo struct {
+	ConnName      string `json:"host"`
+	ClientArch    string `json:"clientarch"`
+	ClientOs      string `json:"clientos"`
+	ClientVersion string `json:"string"`
 }
 
 const (

--- a/pkg/wshrpc/wshserver/wshserver.go
+++ b/pkg/wshrpc/wshserver/wshserver.go
@@ -699,10 +699,10 @@ func (ws *WshServer) ConnReinstallWshCommand(ctx context.Context, data wshrpc.Co
 	return conn.InstallWsh(ctx)
 }
 
-func (ws *WshServer) ConnUpdateWshCommand(ctx context.Context, updateInfo wshrpc.RemoteInfo) (bool, error) {
-	connName := updateInfo.ConnName
+func (ws *WshServer) ConnUpdateWshCommand(ctx context.Context, remoteInfo wshrpc.RemoteInfo) (bool, error) {
+	connName := remoteInfo.ConnName
 	// check version number, return now if update not necessary
-	upToDate, _, err := conncontroller.IsWshVersionUpToDate(updateInfo.ClientVersion)
+	upToDate, _, err := conncontroller.IsWshVersionUpToDate(remoteInfo.ClientVersion)
 	if err != nil {
 		return false, fmt.Errorf("unable to compare wsh version: %w", err)
 	}

--- a/pkg/wshrpc/wshserver/wshserver.go
+++ b/pkg/wshrpc/wshserver/wshserver.go
@@ -708,6 +708,7 @@ func (ws *WshServer) ConnUpdateWshCommand(ctx context.Context, remoteInfo wshrpc
 	}
 	if upToDate {
 		// no need to update
+		log.Printf("wsh update is not needed for connection %s", connName)
 		return false, nil
 	}
 
@@ -724,7 +725,7 @@ func (ws *WshServer) ConnUpdateWshCommand(ctx context.Context, remoteInfo wshrpc
 	if conn == nil {
 		return false, fmt.Errorf("connection not found: %s", connName)
 	}
-	err = conn.UpdateWsh(ctx, connName, &conncontroller.WshInstallOpts{Force: true, NoUserPrompt: true})
+	err = conn.UpdateWsh(ctx, connName, &remoteInfo)
 	if err != nil {
 		return false, fmt.Errorf("update failed: %w", err)
 	}

--- a/pkg/wshutil/wshutil.go
+++ b/pkg/wshutil/wshutil.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -535,4 +536,15 @@ func ExtractUnverifiedSocketName(tokenStr string) (string, error) {
 	}
 	sockName = wavebase.ExpandHomeDirSafe(sockName)
 	return sockName, nil
+}
+
+func GetInfo(rpcContext wshrpc.RpcContext) wshrpc.RemoteInfo {
+	return wshrpc.RemoteInfo{
+		ConnName:      rpcContext.Conn,
+		ClientArch:    runtime.GOARCH,
+		ClientOs:      runtime.GOOS,
+		ClientVersion: wavebase.WaveVersion,
+		Shell:         os.Getenv("SHELL"),
+	}
+
 }


### PR DESCRIPTION
This adds an RPC command for updating wsh on a remote machine without starting a new session. It is not being used yet, but will be used for connections using a single server in the future.