### PR TITLE
Allow AI Presets To Automatically Update Widgets

### DIFF
--- a/db/migrations-wstore/000008_aimeta.down.sql
+++ b/db/migrations-wstore/000008_aimeta.down.sql
@@ -1,0 +1,1 @@
+-- presets exist in config files, and should automatically prepopulate the meta in the older code versions

--- a/db/migrations-wstore/000008_aimeta.up.sql
+++ b/db/migrations-wstore/000008_aimeta.up.sql
@@ -1,0 +1,17 @@
+--- removes all ai: keys except ai:preset
+UPDATE db_block
+SET data = json_remove(
+    db_block.data,
+    '$.meta.ai:*',
+    '$.meta.ai:apitype',
+    '$.meta.ai:baseurl',
+    '$.meta.ai:apitoken',
+    '$.meta.ai:name',
+    '$.meta.ai:model',
+    '$.meta.ai:orgid',
+    '$.meta.ai:apiversion',
+    '$.meta.ai:maxtokens',
+    '$.meta.timeoutms',
+    '$.meta.fontsize',
+    '$.meta.fixedfontsize'
+);

--- a/frontend/app/view/waveai/waveai.tsx
+++ b/frontend/app/view/waveai/waveai.tsx
@@ -163,8 +163,13 @@ export class WaveAiModel implements ViewModel {
         this.aiOpts = atom((get) => {
             const meta = get(this.blockAtom).meta;
             let settings = get(atoms.settingsAtom);
+            let presetKey = get(this.presetKey);
+
+            let presets = get(atoms.fullConfigAtom).presets;
+            let selectedPresets = presets?.[presetKey] ?? {};
             settings = {
                 ...settings,
+                ...selectedPresets,
                 ...meta,
             };
             const opts: WaveAIOptsType = {
@@ -244,7 +249,6 @@ export class WaveAiModel implements ViewModel {
                             onClick: () =>
                                 fireAndForget(() =>
                                     ObjectService.UpdateObjectMeta(WOS.makeORef("block", this.blockId), {
-                                        ...preset[1],
                                         "ai:preset": preset[0],
                                     })
                                 ),


### PR DESCRIPTION
This change makes it so changes to the presets file are no longer being written to metadata. Instead, the preset data is read separately (although it is still possible to override it with metadata if done manually).

Because presets are being tracked separately, if the associated metadata key is not set, changes to the `presets/ai.json` file will be applied immediately without switching the preset choice. Note that `ai:preset` is still used in metadata to associate a block with a preset.

Additionallly, this introduces a database migration to clear out the metadata items starting with `ai:` except for `ai:preset`. This will allow the change to apply to existing blocks in addition to new ones.