### PR TITLE
fix multi-input paste

### DIFF
--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -228,7 +228,7 @@ export class TermWrap {
         this.connectElem.addEventListener("paste", pasteEventHandler, true);
         this.toDispose.push({
             dispose: () => {
-                this.connectElem.removeEventListener("paste", pasteEventHandler);
+                this.connectElem.removeEventListener("paste", pasteEventHandler, true);
             },
         });
     }

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -152,6 +152,7 @@ export class TermWrap {
     sendDataHandler: (data: string) => void;
     onSearchResultsDidChange?: (result: { resultIndex: number; resultCount: number }) => void;
     private toDispose: TermTypes.IDisposable[] = [];
+    pasteActive: boolean = false;
 
     constructor(
         blockId: string,
@@ -217,6 +218,19 @@ export class TermWrap {
         this.handleResize_debounced = debounce(50, this.handleResize.bind(this));
         this.terminal.open(this.connectElem);
         this.handleResize();
+        let pasteEventHandler = () => {
+            this.pasteActive = true;
+            setTimeout(() => {
+                this.pasteActive = false;
+            }, 30);
+        };
+        pasteEventHandler = pasteEventHandler.bind(this);
+        this.connectElem.addEventListener("paste", pasteEventHandler, true);
+        this.toDispose.push({
+            dispose: () => {
+                this.connectElem.removeEventListener("paste", pasteEventHandler);
+            },
+        });
     }
 
     async initTerminal() {
@@ -262,6 +276,12 @@ export class TermWrap {
     handleTermData(data: string) {
         if (!this.loaded) {
             return;
+        }
+        if (this.pasteActive) {
+            this.pasteActive = false;
+            if (this.multiInputCallback) {
+                this.multiInputCallback(data);
+            }
         }
         this.sendDataHandler?.(data);
     }


### PR DESCRIPTION
a fix for #1862.  so now when pasting information into a terminal when multi-input is active, the data will be sent to all terminals in the tab.