### PR TITLE
fix: s3 copy overwrite/sync buttons

### DIFF
--- a/frontend/app/view/preview/directorypreview.tsx
+++ b/frontend/app/view/preview/directorypreview.tsx
@@ -901,8 +901,9 @@ function DirectoryPreview({ model }: DirectoryPreviewProps) {
                 console.log("copy failed:", e);
                 const copyError = `${e}`;
                 const allowRetry =
-                    copyError.endsWith("overwrite not specified") ||
-                    copyError.endsWith("neither overwrite nor merge specified");
+                    copyError.includes("overwrite not specified") ||
+                    copyError.includes("neither overwrite nor merge specified") ||
+                    copyError.includes("neither merge nor overwrite specified");
                 const copyStatus: FileCopyStatus = {
                     copyError,
                     copyData: data,


### PR DESCRIPTION
The copy overwrite/sync buttons were not appearing on s3 do to s3 operations having different error messages. This accounts for those so the options will be available with those files as well.