### PR TITLE
feat: add new window item to macos dock

### DIFF
--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -45,7 +45,7 @@ import {
 import { ElectronWshClient, initElectronWshClient } from "./emain-wsh";
 import { getLaunchSettings } from "./launchsettings";
 import { log } from "./log";
-import { makeAppMenu } from "./menu";
+import { makeAppMenu, makeDockTaskbar } from "./menu";
 import {
     callWithOriginalXdgCurrentDesktopAsync,
     checkIfRunningUnderARM64Translation,
@@ -611,6 +611,7 @@ async function appMain() {
     setTimeout(runActiveTimer, 5000); // start active timer, wait 5s just to be safe
 
     makeAppMenu();
+    makeDockTaskbar();
     await configureAutoUpdater();
     setGlobalIsStarting(false);
     if (fullConfig?.settings?.["window:maxtabcachesize"] != null) {

--- a/emain/menu.ts
+++ b/emain/menu.ts
@@ -360,4 +360,19 @@ electron.ipcMain.on("contextmenu-show", (event, workspaceId: string, menuDefArr?
     event.returnValue = true;
 });
 
-export { getAppMenu };
+const dockMenu = electron.Menu.buildFromTemplate([
+    {
+        label: "New Window",
+        click() {
+            fireAndForget(createNewWaveWindow);
+        },
+    },
+]);
+
+function makeDockTaskbar() {
+    if (unamePlatform == "darwin") {
+        electron.app.dock.setMenu(dockMenu);
+    }
+}
+
+export { getAppMenu, makeDockTaskbar };


### PR DESCRIPTION
Adds an option to the MacOS dock, so the menu that shows up on right click has an option to create a new window.