### PR TITLE
fix: dismiss the error when changing path

### DIFF
--- a/frontend/app/view/preview/preview.tsx
+++ b/frontend/app/view/preview/preview.tsx
@@ -1069,12 +1069,13 @@ function PreviewView({
     model: PreviewModel;
 }) {
     const connStatus = useAtomValue(model.connStatus);
+    const filePath = useAtomValue(model.metaFilePath);
     const [errorMsg, setErrorMsg] = useAtom(model.errorMsgAtom);
     const connection = useAtomValue(model.connectionImmediate);
 
     useEffect(() => {
         setErrorMsg(null);
-    }, [connection]);
+    }, [connection, filePath]);
 
     if (connStatus?.status != "connected") {
         return null;


### PR DESCRIPTION
The error overlay used to persist even after the path was changed. This changes this behavior so it is automatically dismissed when changing the path.