### PR TITLE
Fix 'WebSocket is not defined'

### DIFF
--- a/frontend/util/wsutil.ts
+++ b/frontend/util/wsutil.ts
@@ -1,27 +1,42 @@
 // Copyright 2025, Command Line Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// In browser builds `window` is defined and the global `WebSocket` constructor is
+// available. When running inside the Electron *main* process (Node context),
+// `window` is undefined and we must fall back to the `ws` npm package.
+
+// Import only the *type* from `ws`; the actual module will be required lazily
+// to avoid bundling issues when this file is transpiled for the renderer.
 import type { WebSocket as NodeWebSocketType } from "ws";
 
-let NodeWebSocket: typeof NodeWebSocketType = null;
-
-if (typeof window === "undefined") {
-    // Necessary to avoid issues with Rollup: https://github.com/websockets/ws/issues/2057
-    import("ws")
-        .then((ws) => (NodeWebSocket = ws.default))
-        .catch((e) => {
-            console.log("Error importing 'ws':", e);
-        });
-}
+// Lazily initialised reference to the Node-side WebSocket constructor.
+let NodeWebSocket: typeof NodeWebSocketType | null = null;
 
 type ComboWebSocket = NodeWebSocketType | WebSocket;
 
-function newWebSocket(url: string, headers: { [key: string]: string }): ComboWebSocket {
-    if (NodeWebSocket) {
+function newWebSocket(
+    url: string,
+    headers?: { [key: string]: string } | null
+): ComboWebSocket {
+    // Node / Electron main process path ─ use `ws` package.
+    if (typeof window === "undefined") {
+        if (!NodeWebSocket) {
+            // `require` ensures the module is loaded synchronously to avoid the
+            // timing issue that caused "WebSocket is not defined" errors when
+            // the previous asynchronous dynamic import had not completed yet.
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            // @ts-ignore – CommonJS require is available in Node context.
+            const wsMod = require("ws") as typeof NodeWebSocketType | {
+                default: typeof NodeWebSocketType;
+            };
+            NodeWebSocket = (wsMod as any).default ?? (wsMod as any);
+        }
+        // At this point NodeWebSocket is guaranteed to be initialised.
         return new NodeWebSocket(url, { headers });
-    } else {
-        return new WebSocket(url);
     }
+
+    // Browser / renderer path ─ use the global WebSocket.
+    return new WebSocket(url);
 }
 
 export { newWebSocket };


### PR DESCRIPTION
I just cloned the project. When I tried `task dev` / `task start`, I encountered the following error:

<details><summary>error initializing wshrpc ReferenceError: WebSocket is not defined</summary>
<p>

```
Running in development mode
2025-05-03 06:24:38.554 waveterm-app starting, data_dir=/home/jg/.local/share/waveterm-dev, config_dir=/home/jg/.config/waveterm-dev electronpath=/home/jg/perso/soft/waveterm/dist gopath=/home/jg/perso/soft/waveterm/dist arch=linux/x64
2025-05-03 06:24:38.555 waveterm-app WAVETERM_DEV set
2025-05-03 06:24:38.558 trying to run local server /home/jg/perso/soft/waveterm/dist/bin/wavesrv.x64
2025-05-03 06:24:38.569 spawned wavesrv
2025-05-03 06:24:38.680 [wavesrv] 2025/05/03 06:24:38.584276 checking endpoint "wss://wsapi-dev.waveterm.dev/"
2025-05-03 06:24:38.680 [wavesrv] 2025/05/03 06:24:38.584346 [base] acquiring lock on /home/jg/.local/share/waveterm-dev/wave.lock
2025-05-03 06:24:38.680 [wavesrv] 2025/05/03 06:24:38.584361 wave version: 0.11.3-beta.5 (202505030616)
2025-05-03 06:24:38.680 [wavesrv] 2025/05/03 06:24:38.584364 wave data dir: /home/jg/.local/share/waveterm-dev
2025-05-03 06:24:38.680 [wavesrv] 2025/05/03 06:24:38.584366 wave config dir: /home/jg/.config/waveterm-dev
2025-05-03 06:24:38.680 [wavesrv] 2025/05/03 06:24:38.584376 [db] opening db /home/jg/.local/share/waveterm-dev/db/filestore.db
2025-05-03 06:24:38.680 [wavesrv] 2025/05/03 06:24:38.584404 migrate filestore
2025-05-03 06:24:38.680 [wavesrv] 2025/05/03 06:24:38.587095 filestore initialized
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.587118 migrate wstore
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.589947 wstore initialized
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.590976 initializing wsh and shell startup files
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591029 clientid: e525681b-a39c-414e-9426-e516e4b22a3f
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591042 client has one window
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591046 CheckAndFixWindow e8e13948-76b6-4774-816c-59239cd162a4
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591452 [router] registering wsh route "wavesrv"
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591472 [router] registering wsh route "conn:local"
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591903 subdirs: [/home/jg/.config/waveterm-dev/mimetypes /home/jg/.config/waveterm-dev/defaultwidgets /home/jg/.config/waveterm-dev/widgets /home/jg/.config/waveterm-dev/presets /home/jg/.config/waveterm-dev/termthemes /home/jg/.config/waveterm-dev/connections /home/jg/.config/waveterm-dev/bookmarks]
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591946 failed to add path /home/jg/.config/waveterm-dev/mimetypes to watcher: no such file or directory
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591956 failed to add path /home/jg/.config/waveterm-dev/defaultwidgets to watcher: no such file or directory
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591961 failed to add path /home/jg/.config/waveterm-dev/widgets to watcher: no such file or directory
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591972 failed to add path /home/jg/.config/waveterm-dev/termthemes to watcher: no such file or directory
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591976 failed to add path /home/jg/.config/waveterm-dev/connections to watcher: no such file or directory
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591982 failed to add path /home/jg/.config/waveterm-dev/bookmarks to watcher: no such file or directory
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.591984 starting file watcher
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.596015 error (non-fatal), could not resolve wsh binary "/home/jg/perso/soft/waveterm/dist/bin/wsh-0.11.3-beta.5-linux.x64": stat /home/jg/perso/soft/waveterm/dist/bin/wsh-0.11.3-beta.5-linux.x64: no such file or directory
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.598517 [router] registering wsh route "bare"
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.598629 Server [web] listening on 127.0.0.1:38363
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.598664 Server [websocket] listening on 127.0.0.1:37909
2025-05-03 06:24:38.681 [wavesrv] 2025/05/03 06:24:38.598755 [websocket] running websocket server on 127.0.0.1:37909
2025-05-03 06:24:38.682 [wavesrv] 2025/05/03 06:24:38.599272 Server [unix-domain] listening on /home/jg/.local/share/waveterm-dev/wave.sock
2025-05-03 06:24:38.682 [wavesrv] 2025/05/03 06:24:38.599386 Docsite is nil, initializing
2025-05-03 06:24:38.682 [wavesrv] 2025/05/03 06:24:38.599395 Found static site at /home/jg/perso/soft/waveterm/dist/docsite, serving
2025-05-03 06:24:38.682 [wavesrv] 2025/05/03 06:24:38.599410 Schema is nil, initializing
2025-05-03 06:24:38.682 [wavesrv] 2025/05/03 06:24:38.599412 Found static site at /home/jg/perso/soft/waveterm/dist/schema, serving
2025-05-03 06:24:38.683 wavesrv ready signal received true 126 ms
2025-05-03 06:24:38.792 error initializing wshrpc ReferenceError: WebSocket is not defined
    at newWebSocket (file:///home/jg/perso/soft/waveterm/dist/main/index.js:6219:5)
    at WSControl.connectNow (file:///home/jg/perso/soft/waveterm/dist/main/index.js:7034:19)
    at initElectronWshrpc (file:///home/jg/perso/soft/waveterm/dist/main/index.js:7605:12)
    at appMain (file:///home/jg/perso/soft/waveterm/dist/main/index.js:47479:5)
2025-05-03 06:24:48.599 [wavesrv] 2025/05/03 06:24:48.598906 [wcloud] sending 5 tevents
2025-05-03 06:24:48.600 [wavesrv] 2025/05/03 06:24:48.599609 [wcloud] sending request POST https://api-dev.waveterm.dev/central/tevents
2025-05-03 06:24:50.637 [wavesrv] 2025/05/03 06:24:50.636841 [wcloud] sending telemetry data
2025-05-03 06:24:50.637 [wavesrv] 2025/05/03 06:24:50.636966 [wcloud] sending request POST https://api-dev.waveterm.dev/central/telemetry
```

</p>
</details> 

An AI suggested this fix which works for me. Its comments were:

> I replaced the async import('ws') with a synchronous lazy require inside newWebSocket().
> 
> Why this fixes startup:
> -  In the Electron main (Node) context window is undefined, so frontend code expected ws to be loaded.
> - The old async import often hadn’t finished when newWebSocket() ran, so NodeWebSocket was still null → “WebSocket is not defined” + subsequent undefined.close crashes.
> 
> Key changes in frontend/util/wsutil.ts
> - Removed top-level dynamic import.
> - Initialise NodeWebSocket synchronously the first time newWebSocket() is called (only in Node).
> - Made headers param optional.
> - Returned browser WebSocket unchanged for renderer.

As for why I encounter the bug when other contributors don't, it suggested:

> 1. Recent regression [...]
> 2. Environment difference:
>     - System specificity: The issue might only appear on certain Linux distributions or hardware combinations that affect Node/Electron timing
>     - The error happens consistently for you but might be intermittent for others
>     - Maintainers might work primarily on macOS where Node timing is different

I am not familiar with the stack so I don't know whether this is actually a good change! I hope it's valid.