### PR TITLE
Fix markdown padding

### DIFF
--- a/frontend/app/element/markdown.scss
+++ b/frontend/app/element/markdown.scss
@@ -19,6 +19,7 @@
         font-family: var(--markdown-font-family);
         font-size: var(--markdown-font-size);
         overflow-wrap: break-word;
+        padding: 5px 15px;
 
         &.non-scrollable {
             overflow: hidden;

--- a/frontend/app/view/preview/preview.scss
+++ b/frontend/app/view/preview/preview.scss
@@ -13,9 +13,6 @@
         align-items: start;
         justify-content: start;
         overflow: auto;
-        .markdown {
-            margin: 10px 5px;
-        }
     }
 
     &.view-preview-text {
@@ -40,8 +37,7 @@
             object-fit: contain;
         }
     }
-    &.view-preview-pdf,
-    &.view-preview-markdown {
+    &.view-preview-pdf {
         padding: 5px;
     }
 }


### PR DESCRIPTION
Moves the markdown padding inside the component so the scrollbar stays glued to the edge