### PR TITLE
fix: set wsh ssh rpc timeout to 60 seconds

### DIFF
--- a/cmd/wsh/cmd/wshcmd-ssh.go
+++ b/cmd/wsh/cmd/wshcmd-ssh.go
@@ -45,7 +45,7 @@ func sshRun(cmd *cobra.Command, args []string) (rtnErr error) {
 			SshIdentityFile: identityFiles,
 		},
 	}
-	wshclient.ConnConnectCommand(RpcClient, connOpts, nil)
+	wshclient.ConnConnectCommand(RpcClient, connOpts, &wshrpc.RpcOpts{Timeout: 60000})
 
 	// now, with that made, it will be straightforward to connect
 	data := wshrpc.CommandSetMetaData{


### PR DESCRIPTION
This is required so connections that require user input give the full 60 seconds for the user to type in a password or passphrase.