### PR TITLE
New tabs inherit working directory from active tab

### DIFF
--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -197,15 +197,35 @@ func getTabPresetMeta() (waveobj.MetaMapType, error) {
 
 // returns tabid
 func CreateTab(ctx context.Context, workspaceId string, tabName string, activateTab bool, isInitialLaunch bool) (string, error) {
+	ws, err := GetWorkspace(ctx, workspaceId)
+	if err != nil {
+		return "", fmt.Errorf("workspace %s not found: %w", workspaceId, err)
+	}
+
 	if tabName == "" {
-		ws, err := GetWorkspace(ctx, workspaceId)
-		if err != nil {
-			return "", fmt.Errorf("workspace %s not found: %w", workspaceId, err)
-		}
 		tabName = "T" + fmt.Sprint(len(ws.TabIds)+1)
 	}
 
-	tab, err := createTabObj(ctx, workspaceId, tabName, nil)
+	// Try to inherit cwd from the active tab
+	var inheritedMeta waveobj.MetaMapType
+	if ws.ActiveTabId != "" && !isInitialLaunch {
+		activeTab, _ := wstore.DBGet[*waveobj.Tab](ctx, ws.ActiveTabId)
+		if activeTab != nil && len(activeTab.BlockIds) > 0 {
+			// Get the first block from the active tab
+			firstBlock, _ := wstore.DBGet[*waveobj.Block](ctx, activeTab.BlockIds[0])
+			if firstBlock != nil {
+				meta := waveobj.GetMeta(firstBlock)
+				if cwd, ok := meta[waveobj.MetaKey_CmdCwd].(string); ok && cwd != "" {
+					// Inherit the cwd for the new tab
+					inheritedMeta = waveobj.MetaMapType{
+						waveobj.MetaKey_CmdCwd: cwd,
+					}
+				}
+			}
+		}
+	}
+
+	tab, err := createTabObj(ctx, workspaceId, tabName, inheritedMeta)
 	if err != nil {
 		return "", fmt.Errorf("error creating tab: %w", err)
 	}
@@ -218,7 +238,17 @@ func CreateTab(ctx context.Context, workspaceId string, tabName string, activate
 
 	// No need to apply an initial layout for the initial launch, since the starter layout will get applied after onboarding modal dismissal
 	if !isInitialLaunch {
-		err = ApplyPortableLayout(ctx, tab.OID, GetNewTabLayout(), true)
+		newTabLayout := GetNewTabLayout()
+		// Merge inherited cwd into the terminal block's meta
+		if len(inheritedMeta) > 0 && len(newTabLayout) > 0 {
+			if newTabLayout[0].BlockDef.Meta == nil {
+				newTabLayout[0].BlockDef.Meta = make(waveobj.MetaMapType)
+			}
+			for k, v := range inheritedMeta {
+				newTabLayout[0].BlockDef.Meta[k] = v
+			}
+		}
+		err = ApplyPortableLayout(ctx, tab.OID, newTabLayout, true)
 		if err != nil {
 			return tab.OID, fmt.Errorf("error applying new tab layout: %w", err)
 		}


### PR DESCRIPTION
## Summary
Makes new tab creation more intuitive by inheriting the current working directory from the active tab.

## Problem
When creating a new tab (Cmd+T), it always starts in the home directory, requiring users to cd back to their project directory. This breaks workflow continuity.

## Solution
- Extract `cmd:cwd` from the active tab's first terminal block
- Pass inherited cwd as metadata to the new tab's terminal block
- Terminal starts in the same directory as the previous tab

## Behavior
- **With active tab in /projects/myapp**: New tab starts in /projects/myapp
- **No active tab or no cwd**: Falls back to home directory (~)
- **Initial launch**: Not affected (uses default behavior)

## Implementation
- Modified CreateTab in pkg/wcore/workspace.go
- Reads active tab's block metadata for cmd:cwd
- Merges inherited cwd into new tab's terminal block
- Backward compatible (doesn't break existing tab creation)

## Test Plan
- [x] cd to project directory
- [x] Press Cmd+T to create new tab
- [x] Verify pwd shows same directory
- [x] Test with no active tab (home directory)
- [x] Test initial app launch (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)