### PR TITLE
fix: yvalMeta .name null check

### DIFF
--- a/frontend/app/view/sysinfo/sysinfo.tsx
+++ b/frontend/app/view/sysinfo/sysinfo.tsx
@@ -447,7 +447,7 @@ function SingleLinePlot({
     );
     if (title) {
         marks.push(
-            Plot.text([yvalMeta.name], {
+            Plot.text([yvalMeta?.name], {
                 frameAnchor: "top-left",
                 dx: 4,
                 fill: "var(--grey-text-color)",


### PR DESCRIPTION
While it is rare, we have had users report an error where the access of `.name` in SingleLinePlot causes a bug. The only time this could happen would be a null `yvalMeta`. This makes it so the .name check is skipped if yvalMeta is null. Addresses #1724.