### PR TITLE
fix: cleanup gotypes.d.ts extra type

### DIFF
--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -296,7 +296,6 @@ declare global {
     type ConnKeywords = {
         "conn:wshenabled"?: boolean;
         "conn:askbeforewshinstall"?: boolean;
-        "conn:overrideconfig"?: boolean;
         "conn:wshpath"?: string;
         "conn:shellpath"?: string;
         "conn:ignoresshconfig"?: boolean;


### PR DESCRIPTION
An earlier commit was pushed without running task generate to clear out the frontend. This fixes that to bring the backend and frontend in sync.