### PR TITLE
Remove pull_request edited event from workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,6 @@ on:
             - opened
             - synchronize
             - reopened
-            - edited
             - ready_for_review
     schedule:
         - cron: "36 5 * * 5"

--- a/.github/workflows/deploy-docsite.yml
+++ b/.github/workflows/deploy-docsite.yml
@@ -18,7 +18,6 @@ on:
             - opened
             - synchronize
             - reopened
-            - edited
             - ready_for_review
         paths:
             - "docs/**"

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -10,7 +10,6 @@ on:
             - opened
             - synchronize
             - reopened
-            - edited
             - ready_for_review
 
 jobs:

--- a/.github/workflows/testdriver-build.yml
+++ b/.github/workflows/testdriver-build.yml
@@ -22,7 +22,6 @@ on:
             - opened
             - synchronize
             - reopened
-            - edited
             - ready_for_review
     schedule:
         - cron: 0 21 * * *


### PR DESCRIPTION
edited didn't do what i thought it did, it actually gets triggered if the comments or title change, which we don't want. synchronize is for when the head changes