### PR TITLE
Fix dir preview table header width so it still expands to fill whole view

### DIFF
--- a/frontend/app/view/preview/directorypreview.scss
+++ b/frontend/app/view/preview/directorypreview.scss
@@ -31,7 +31,8 @@
             position: sticky;
             top: 0;
             z-index: 10;
-            width: fit-content;
+            width: 100%;
+            min-width: fit-content;
             border-bottom: 1px solid var(--border-color);
 
             .dir-table-head-row {


### PR DESCRIPTION
My last fix to set `width: fit-content` for the dir preview table header ended up meaning that if the widget is wider than the table, the header wouldn't extend to the full width of the widget. Now it will.