### PR TITLE
remove .build-id links for rpm builds to fix slack conflict (#2277)

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -84,6 +84,10 @@ const config = {
                 Categories: "Development;Utility;",
             },
         },
+        rpm: {
+            // this should remove /usr/lib/.build-id/ links which can conflict with other electron apps like slack
+            fpm: ["--rpm-rpmbuild-define", "_build_id_links none"],
+        },
         executableArgs: ["--enable-features", "UseOzonePlatform", "--ozone-platform-hint", "auto"], // Hint Electron to use Ozone abstraction layer for native Wayland support
     },
     deb: {


### PR DESCRIPTION
potential fix for #2277