### PR TITLE
fix: remove final row during directory search

### DIFF
--- a/frontend/app/view/preview/directorypreview.tsx
+++ b/frontend/app/view/preview/directorypreview.tsx
@@ -360,7 +360,7 @@ function DirectoryTable({
                 return;
             }
         }
-    }, [data]);
+    }, [table]);
     const columnSizeVars = useMemo(() => {
         const headers = table.getFlatHeaders();
         const colSizes: { [key: string]: number } = {};


### PR DESCRIPTION
A bug prevented the final row from being removed while searching for directory files. Additionally, a console error would come up when the directory was filtered far enough. This corrects a react dependency so that is no longer an issue.