### PR TITLE
Honor SSH IdentitiesOnly config

### DIFF
--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -315,6 +315,7 @@ declare global {
         "ssh:hostname"?: string;
         "ssh:port"?: string;
         "ssh:identityfile"?: string[];
+        "ssh:identitiesonly"?: boolean;
         "ssh:batchmode"?: boolean;
         "ssh:pubkeyauthentication"?: boolean;
         "ssh:passwordauthentication"?: boolean;

--- a/pkg/remote/sshclient.go
+++ b/pkg/remote/sshclient.go
@@ -579,6 +579,9 @@ func createClientConfig(connCtx context.Context, sshKeywords *wshrpc.ConnKeyword
 
 	var authSockSigners []ssh.Signer
 	var agentClient agent.ExtendedAgent
+
+	// IdentitiesOnly indicates that only the keys listed in IdentityFile should be used, even if there are matches in the SSH Agent, PKCS11Provider, or SecurityKeyProvider. See https://man.openbsd.org/ssh_config#IdentitiesOnly
+	// TODO: Update if we decide to support PKCS11Provider and SecurityKeyProvider
 	if !utilfn.SafeDeref(sshKeywords.SshIdentitiesOnly) {
 		conn, err := net.Dial("unix", utilfn.SafeDeref(sshKeywords.SshIdentityAgent))
 		if err != nil {

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -489,6 +489,7 @@ type ConnKeywords struct {
 	SshHostName                     *string  `json:"ssh:hostname,omitempty"`
 	SshPort                         *string  `json:"ssh:port,omitempty"`
 	SshIdentityFile                 []string `json:"ssh:identityfile,omitempty"`
+	SshIdentitiesOnly               *bool    `json:"ssh:identitiesonly,omitempty"`
 	SshBatchMode                    *bool    `json:"ssh:batchmode,omitempty"`
 	SshPubkeyAuthentication         *bool    `json:"ssh:pubkeyauthentication,omitempty"`
 	SshPasswordAuthentication       *bool    `json:"ssh:passwordauthentication,omitempty"`


### PR DESCRIPTION
Skip SSH Agent client initialization if the IdentitiesOnly config is set for a given host

For now, we only need to support this for the SSH Agent, but if we ever add support for PKCS11Provider or SecurityKeyProvider, we'll need to update this check to also ignore those.

See https://man.openbsd.org/ssh_config#IdentitiesOnly