### PR TITLE
fix: sysinfo scroll data on initialization

### DIFF
--- a/frontend/app/view/sysinfo/sysinfo.tsx
+++ b/frontend/app/view/sysinfo/sysinfo.tsx
@@ -377,7 +377,7 @@ function SysinfoView({ model, blockId }: SysinfoViewProps) {
         return () => {
             unsubFn();
         };
-    }, [connName]);
+    }, [connName, addContinuousData]);
     if (connStatus?.status != "connected") {
         return null;
     }


### PR DESCRIPTION
A bug in sysinfo made it so the initial data would load but not update until refreshed. This updates the subscription handler with the correct addContinuousData function to correct this.