### PR TITLE
Improve preview and web widget padding

### DIFF
--- a/frontend/app/view/preview/preview.scss
+++ b/frontend/app/view/preview/preview.scss
@@ -5,11 +5,9 @@
     display: flex;
     flex-direction: row;
     height: 100%;
-    flex-grow: 1;
     overflow: hidden;
     align-items: center;
     justify-content: center;
-    padding: 0 5px;
 
     &.view-preview-markdown {
         align-items: start;
@@ -42,6 +40,10 @@
     &.view-preview-directory {
         flex-direction: column;
         align-items: start;
+    }
+    &.view-preview-pdf,
+    &.view-preview-directory {
+        padding: 5px;
     }
 }
 

--- a/frontend/app/view/preview/preview.tsx
+++ b/frontend/app/view/preview/preview.tsx
@@ -117,6 +117,7 @@ export class PreviewModel implements ViewModel {
     viewType: string;
     blockId: string;
     nodeModel: BlockNodeModel;
+    noPadding?: Atom<boolean>;
     blockAtom: Atom<Block>;
     viewIcon: Atom<string | IconButtonDecl>;
     viewName: Atom<string>;
@@ -433,6 +434,8 @@ export class PreviewModel implements ViewModel {
             const connAtom = getConnStatusAtom(connName);
             return get(connAtom);
         });
+
+        this.noPadding = atom(true);
     }
 
     markdownShowTocToggle() {
@@ -825,7 +828,7 @@ function StreamingPreview({ model }: SpecializedViewProps) {
     if (fileInfo.mimetype == "application/pdf") {
         return (
             <div className="view-preview view-preview-pdf">
-                <iframe src={streamingUrl} width="95%" height="95%" name="pdfview" />
+                <iframe src={streamingUrl} width="100%" height="100%" name="pdfview" />
             </div>
         );
     }

--- a/frontend/app/view/webview/webview.tsx
+++ b/frontend/app/view/webview/webview.tsx
@@ -33,6 +33,7 @@ function getWebviewPreloadUrl() {
 export class WebViewModel implements ViewModel {
     viewType: string;
     blockId: string;
+    noPadding?: Atom<boolean>;
     blockAtom: Atom<Block>;
     viewIcon: Atom<string | IconButtonDecl>;
     viewName: Atom<string>;
@@ -58,6 +59,7 @@ export class WebViewModel implements ViewModel {
         this.nodeModel = nodeModel;
         this.viewType = "web";
         this.blockId = blockId;
+        this.noPadding = atom(true);
         this.blockAtom = WOS.getWaveObjectAtom<Block>(`block:${blockId}`);
         this.url = atom();
         const defaultUrlAtom = getSettingsKeyAtom("web:defaulturl");


### PR DESCRIPTION
Removes the padding for most of the specialized previews, moves where it's defined for the directory preview so that the header borders extend to the edge of the block