### PR TITLE
Fix copy to align better with cp

### DIFF
--- a/cmd/wsh/cmd/wshcmd-view.go
+++ b/cmd/wsh/cmd/wshcmd-view.go
@@ -19,6 +19,7 @@ var viewMagnified bool
 
 var viewCmd = &cobra.Command{
 	Use:     "view {file|directory|URL}",
+	Aliases: []string{"preview", "open"},
 	Short:   "preview/edit a file or directory",
 	RunE:    viewRun,
 	PreRunE: preRunSetupRpcClient,

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -263,7 +263,7 @@ class RpcApiType {
     }
 
     // command "remotefilecopy" [call]
-    RemoteFileCopyCommand(client: WshClient, data: CommandRemoteFileCopyData, opts?: RpcOpts): Promise<void> {
+    RemoteFileCopyCommand(client: WshClient, data: CommandFileCopyData, opts?: RpcOpts): Promise<void> {
         return client.wshRpcCall("remotefilecopy", data, opts);
     }
 
@@ -283,7 +283,7 @@ class RpcApiType {
     }
 
     // command "remotefilemove" [call]
-    RemoteFileMoveCommand(client: WshClient, data: CommandRemoteFileCopyData, opts?: RpcOpts): Promise<void> {
+    RemoteFileMoveCommand(client: WshClient, data: CommandFileCopyData, opts?: RpcOpts): Promise<void> {
         return client.wshRpcCall("remotefilemove", data, opts);
     }
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -202,13 +202,6 @@ declare global {
         message: string;
     };
 
-    // wshrpc.CommandRemoteFileCopyData
-    type CommandRemoteFileCopyData = {
-        srcuri: string;
-        desturi: string;
-        opts?: FileCopyOpts;
-    };
-
     // wshrpc.CommandRemoteListEntriesData
     type CommandRemoteListEntriesData = {
         path: string;

--- a/pkg/remote/fileshare/fstype/fstype.go
+++ b/pkg/remote/fileshare/fstype/fstype.go
@@ -5,10 +5,15 @@ package fstype
 
 import (
 	"context"
+	"time"
 
 	"github.com/wavetermdev/waveterm/pkg/remote/connparse"
 	"github.com/wavetermdev/waveterm/pkg/util/iochan/iochantypes"
 	"github.com/wavetermdev/waveterm/pkg/wshrpc"
+)
+
+const (
+	DefaultTimeout = 30 * time.Second
 )
 
 type FileShareClient interface {

--- a/pkg/remote/fileshare/wshfs/wshfs.go
+++ b/pkg/remote/fileshare/wshfs/wshfs.go
@@ -157,7 +157,7 @@ func (c WshClient) MoveInternal(ctx context.Context, srcConn, destConn *connpars
 	if timeout == 0 {
 		timeout = ThirtySeconds
 	}
-	return wshclient.RemoteFileMoveCommand(RpcClient, wshrpc.CommandRemoteFileCopyData{SrcUri: srcConn.GetFullURI(), DestUri: destConn.GetFullURI(), Opts: opts}, &wshrpc.RpcOpts{Route: wshutil.MakeConnectionRouteId(destConn.Host), Timeout: timeout})
+	return wshclient.RemoteFileMoveCommand(RpcClient, wshrpc.CommandFileCopyData{SrcUri: srcConn.GetFullURI(), DestUri: destConn.GetFullURI(), Opts: opts}, &wshrpc.RpcOpts{Route: wshutil.MakeConnectionRouteId(destConn.Host), Timeout: timeout})
 }
 
 func (c WshClient) CopyRemote(ctx context.Context, srcConn, destConn *connparse.Connection, _ fstype.FileShareClient, opts *wshrpc.FileCopyOpts) error {
@@ -172,7 +172,7 @@ func (c WshClient) CopyInternal(ctx context.Context, srcConn, destConn *connpars
 	if timeout == 0 {
 		timeout = ThirtySeconds
 	}
-	return wshclient.RemoteFileCopyCommand(RpcClient, wshrpc.CommandRemoteFileCopyData{SrcUri: srcConn.GetFullURI(), DestUri: destConn.GetFullURI(), Opts: opts}, &wshrpc.RpcOpts{Route: wshutil.MakeConnectionRouteId(destConn.Host), Timeout: timeout})
+	return wshclient.RemoteFileCopyCommand(RpcClient, wshrpc.CommandFileCopyData{SrcUri: srcConn.GetFullURI(), DestUri: destConn.GetFullURI(), Opts: opts}, &wshrpc.RpcOpts{Route: wshutil.MakeConnectionRouteId(destConn.Host), Timeout: timeout})
 }
 
 func (c WshClient) Delete(ctx context.Context, conn *connparse.Connection, recursive bool) error {

--- a/pkg/util/fileutil/fileutil.go
+++ b/pkg/util/fileutil/fileutil.go
@@ -19,6 +19,7 @@ import (
 )
 
 func FixPath(path string) (string, error) {
+	origPath := path
 	var err error
 	if strings.HasPrefix(path, "~") {
 		path = filepath.Join(wavebase.GetHomeDir(), path[1:])
@@ -27,6 +28,9 @@ func FixPath(path string) (string, error) {
 		if err != nil {
 			return "", err
 		}
+	}
+	if strings.HasSuffix(origPath, "/") && !strings.HasSuffix(path, "/") {
+		path += "/"
 	}
 	return path, nil
 }

--- a/pkg/util/tarcopy/tarcopy.go
+++ b/pkg/util/tarcopy/tarcopy.go
@@ -45,9 +45,9 @@ func TarCopySrc(ctx context.Context, pathPrefix string) (outputChan chan wshrpc.
 		gracefulClose(pipeReader, tarCopySrcName, pipeReaderName)
 	})
 
-	return rtnChan, func(fi fs.FileInfo, file string, singleFile bool) error {
+	return rtnChan, func(fi fs.FileInfo, path string, singleFile bool) error {
 			// generate tar header
-			header, err := tar.FileInfoHeader(fi, file)
+			header, err := tar.FileInfoHeader(fi, path)
 			if err != nil {
 				return err
 			}
@@ -56,7 +56,10 @@ func TarCopySrc(ctx context.Context, pathPrefix string) (outputChan chan wshrpc.
 				header.PAXRecords = map[string]string{SingleFile: "true"}
 			}
 
-			header.Name = filepath.Clean(strings.TrimPrefix(file, pathPrefix))
+			header.Name = filepath.Clean(strings.TrimPrefix(path, pathPrefix))
+			if header.Name == "." {
+				return nil
+			}
 			if err := validatePath(header.Name); err != nil {
 				return err
 			}

--- a/pkg/util/tarcopy/tarcopy.go
+++ b/pkg/util/tarcopy/tarcopy.go
@@ -30,7 +30,7 @@ const (
 	pipeWriterName  = "pipe writer"
 	tarWriterName   = "tar writer"
 
-	// custom flag to indicate that the source is a single file, not a directory the contents of a directory
+	// custom flag to indicate that the source is a single file
 	SingleFile = "singlefile"
 )
 

--- a/pkg/wshrpc/wshclient/wshclient.go
+++ b/pkg/wshrpc/wshclient/wshclient.go
@@ -321,7 +321,7 @@ func RecordTEventCommand(w *wshutil.WshRpc, data telemetrydata.TEvent, opts *wsh
 }
 
 // command "remotefilecopy", wshserver.RemoteFileCopyCommand
-func RemoteFileCopyCommand(w *wshutil.WshRpc, data wshrpc.CommandRemoteFileCopyData, opts *wshrpc.RpcOpts) error {
+func RemoteFileCopyCommand(w *wshutil.WshRpc, data wshrpc.CommandFileCopyData, opts *wshrpc.RpcOpts) error {
 	_, err := sendRpcRequestCallHelper[any](w, "remotefilecopy", data, opts)
 	return err
 }
@@ -345,7 +345,7 @@ func RemoteFileJoinCommand(w *wshutil.WshRpc, data []string, opts *wshrpc.RpcOpt
 }
 
 // command "remotefilemove", wshserver.RemoteFileMoveCommand
-func RemoteFileMoveCommand(w *wshutil.WshRpc, data wshrpc.CommandRemoteFileCopyData, opts *wshrpc.RpcOpts) error {
+func RemoteFileMoveCommand(w *wshutil.WshRpc, data wshrpc.CommandFileCopyData, opts *wshrpc.RpcOpts) error {
 	_, err := sendRpcRequestCallHelper[any](w, "remotefilemove", data, opts)
 	return err
 }

--- a/pkg/wshrpc/wshremote/wshremote.go
+++ b/pkg/wshrpc/wshremote/wshremote.go
@@ -254,7 +254,7 @@ func (impl *ServerImpl) RemoteTarStreamCommand(ctx context.Context, data wshrpc.
 	if !singleFile && srcHasSlash {
 		pathPrefix = cleanedPath
 	} else {
-		pathPrefix = filepath.Dir(cleanedPath) + "/"
+		pathPrefix = filepath.Dir(cleanedPath)
 	}
 	log.Printf("RemoteTarStreamCommand: path=%s, pathPrefix=%s\n", path, pathPrefix)
 

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -206,11 +206,11 @@ type WshRpcInterface interface {
 	// remotes
 	RemoteStreamFileCommand(ctx context.Context, data CommandRemoteStreamFileData) chan RespOrErrorUnion[FileData]
 	RemoteTarStreamCommand(ctx context.Context, data CommandRemoteStreamTarData) <-chan RespOrErrorUnion[iochantypes.Packet]
-	RemoteFileCopyCommand(ctx context.Context, data CommandRemoteFileCopyData) error
+	RemoteFileCopyCommand(ctx context.Context, data CommandFileCopyData) error
 	RemoteListEntriesCommand(ctx context.Context, data CommandRemoteListEntriesData) chan RespOrErrorUnion[CommandRemoteListEntriesRtnData]
 	RemoteFileInfoCommand(ctx context.Context, path string) (*FileInfo, error)
 	RemoteFileTouchCommand(ctx context.Context, path string) error
-	RemoteFileMoveCommand(ctx context.Context, data CommandRemoteFileCopyData) error
+	RemoteFileMoveCommand(ctx context.Context, data CommandFileCopyData) error
 	RemoteFileDeleteCommand(ctx context.Context, data CommandDeleteFileData) error
 	RemoteWriteFileCommand(ctx context.Context, data FileData) error
 	RemoteFileJoinCommand(ctx context.Context, paths []string) (*FileInfo, error)
@@ -515,12 +515,6 @@ type CommandFileCopyData struct {
 	Opts    *FileCopyOpts `json:"opts,omitempty"`
 }
 
-type CommandRemoteFileCopyData struct {
-	SrcUri  string        `json:"srcuri"`
-	DestUri string        `json:"desturi"`
-	Opts    *FileCopyOpts `json:"opts,omitempty"`
-}
-
 type CommandRemoteStreamTarData struct {
 	Path string        `json:"path"`
 	Opts *FileCopyOpts `json:"opts,omitempty"`
@@ -528,8 +522,8 @@ type CommandRemoteStreamTarData struct {
 
 type FileCopyOpts struct {
 	Overwrite bool  `json:"overwrite,omitempty"`
-	Recursive bool  `json:"recursive,omitempty"`
-	Merge     bool  `json:"merge,omitempty"`
+	Recursive bool  `json:"recursive,omitempty"` // only used for move, always true for copy
+	Merge     bool  `json:"merge,omitempty"`     // only used for copy, always false for move
 	Timeout   int64 `json:"timeout,omitempty"`
 }
 

--- a/pkg/wshutil/wshproxy.go
+++ b/pkg/wshutil/wshproxy.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/google/uuid"
+	"github.com/wavetermdev/waveterm/pkg/panichandler"
 	"github.com/wavetermdev/waveterm/pkg/util/shellutil"
 	"github.com/wavetermdev/waveterm/pkg/util/utilfn"
 	"github.com/wavetermdev/waveterm/pkg/wshrpc"
@@ -248,6 +249,9 @@ func (p *WshRpcProxy) HandleAuthentication() (*wshrpc.RpcContext, error) {
 }
 
 func (p *WshRpcProxy) SendRpcMessage(msg []byte) {
+	defer func() {
+		panichandler.PanicHandler("WshRpcProxy.SendRpcMessage", recover())
+	}()
 	p.ToRemoteCh <- msg
 }
 


### PR DESCRIPTION
This updates `wsh file cp` so it behaves more like `cp` for things like copying directories and directory entries. It's not meant to align with `cp` on everything, though. Our `wsh cp` will be recursive and will create intermediate directories by default.

This also adds new aliases for `wsh view`: `wsh preview` and `wsh open`