### PR TITLE
fix: decouple AiSettingsType from SettingsType

### DIFF
--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -46,6 +46,8 @@ type AiSettingsType struct {
 	AiTimeoutMs     float64 `json:"ai:timeoutms,omitempty"`
 	AiFontSize      float64 `json:"ai:fontsize,omitempty"`
 	AiFixedFontSize float64 `json:"ai:fixedfontsize,omitempty"`
+	DisplayName     string  `json:"display:name,omitempty"`
+	DisplayOrder    float64 `json:"display:order,omitempty"`
 }
 
 type SettingsType struct {
@@ -54,7 +56,19 @@ type SettingsType struct {
 	AppDismissArchitectureWarning bool   `json:"app:dismissarchitecturewarning,omitempty"`
 	AppDefaultNewBlock            string `json:"app:defaultnewblock,omitempty"`
 
-	AiSettingsType
+	AiClear         bool    `json:"ai:*,omitempty"`
+	AiPreset        string  `json:"ai:preset,omitempty"`
+	AiApiType       string  `json:"ai:apitype,omitempty"`
+	AiBaseURL       string  `json:"ai:baseurl,omitempty"`
+	AiApiToken      string  `json:"ai:apitoken,omitempty"`
+	AiName          string  `json:"ai:name,omitempty"`
+	AiModel         string  `json:"ai:model,omitempty"`
+	AiOrgID         string  `json:"ai:orgid,omitempty"`
+	AIApiVersion    string  `json:"ai:apiversion,omitempty"`
+	AiMaxTokens     float64 `json:"ai:maxtokens,omitempty"`
+	AiTimeoutMs     float64 `json:"ai:timeoutms,omitempty"`
+	AiFontSize      float64 `json:"ai:fontsize,omitempty"`
+	AiFixedFontSize float64 `json:"ai:fixedfontsize,omitempty"`
 
 	TermClear               bool     `json:"term:*,omitempty"`
 	TermFontSize            float64  `json:"term:fontsize,omitempty"`

--- a/schema/aipresets.json
+++ b/schema/aipresets.json
@@ -41,6 +41,12 @@
         },
         "ai:fixedfontsize": {
           "type": "number"
+        },
+        "display:name": {
+          "type": "string"
+        },
+        "display:order": {
+          "type": "number"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
While there is significant overlap between SettingsType and AiSettingsType, they are distinct entities and should be treated as such until more changes have been made.