### PR TITLE
fix: schema build process ignore rmrf error

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -124,6 +124,7 @@ tasks:
         cmds:
             - go run cmd/generateschema/main-generateschema.go
             - '{{.RMRF}} "dist/schema"'
+              ignore_error: true
             - task: copyfiles:'schema':'dist/schema'
 
     build:server:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -123,7 +123,7 @@ tasks:
             - "dist/schema/**/*"
         cmds:
             - go run cmd/generateschema/main-generateschema.go
-            - '{{.RMRF}} "dist/schema"'
+            - cmd: '{{.RMRF}} "dist/schema"'
               ignore_error: true
             - task: copyfiles:'schema':'dist/schema'
 


### PR DESCRIPTION
In prod builds, the RMRF step of build:schema is breaking the build. This ignores the error produced to avoid that.