### PR TITLE
Correct XDG_CURRENT_DESKTOP env var

### DIFF
--- a/emain/emain-wavesrv.ts
+++ b/emain/emain-wavesrv.ts
@@ -14,6 +14,7 @@ import {
     getWaveDataDir,
     getWaveSrvCwd,
     getWaveSrvPath,
+    getXdgCurrentDesktop,
     WaveConfigHomeVarName,
     WaveDataHomeVarName,
 } from "./platform";
@@ -53,6 +54,10 @@ export function runWaveSrv(handleWSEvent: (evtMsg: WSEventType) => void): Promis
         pReject = argReject;
     });
     const envCopy = { ...process.env };
+    const xdgCurrentDesktop = getXdgCurrentDesktop();
+    if (xdgCurrentDesktop != null) {
+        envCopy["XDG_CURRENT_DESKTOP"] = xdgCurrentDesktop;
+    }
     envCopy[WaveAppPathVarName] = getElectronAppUnpackedBasePath();
     envCopy[WaveAuthKeyEnv] = AuthKey;
     envCopy[WaveDataHomeVarName] = getWaveDataDir();

--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -121,19 +121,6 @@ function handleWSEvent(evtMsg: WSEventType) {
 // Listen for the open-external event from the renderer process
 electron.ipcMain.on("open-external", (event, url) => {
     if (url && typeof url === "string") {
-        if (unamePlatform === "linux") {
-            child_process.execFile("x-www-browser", [url], (error, stdout, stderr) => {
-                if (error) {
-                    console.error(
-                        `Failed to open URL ${url} with x-www-browser, falling back to xdg-open; err: ${error}`
-                    );
-                    electron.shell.openExternal(url).catch((err) => {
-                        console.error(`Failed to open URL ${url} with xdg-open:`, err);
-                    });
-                }
-            });
-            return;
-        }
         electron.shell.openExternal(url).catch((err) => {
             console.error(`Failed to open URL ${url}:`, err);
         });

--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -121,6 +121,19 @@ function handleWSEvent(evtMsg: WSEventType) {
 // Listen for the open-external event from the renderer process
 electron.ipcMain.on("open-external", (event, url) => {
     if (url && typeof url === "string") {
+        if (unamePlatform === "linux") {
+            child_process.execFile("x-www-browser", [url], (error, stdout, stderr) => {
+                if (error) {
+                    console.error(
+                        `Failed to open URL ${url} with x-www-browser, falling back to xdg-open; err: ${error}`
+                    );
+                    electron.shell.openExternal(url).catch((err) => {
+                        console.error(`Failed to open URL ${url} with xdg-open:`, err);
+                    });
+                }
+            });
+            return;
+        }
         electron.shell.openExternal(url).catch((err) => {
             console.error(`Failed to open URL ${url}:`, err);
         });

--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -52,6 +52,7 @@ import {
     getElectronAppUnpackedBasePath,
     getWaveConfigDir,
     getWaveDataDir,
+    getXdgCurrentDesktop,
     isDev,
     unameArch,
     unamePlatform,
@@ -121,8 +122,17 @@ function handleWSEvent(evtMsg: WSEventType) {
 // Listen for the open-external event from the renderer process
 electron.ipcMain.on("open-external", (event, url) => {
     if (url && typeof url === "string") {
-        electron.shell.openExternal(url).catch((err) => {
-            console.error(`Failed to open URL ${url}:`, err);
+        fireAndForget(async () => {
+            const curXdgCurrentDesktop = process.env.XDG_CURRENT_DESKTOP;
+            if (curXdgCurrentDesktop) {
+                process.env.XDG_CURRENT_DESKTOP = getXdgCurrentDesktop();
+            }
+            await electron.shell.openExternal(url).catch((err) => {
+                console.error(`Failed to open URL ${url}:`, err);
+            });
+            if (curXdgCurrentDesktop) {
+                process.env.XDG_CURRENT_DESKTOP = curXdgCurrentDesktop;
+            }
         });
     } else {
         console.error("Invalid URL received in open-external event:", url);
@@ -346,11 +356,18 @@ electron.ipcMain.on("quicklook", (event, filePath: string) => {
 
 electron.ipcMain.on("open-native-path", (event, filePath: string) => {
     console.log("open-native-path", filePath);
-    fireAndForget(() =>
-        electron.shell.openPath(filePath).then((excuse) => {
+    fireAndForget(async () => {
+        const curXdgCurrentDesktop = process.env.XDG_CURRENT_DESKTOP;
+        if (curXdgCurrentDesktop) {
+            process.env.XDG_CURRENT_DESKTOP = getXdgCurrentDesktop();
+        }
+        await electron.shell.openPath(filePath).then((excuse) => {
             if (excuse) console.error(`Failed to open ${filePath} in native application: ${excuse}`);
-        })
-    );
+        });
+        if (curXdgCurrentDesktop) {
+            process.env.XDG_CURRENT_DESKTOP = curXdgCurrentDesktop;
+        }
+    });
 });
 
 electron.ipcMain.on("set-window-init-status", (event, status: "ready" | "wave-ready") => {

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -194,13 +194,13 @@ ipcMain.on("get-config-dir", (event) => {
     event.returnValue = getWaveConfigDir();
 });
 
-function correctXDGCurrentDesktop() {
+function getXdgCurrentDesktop(): string {
     if (process.env.ORIGINAL_XDG_CURRENT_DESKTOP) {
-        process.env.XDG_CURRENT_DESKTOP = process.env.ORIGINAL_XDG_CURRENT_DESKTOP;
+        return process.env.ORIGINAL_XDG_CURRENT_DESKTOP;
+    } else {
+        return process.env.XDG_CURRENT_DESKTOP;
     }
 }
-
-correctXDGCurrentDesktop();
 
 export {
     getElectronAppBasePath,
@@ -209,6 +209,7 @@ export {
     getWaveDataDir,
     getWaveSrvCwd,
     getWaveSrvPath,
+    getXdgCurrentDesktop,
     isDev,
     isDevVite,
     unameArch,

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -212,6 +212,7 @@ function getXdgCurrentDesktop(): string {
 
 /**
  * Calls the given callback with the value of the XDG_CURRENT_DESKTOP environment variable set to ORIGINAL_XDG_CURRENT_DESKTOP if it is set.
+ * @see https://www.electronjs.org/docs/latest/api/environment-variables#original_xdg_current_desktop
  * @param callback The callback to call.
  */
 function callWithOriginalXdgCurrentDesktop(callback: () => void) {
@@ -228,6 +229,7 @@ function callWithOriginalXdgCurrentDesktop(callback: () => void) {
 
 /**
  * Calls the given async callback with the value of the XDG_CURRENT_DESKTOP environment variable set to ORIGINAL_XDG_CURRENT_DESKTOP if it is set.
+ * @see https://www.electronjs.org/docs/latest/api/environment-variables#original_xdg_current_desktop
  * @param callback The async callback to call.
  */
 async function callWithOriginalXdgCurrentDesktopAsync(callback: () => Promise<void>) {

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -216,14 +216,19 @@ function getXdgCurrentDesktop(): string {
  * @param callback The callback to call.
  */
 function callWithOriginalXdgCurrentDesktop(callback: () => void) {
+    const currXdgCurrentDesktopDefined = "XDG_CURRENT_DESKTOP" in process.env;
     const currXdgCurrentDesktop = process.env.XDG_CURRENT_DESKTOP;
     const originalXdgCurrentDesktop = getXdgCurrentDesktop();
-    if (currXdgCurrentDesktop) {
+    if (originalXdgCurrentDesktop) {
         process.env.XDG_CURRENT_DESKTOP = originalXdgCurrentDesktop;
     }
     callback();
-    if (currXdgCurrentDesktop) {
-        process.env.XDG_CURRENT_DESKTOP = currXdgCurrentDesktop;
+    if (originalXdgCurrentDesktop) {
+        if (currXdgCurrentDesktopDefined) {
+            process.env.XDG_CURRENT_DESKTOP = currXdgCurrentDesktop;
+        } else {
+            delete process.env.XDG_CURRENT_DESKTOP;
+        }
     }
 }
 
@@ -233,14 +238,19 @@ function callWithOriginalXdgCurrentDesktop(callback: () => void) {
  * @param callback The async callback to call.
  */
 async function callWithOriginalXdgCurrentDesktopAsync(callback: () => Promise<void>) {
+    const currXdgCurrentDesktopDefined = "XDG_CURRENT_DESKTOP" in process.env;
     const currXdgCurrentDesktop = process.env.XDG_CURRENT_DESKTOP;
     const originalXdgCurrentDesktop = getXdgCurrentDesktop();
-    if (currXdgCurrentDesktop) {
+    if (originalXdgCurrentDesktop) {
         process.env.XDG_CURRENT_DESKTOP = originalXdgCurrentDesktop;
     }
     await callback();
-    if (currXdgCurrentDesktop) {
-        process.env.XDG_CURRENT_DESKTOP = currXdgCurrentDesktop;
+    if (originalXdgCurrentDesktop) {
+        if (currXdgCurrentDesktopDefined) {
+            process.env.XDG_CURRENT_DESKTOP = currXdgCurrentDesktop;
+        } else {
+            delete process.env.XDG_CURRENT_DESKTOP;
+        }
     }
 }
 

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -194,6 +194,14 @@ ipcMain.on("get-config-dir", (event) => {
     event.returnValue = getWaveConfigDir();
 });
 
+function correctXDGCurrentDesktop() {
+    if (process.env.ORIGINAL_XDG_CURRENT_DESKTOP) {
+        process.env.XDG_CURRENT_DESKTOP = process.env.ORIGINAL_XDG_CURRENT_DESKTOP;
+    }
+}
+
+correctXDGCurrentDesktop();
+
 export {
     getElectronAppBasePath,
     getElectronAppUnpackedBasePath,

--- a/emain/platform.ts
+++ b/emain/platform.ts
@@ -194,15 +194,57 @@ ipcMain.on("get-config-dir", (event) => {
     event.returnValue = getWaveConfigDir();
 });
 
+/**
+ * Gets the value of the XDG_CURRENT_DESKTOP environment variable. If ORIGINAL_XDG_CURRENT_DESKTOP is set, it will be returned instead.
+ * This corrects for a strange behavior in Electron, where it sets its own value for XDG_CURRENT_DESKTOP to improve Chromium compatibility.
+ * @see https://www.electronjs.org/docs/latest/api/environment-variables#original_xdg_current_desktop
+ * @returns The value of the XDG_CURRENT_DESKTOP environment variable, or ORIGINAL_XDG_CURRENT_DESKTOP if set, or undefined if neither are set.
+ */
 function getXdgCurrentDesktop(): string {
     if (process.env.ORIGINAL_XDG_CURRENT_DESKTOP) {
         return process.env.ORIGINAL_XDG_CURRENT_DESKTOP;
-    } else {
+    } else if (process.env.XDG_CURRENT_DESKTOP) {
         return process.env.XDG_CURRENT_DESKTOP;
+    } else {
+        return undefined;
+    }
+}
+
+/**
+ * Calls the given callback with the value of the XDG_CURRENT_DESKTOP environment variable set to ORIGINAL_XDG_CURRENT_DESKTOP if it is set.
+ * @param callback The callback to call.
+ */
+function callWithOriginalXdgCurrentDesktop(callback: () => void) {
+    const currXdgCurrentDesktop = process.env.XDG_CURRENT_DESKTOP;
+    const originalXdgCurrentDesktop = getXdgCurrentDesktop();
+    if (currXdgCurrentDesktop) {
+        process.env.XDG_CURRENT_DESKTOP = originalXdgCurrentDesktop;
+    }
+    callback();
+    if (currXdgCurrentDesktop) {
+        process.env.XDG_CURRENT_DESKTOP = currXdgCurrentDesktop;
+    }
+}
+
+/**
+ * Calls the given async callback with the value of the XDG_CURRENT_DESKTOP environment variable set to ORIGINAL_XDG_CURRENT_DESKTOP if it is set.
+ * @param callback The async callback to call.
+ */
+async function callWithOriginalXdgCurrentDesktopAsync(callback: () => Promise<void>) {
+    const currXdgCurrentDesktop = process.env.XDG_CURRENT_DESKTOP;
+    const originalXdgCurrentDesktop = getXdgCurrentDesktop();
+    if (currXdgCurrentDesktop) {
+        process.env.XDG_CURRENT_DESKTOP = originalXdgCurrentDesktop;
+    }
+    await callback();
+    if (currXdgCurrentDesktop) {
+        process.env.XDG_CURRENT_DESKTOP = currXdgCurrentDesktop;
     }
 }
 
 export {
+    callWithOriginalXdgCurrentDesktop,
+    callWithOriginalXdgCurrentDesktopAsync,
     getElectronAppBasePath,
     getElectronAppUnpackedBasePath,
     getWaveConfigDir,


### PR DESCRIPTION
Electron sets XDG_CURRENT_DESKTOP for better Chromium compatibility on Linux. We need to unset this for `wavesrv` and for any calls to open a file or URL externally in `emain`.

See https://www.electronjs.org/docs/latest/api/environment-variables#original_xdg_current_desktop

There's a bug open in Electron related to this: https://github.com/electron/electron/issues/45129

closes #1733 