### PR TITLE
fix: frontend file delete add recursive false

### DIFF
--- a/frontend/app/view/preview/directorypreview.tsx
+++ b/frontend/app/view/preview/directorypreview.tsx
@@ -639,9 +639,8 @@ function TableBody({
                     click: () => {
                         fireAndForget(async () => {
                             await RpcApi.FileDeleteCommand(TabRpcClient, {
-                                info: {
-                                    path: await model.formatRemoteUri(finfo.path, globalStore.get),
-                                },
+                                path: await model.formatRemoteUri(finfo.path, globalStore.get),
+                                recursive: false,
                             }).catch((e) => console.log(e));
                             setRefreshVersion((current) => current + 1);
                         });


### PR DESCRIPTION
There was a recent backend change that update the interface to FileDeleteCommand. This updated was not reflected in directorypreview.tsx on the frontend. This updates the frontend to match.