### PR TITLE
RcFileInstall RPC Command

### DIFF
--- a/cmd/wsh/cmd/wshcmd-rcfiles.go
+++ b/cmd/wsh/cmd/wshcmd-rcfiles.go
@@ -4,11 +4,8 @@
 package cmd
 
 import (
-	"path/filepath"
-
 	"github.com/spf13/cobra"
-	"github.com/wavetermdev/waveterm/pkg/util/shellutil"
-	"github.com/wavetermdev/waveterm/pkg/wavebase"
+	"github.com/wavetermdev/waveterm/pkg/wshutil"
 )
 
 func init() {
@@ -20,10 +17,7 @@ var rcfilesCmd = &cobra.Command{
 	Hidden: true,
 	Short:  "Generate the rc files needed for various shells",
 	Run: func(cmd *cobra.Command, args []string) {
-		home := wavebase.GetHomeDir()
-		waveDir := filepath.Join(home, wavebase.RemoteWaveHomeDirName)
-		winBinDir := filepath.Join(waveDir, wavebase.RemoteWshBinDirName)
-		err := shellutil.InitRcFiles(waveDir, winBinDir)
+		err := wshutil.InstallRcFiles()
 		if err != nil {
 			WriteStderr(err.Error())
 			return

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -247,6 +247,11 @@ class RpcApiType {
         return client.wshRpcCall("remotegetinfo", null, opts);
     }
 
+    // command "remoteinstallrcfiles" [call]
+    RemoteInstallRcFilesCommand(client: WshClient, opts?: RpcOpts): Promise<void> {
+        return client.wshRpcCall("remoteinstallrcfiles", null, opts);
+    }
+
     // command "remotemkdir" [call]
     RemoteMkdirCommand(client: WshClient, data: string, opts?: RpcOpts): Promise<void> {
         return client.wshRpcCall("remotemkdir", data, opts);

--- a/pkg/remote/connutil.go
+++ b/pkg/remote/connutil.go
@@ -209,19 +209,6 @@ func CpWshToRemote(ctx context.Context, client *ssh.Client, clientOs string, cli
 	return nil
 }
 
-func InstallClientRcFiles(client *ssh.Client) error {
-	path := GetWshPath(client)
-	log.Printf("path to wsh searched is: %s", path)
-	session, err := client.NewSession()
-	if err != nil {
-		// this is a true error that should stop further progress
-		return err
-	}
-
-	_, err = session.Output(path + " rcfiles")
-	return err
-}
-
 func IsPowershell(shellPath string) bool {
 	// get the base path, and then check contains
 	shellBase := filepath.Base(shellPath)

--- a/pkg/shellexec/shellexec.go
+++ b/pkg/shellexec/shellexec.go
@@ -305,7 +305,7 @@ func StartRemoteShellProc(termSize waveobj.TermSize, cmdStr string, cmdOpts Comm
 	var cmdCombined string
 	log.Printf("using shell: %s", shellPath)
 
-	err = remote.InstallClientRcFiles(client)
+	err = wshclient.RemoteInstallRcFilesCommand(rpcClient, &wshrpc.RpcOpts{Route: connRoute, Timeout: 2000})
 	if err != nil {
 		log.Printf("error installing rc files: %v", err)
 		return nil, err

--- a/pkg/wshrpc/wshclient/wshclient.go
+++ b/pkg/wshrpc/wshclient/wshclient.go
@@ -301,6 +301,12 @@ func RemoteGetInfoCommand(w *wshutil.WshRpc, opts *wshrpc.RpcOpts) (wshrpc.Remot
 	return resp, err
 }
 
+// command "remoteinstallrcfiles", wshserver.RemoteInstallRcFilesCommand
+func RemoteInstallRcFilesCommand(w *wshutil.WshRpc, opts *wshrpc.RpcOpts) error {
+	_, err := sendRpcRequestCallHelper[any](w, "remoteinstallrcfiles", nil, opts)
+	return err
+}
+
 // command "remotemkdir", wshserver.RemoteMkdirCommand
 func RemoteMkdirCommand(w *wshutil.WshRpc, data string, opts *wshrpc.RpcOpts) error {
 	_, err := sendRpcRequestCallHelper[any](w, "remotemkdir", data, opts)

--- a/pkg/wshrpc/wshremote/wshremote.go
+++ b/pkg/wshrpc/wshremote/wshremote.go
@@ -392,3 +392,7 @@ func (*ServerImpl) RemoteFileDeleteCommand(ctx context.Context, path string) err
 func (*ServerImpl) RemoteGetInfoCommand(ctx context.Context) (wshrpc.RemoteInfo, error) {
 	return wshutil.GetInfo(), nil
 }
+
+func (*ServerImpl) RemoteInstallRcFilesCommand(ctx context.Context) error {
+	return wshutil.InstallRcFiles()
+}

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -74,6 +74,7 @@ const (
 	Command_SetVar               = "setvar"
 	Command_RemoteMkdir          = "remotemkdir"
 	Command_RemoteGetInfo        = "remotegetinfo"
+	Command_RemoteInstallRcfiles = "remoteinstallrcfiles"
 
 	Command_ConnStatus       = "connstatus"
 	Command_WslStatus        = "wslstatus"
@@ -181,6 +182,7 @@ type WshRpcInterface interface {
 	RemoteMkdirCommand(ctx context.Context, path string) error
 	RemoteStreamCpuDataCommand(ctx context.Context) chan RespOrErrorUnion[TimeSeriesData]
 	RemoteGetInfoCommand(ctx context.Context) (RemoteInfo, error)
+	RemoteInstallRcFilesCommand(ctx context.Context) error
 
 	// emain
 	WebSelectorCommand(ctx context.Context, data CommandWebSelectorData) ([]string, error)

--- a/pkg/wshutil/wshutil.go
+++ b/pkg/wshutil/wshutil.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -560,4 +561,11 @@ func GetInfo() wshrpc.RemoteInfo {
 		Shell:         getShell(),
 	}
 
+}
+
+func InstallRcFiles() error {
+	home := wavebase.GetHomeDir()
+	waveDir := filepath.Join(home, wavebase.RemoteWaveHomeDirName)
+	winBinDir := filepath.Join(waveDir, wavebase.RemoteWshBinDirName)
+	return shellutil.InitRcFiles(waveDir, winBinDir)
 }


### PR DESCRIPTION
Creates an RPC command for installing shell rcfiles instead of relying on a separate installation session.