### PR TITLE
fix: allow the ssh error popup to scroll

### DIFF
--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -336,9 +336,11 @@
                         gap: 4px;
                         flex-grow: 1;
                         width: 100%;
+                        text-wrap: wrap;
+                        overflow: auto;
+                        max-height: 80px;
 
                         .connstatus-status-text {
-                            @include mixins.ellipsis();
                             max-width: 100%;
                             font-size: 11px;
                             font-style: normal;
@@ -349,7 +351,6 @@
                         }
 
                         .connstatus-error {
-                            @include mixins.ellipsis();
                             width: 94%;
                             font-size: 11px;
                             font-style: normal;


### PR DESCRIPTION
Previously, the ssh error popup would show a small portion of the error message ending in ellipses. This extends it so it can cover multiple lines. Additionally, it puts a max height on the component and allow the text to be scrolled if it exceeds that.