### PR TITLE
Proposal: Add ability to hide widgets via config

### DIFF
--- a/frontend/app/workspace/workspace.tsx
+++ b/frontend/app/workspace/workspace.tsx
@@ -78,7 +78,14 @@ async function handleWidgetSelect(widget: WidgetConfigType) {
 
 const Widget = memo(({ widget }: { widget: WidgetConfigType }) => {
     return (
-        <div className="widget" onClick={() => handleWidgetSelect(widget)} title={widget.description || widget.label}>
+        <div
+            className="widget"
+            onClick={() => handleWidgetSelect(widget)}
+            title={widget.description || widget.label}
+            style={{
+                display: widget["display:hidden"] ? "none" : "inherit",
+            }}
+        >
             <div className="widget-icon" style={{ color: widget.color }}>
                 <i className={makeIconClass(widget.icon, true, { defaultIcon: "browser" })}></i>
             </div>

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1212,6 +1212,7 @@ declare global {
     // wconfig.WidgetConfigType
     type WidgetConfigType = {
         "display:order"?: number;
+        "display:hidden"?: boolean;
         icon?: string;
         color?: string;
         label?: string;

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -582,13 +582,14 @@ func SetConnectionsConfigValue(connName string, toMerge waveobj.MetaMapType) err
 }
 
 type WidgetConfigType struct {
-	DisplayOrder float64          `json:"display:order,omitempty"`
-	Icon         string           `json:"icon,omitempty"`
-	Color        string           `json:"color,omitempty"`
-	Label        string           `json:"label,omitempty"`
-	Description  string           `json:"description,omitempty"`
-	Magnified    bool             `json:"magnified,omitempty"`
-	BlockDef     waveobj.BlockDef `json:"blockdef"`
+	DisplayOrder  float64          `json:"display:order,omitempty"`
+	DisplayHidden bool             `json:"display:hidden,omitempty"`
+	Icon          string           `json:"icon,omitempty"`
+	Color         string           `json:"color,omitempty"`
+	Label         string           `json:"label,omitempty"`
+	Description   string           `json:"description,omitempty"`
+	Magnified     bool             `json:"magnified,omitempty"`
+	BlockDef      waveobj.BlockDef `json:"blockdef"`
 }
 
 type MimeTypeConfigType struct {


### PR DESCRIPTION
👋 Hello, I'm not sure if this warranted an Issue first but it seemed small enough to just raise a PR. I'm happy to add something to the documentation as well if you agree with the proposal.

There are some widgets that I'd rather not be displayed in the sidebar - at the moment these are default widgets for which I cannot see any existing means of omitting them via configuration. I'm proposing a `display:hidden` field on the widget settings such that I can configure the following:

```json
{
    "defwidget@ai": {
        "display:hidden": true
    }
}
```

I'm considering this option to be distinct from any means of outright "disabling" the widget - that is to say that I've not chosen to filter the widgets from the configuration because I'm not fully aware of the project goals. Where for example I imagine that it might be useful to be able to interact with a widget or it's config via the CLI or shortcut regardless of visibility?

<img width="1421" alt="example" src="https://github.com/user-attachments/assets/7cafa942-727d-4140-8940-38b4022f2ef0" />

