### PR TITLE
fix: connection error only shows in error state

### DIFF
--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -339,7 +339,7 @@ const ConnStatusOverlay = React.memo(
         React.useEffect(() => {
             if (width) {
                 const hasError = !util.isBlank(connStatus.error);
-                const showError = hasError && width >= 250 && connStatus.status != "connecting";
+                const showError = hasError && width >= 250 && connStatus.status == "error";
                 setShowError(showError);
             }
         }, [width, connStatus, setShowError]);


### PR DESCRIPTION
This ensures that an error of EOF does not get displayed in the disconnected state.