### PR TITLE
Switch to the free Ubuntu ARM runners

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -24,7 +24,7 @@ jobs:
                     - platform: "linux"
                       runner: "ubuntu-latest"
                     - platform: "linux"
-                      runner: ubuntu-24.04-arm64-16core
+                      runner: ubuntu-24.04-arm
                     - platform: "windows"
                       runner: "windows-latest"
                     # - platform: "windows"


### PR DESCRIPTION
GitHub has made Ubuntu ARM runners free for OSS repos so we can retire our hosted runner.