### PR TITLE
default bracketed paste mode ON, add context menu

### DIFF
--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -245,7 +245,6 @@ const TerminalView = ({ blockId, model }: ViewComponentProps<TermViewModel>) => 
         const fullConfig = globalStore.get(atoms.fullConfigAtom);
         const termThemeName = globalStore.get(model.termThemeNameAtom);
         const termTransparency = globalStore.get(model.termTransparencyAtom);
-        const termBPMAtom = getOverrideConfigAtom(blockId, "term:allowbracketedpaste");
         const termMacOptionIsMetaAtom = getOverrideConfigAtom(blockId, "term:macoptionismeta");
         const [termTheme, _] = computeTheme(fullConfig, termThemeName, termTransparency);
         let termScrollback = 2000;
@@ -261,7 +260,7 @@ const TerminalView = ({ blockId, model }: ViewComponentProps<TermViewModel>) => 
         if (termScrollback > 50000) {
             termScrollback = 50000;
         }
-        const termAllowBPM = globalStore.get(termBPMAtom) ?? false;
+        const termAllowBPM = globalStore.get(model.termBPMAtom) ?? true;
         const termMacOptionIsMeta = globalStore.get(termMacOptionIsMetaAtom) ?? false;
         const wasFocused = model.termRef.current != null && globalStore.get(model.nodeModel.isFocused);
         const termWrap = new TermWrap(

--- a/pkg/blockcontroller/shellcontroller.go
+++ b/pkg/blockcontroller/shellcontroller.go
@@ -204,6 +204,7 @@ func (sc *ShellController) resetTerminalState(logCtx context.Context) {
 	buf.WriteString("\x1b[?25h")                     // show cursor
 	buf.WriteString("\x1b[?1000l")                   // disable mouse tracking
 	buf.WriteString("\x1b[?1007l")                   // disable alternate scroll mode
+	buf.WriteString("\x1b[?2004l")                   // disable bracketed paste mode
 	buf.WriteString(shellutil.FormatOSC(16162, "R")) // OSC 16162 "R" - disable alternate screen mode (only if active), reset "shell integration" status.
 	buf.WriteString("\r\n\r\n")
 	err := HandleAppendBlockFile(sc.BlockId, wavebase.BlockFile_Term, buf.Bytes())


### PR DESCRIPTION
We were too conservative by defaulting ignorebrackedpastemode in xterm.js to true.  it should have been set to false.  this solves issues with pasting multi-line strings into zsh, claude code, etc.

add a new context menu option to more easily disable if you're in a weird ssh session or a REPL that doesn't support bracketedpaste.