### PR TITLE
RemoteInfo Rpc

### DIFF
--- a/cmd/wsh/cmd/wshcmd-connserver.go
+++ b/cmd/wsh/cmd/wshcmd-connserver.go
@@ -190,7 +190,7 @@ func serverRunRouter() error {
 }
 
 func checkForUpdate() error {
-	remoteInfo := wshutil.GetInfo(RpcContext)
+	remoteInfo := wshutil.GetInfo()
 	needsRestartRaw, err := RpcClient.SendRpcRequest(wshrpc.Command_ConnUpdateWsh, remoteInfo, &wshrpc.RpcOpts{Timeout: 60000})
 	if err != nil {
 		return fmt.Errorf("could not update: %w", err)

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -242,6 +242,11 @@ class RpcApiType {
         return client.wshRpcCall("remotefiletouch", data, opts);
     }
 
+    // command "remotegetinfo" [call]
+    RemoteGetInfoCommand(client: WshClient, opts?: RpcOpts): Promise<void> {
+        return client.wshRpcCall("remotegetinfo", null, opts);
+    }
+
     // command "remotemkdir" [call]
     RemoteMkdirCommand(client: WshClient, data: string, opts?: RpcOpts): Promise<void> {
         return client.wshRpcCall("remotemkdir", data, opts);

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -243,7 +243,7 @@ class RpcApiType {
     }
 
     // command "remotegetinfo" [call]
-    RemoteGetInfoCommand(client: WshClient, opts?: RpcOpts): Promise<void> {
+    RemoteGetInfoCommand(client: WshClient, opts?: RpcOpts): Promise<RemoteInfo> {
         return client.wshRpcCall("remotegetinfo", null, opts);
     }
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -555,7 +555,6 @@ declare global {
 
     // wshrpc.RemoteInfo
     type RemoteInfo = {
-        host: string;
         clientarch: string;
         clientos: string;
         clientversion: string;

--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -379,7 +379,7 @@ Would you like to install them?
 
 func (conn *SSHConn) UpdateWsh(ctx context.Context, clientDisplayName string, remoteInfo *wshrpc.RemoteInfo) error {
 	conn.Infof(ctx, "attempting to update wsh for connection %s (os:%s arch:%s version:%s)\n",
-		remoteInfo.ConnName, remoteInfo.ClientOs, remoteInfo.ClientArch, remoteInfo.ClientVersion)
+		conn.GetName(), remoteInfo.ClientOs, remoteInfo.ClientArch, remoteInfo.ClientVersion)
 	client := conn.GetClient()
 	if client == nil {
 		return fmt.Errorf("cannot update wsh: ssh client is not connected")

--- a/pkg/remote/connutil.go
+++ b/pkg/remote/connutil.go
@@ -35,25 +35,6 @@ func ParseOpts(input string) (*SSHOpts, error) {
 	return &SSHOpts{SSHHost: remoteHost, SSHUser: remoteUser, SSHPort: remotePort}, nil
 }
 
-func DetectShell(client *ssh.Client) (string, error) {
-	wshPath := GetWshPath(client)
-
-	session, err := client.NewSession()
-	if err != nil {
-		return "", err
-	}
-
-	log.Printf("shell detecting using command: %s shell", wshPath)
-	out, err := session.Output(wshPath + " shell")
-	if err != nil {
-		log.Printf("unable to determine shell. defaulting to /bin/bash: %s", err)
-		return "/bin/bash", nil
-	}
-	log.Printf("detecting shell: %s", out)
-
-	return fmt.Sprintf(`"%s"`, strings.TrimSpace(string(out))), nil
-}
-
 func GetWshPath(client *ssh.Client) string {
 	defaultPath := wavebase.RemoteFullWshBinPath
 	session, err := client.NewSession()

--- a/pkg/remote/connutil.go
+++ b/pkg/remote/connutil.go
@@ -241,18 +241,6 @@ func InstallClientRcFiles(client *ssh.Client) error {
 	return err
 }
 
-func GetHomeDir(client *ssh.Client) string {
-	session, err := client.NewSession()
-	if err != nil {
-		return "~"
-	}
-	out, err := session.Output(`echo "$HOME"`)
-	if err == nil {
-		return strings.TrimSpace(string(out))
-	}
-	return "~"
-}
-
 func IsPowershell(shellPath string) bool {
 	// get the base path, and then check contains
 	shellBase := filepath.Base(shellPath)

--- a/pkg/wshrpc/wshclient/wshclient.go
+++ b/pkg/wshrpc/wshclient/wshclient.go
@@ -295,6 +295,12 @@ func RemoteFileTouchCommand(w *wshutil.WshRpc, data string, opts *wshrpc.RpcOpts
 	return err
 }
 
+// command "remotegetinfo", wshserver.RemoteGetInfoCommand
+func RemoteGetInfoCommand(w *wshutil.WshRpc, opts *wshrpc.RpcOpts) error {
+	_, err := sendRpcRequestCallHelper[any](w, "remotegetinfo", nil, opts)
+	return err
+}
+
 // command "remotemkdir", wshserver.RemoteMkdirCommand
 func RemoteMkdirCommand(w *wshutil.WshRpc, data string, opts *wshrpc.RpcOpts) error {
 	_, err := sendRpcRequestCallHelper[any](w, "remotemkdir", data, opts)

--- a/pkg/wshrpc/wshclient/wshclient.go
+++ b/pkg/wshrpc/wshclient/wshclient.go
@@ -296,9 +296,9 @@ func RemoteFileTouchCommand(w *wshutil.WshRpc, data string, opts *wshrpc.RpcOpts
 }
 
 // command "remotegetinfo", wshserver.RemoteGetInfoCommand
-func RemoteGetInfoCommand(w *wshutil.WshRpc, opts *wshrpc.RpcOpts) error {
-	_, err := sendRpcRequestCallHelper[any](w, "remotegetinfo", nil, opts)
-	return err
+func RemoteGetInfoCommand(w *wshutil.WshRpc, opts *wshrpc.RpcOpts) (wshrpc.RemoteInfo, error) {
+	resp, err := sendRpcRequestCallHelper[wshrpc.RemoteInfo](w, "remotegetinfo", nil, opts)
+	return resp, err
 }
 
 // command "remotemkdir", wshserver.RemoteMkdirCommand

--- a/pkg/wshrpc/wshremote/wshremote.go
+++ b/pkg/wshrpc/wshremote/wshremote.go
@@ -389,6 +389,6 @@ func (*ServerImpl) RemoteFileDeleteCommand(ctx context.Context, path string) err
 	return nil
 }
 
-func (*ServerImpl) RemoteGetInfoCommand(ctx context.Context) wshrpc.RemoteInfo {
-	return wshutil.GetInfo()
+func (*ServerImpl) RemoteGetInfoCommand(ctx context.Context) (wshrpc.RemoteInfo, error) {
+	return wshutil.GetInfo(), nil
 }

--- a/pkg/wshrpc/wshremote/wshremote.go
+++ b/pkg/wshrpc/wshremote/wshremote.go
@@ -18,6 +18,7 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/util/utilfn"
 	"github.com/wavetermdev/waveterm/pkg/wavebase"
 	"github.com/wavetermdev/waveterm/pkg/wshrpc"
+	"github.com/wavetermdev/waveterm/pkg/wshutil"
 )
 
 const MaxFileSize = 50 * 1024 * 1024 // 10M
@@ -386,4 +387,8 @@ func (*ServerImpl) RemoteFileDeleteCommand(ctx context.Context, path string) err
 		return fmt.Errorf("cannot delete file %q: %w", path, err)
 	}
 	return nil
+}
+
+func (*ServerImpl) RemoteGetInfoCommand(ctx context.Context) wshrpc.RemoteInfo {
+	return wshutil.GetInfo()
 }

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -180,7 +180,7 @@ type WshRpcInterface interface {
 	RemoteFileJoinCommand(ctx context.Context, paths []string) (*FileInfo, error)
 	RemoteMkdirCommand(ctx context.Context, path string) error
 	RemoteStreamCpuDataCommand(ctx context.Context) chan RespOrErrorUnion[TimeSeriesData]
-	RemoteGetInfoCommand(ctx context.Context) RemoteInfo
+	RemoteGetInfoCommand(ctx context.Context) (RemoteInfo, error)
 
 	// emain
 	WebSelectorCommand(ctx context.Context, data CommandWebSelectorData) ([]string, error)

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -73,6 +73,7 @@ const (
 	Command_GetVar               = "getvar"
 	Command_SetVar               = "setvar"
 	Command_RemoteMkdir          = "remotemkdir"
+	Command_RemoteGetInfo        = "remotegetinfo"
 
 	Command_ConnStatus       = "connstatus"
 	Command_WslStatus        = "wslstatus"
@@ -179,6 +180,7 @@ type WshRpcInterface interface {
 	RemoteFileJoinCommand(ctx context.Context, paths []string) (*FileInfo, error)
 	RemoteMkdirCommand(ctx context.Context, path string) error
 	RemoteStreamCpuDataCommand(ctx context.Context) chan RespOrErrorUnion[TimeSeriesData]
+	RemoteGetInfoCommand(ctx context.Context) RemoteInfo
 
 	// emain
 	WebSelectorCommand(ctx context.Context, data CommandWebSelectorData) ([]string, error)
@@ -503,7 +505,6 @@ type ConnRequest struct {
 }
 
 type RemoteInfo struct {
-	ConnName      string `json:"host"`
 	ClientArch    string `json:"clientarch"`
 	ClientOs      string `json:"clientos"`
 	ClientVersion string `json:"clientversion"`

--- a/pkg/wshrpc/wshserver/wshserver.go
+++ b/pkg/wshrpc/wshserver/wshserver.go
@@ -700,7 +700,11 @@ func (ws *WshServer) ConnReinstallWshCommand(ctx context.Context, data wshrpc.Co
 }
 
 func (ws *WshServer) ConnUpdateWshCommand(ctx context.Context, remoteInfo wshrpc.RemoteInfo) (bool, error) {
-	connName := remoteInfo.ConnName
+	handler := wshutil.GetRpcResponseHandlerFromContext(ctx)
+	if handler == nil {
+		return false, fmt.Errorf("could not determine handler from context")
+	}
+	connName := handler.GetRpcContext().Conn
 	if connName == "" {
 		return false, fmt.Errorf("invalid remote info: missing connection name")
 	}

--- a/pkg/wshutil/wshutil.go
+++ b/pkg/wshutil/wshutil.go
@@ -542,14 +542,14 @@ func ExtractUnverifiedSocketName(tokenStr string) (string, error) {
 
 func getShell() string {
 	if runtime.GOOS == "darwin" {
-		return shellutil.GetMacUserShell() + "\n"
+		return shellutil.GetMacUserShell()
 	}
 
 	shell := os.Getenv("SHELL")
 	if shell == "" {
-		return "/bin/bash\n"
+		return "/bin/bash"
 	}
-	return strings.TrimSpace(shell) + "\n"
+	return strings.TrimSpace(shell)
 }
 
 func GetInfo() wshrpc.RemoteInfo {

--- a/pkg/wshutil/wshutil.go
+++ b/pkg/wshutil/wshutil.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -22,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/wavetermdev/waveterm/pkg/panichandler"
 	"github.com/wavetermdev/waveterm/pkg/util/packetparser"
+	"github.com/wavetermdev/waveterm/pkg/util/shellutil"
 	"github.com/wavetermdev/waveterm/pkg/wavebase"
 	"github.com/wavetermdev/waveterm/pkg/wshrpc"
 	"golang.org/x/term"
@@ -538,12 +540,24 @@ func ExtractUnverifiedSocketName(tokenStr string) (string, error) {
 	return sockName, nil
 }
 
+func getShell() string {
+	if runtime.GOOS == "darwin" {
+		return shellutil.GetMacUserShell() + "\n"
+	}
+
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		return "/bin/bash\n"
+	}
+	return strings.TrimSpace(shell) + "\n"
+}
+
 func GetInfo() wshrpc.RemoteInfo {
 	return wshrpc.RemoteInfo{
 		ClientArch:    runtime.GOARCH,
 		ClientOs:      runtime.GOOS,
 		ClientVersion: wavebase.WaveVersion,
-		Shell:         os.Getenv("SHELL"),
+		Shell:         getShell(),
 	}
 
 }

--- a/pkg/wshutil/wshutil.go
+++ b/pkg/wshutil/wshutil.go
@@ -538,9 +538,8 @@ func ExtractUnverifiedSocketName(tokenStr string) (string, error) {
 	return sockName, nil
 }
 
-func GetInfo(rpcContext wshrpc.RpcContext) wshrpc.RemoteInfo {
+func GetInfo() wshrpc.RemoteInfo {
 	return wshrpc.RemoteInfo{
-		ConnName:      rpcContext.Conn,
 		ClientArch:    runtime.GOARCH,
 		ClientOs:      runtime.GOOS,
 		ClientVersion: wavebase.WaveVersion,


### PR DESCRIPTION
Adds an Rpc Command for getting RemoteInfo. This is used to replace the session that was used to determine the shell on remote machines.