### PR TITLE
Fix terminal state loss when switching workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "waveterm",
-    "version": "0.13.1",
+    "version": "0.13.1-beta.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "waveterm",
-            "version": "0.13.1",
+            "version": "0.13.1-beta.1",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "workspaces": [
@@ -89,7 +89,7 @@
             "devDependencies": {
                 "@eslint/js": "^8.57.0",
                 "@rollup/plugin-node-resolve": "^16.0.3",
-                "@tailwindcss/vite": "^4.1.18",
+                "@tailwindcss/vite": "^4.1.17",
                 "@types/color": "^4.2.0",
                 "@types/css-tree": "^2",
                 "@types/debug": "^4",
@@ -119,7 +119,8 @@
                 "prettier-plugin-jsdoc": "^1.8.0",
                 "prettier-plugin-organize-imports": "^4.3.0",
                 "sass": "1.91.0",
-                "tailwindcss": "^4.1.18",
+                "sharp": "^0.34.5",
+                "tailwindcss": "^4.1.17",
                 "tailwindcss-animate": "^1.0.7",
                 "ts-node": "^10.9.2",
                 "tslib": "^2.8.1",
@@ -138,14 +139,14 @@
             "name": "waveterm-docs",
             "version": "0.0.0",
             "dependencies": {
-                "@docusaurus/core": "^3.9.2",
-                "@docusaurus/plugin-content-docs": "^3.9.2",
-                "@docusaurus/plugin-debug": "^3.9.2",
-                "@docusaurus/plugin-ideal-image": "^3.9.2",
-                "@docusaurus/plugin-sitemap": "^3.9.2",
-                "@docusaurus/plugin-svgr": "^3.9.2",
-                "@docusaurus/theme-classic": "^3.9.2",
-                "@docusaurus/theme-search-algolia": "^3.9.2",
+                "@docusaurus/core": "^3.7.0",
+                "@docusaurus/plugin-content-docs": "^3.7.0",
+                "@docusaurus/plugin-debug": "^3.7.0",
+                "@docusaurus/plugin-ideal-image": "^3.7.0",
+                "@docusaurus/plugin-sitemap": "^3.7.0",
+                "@docusaurus/plugin-svgr": "^3.7.0",
+                "@docusaurus/theme-classic": "^3.7.0",
+                "@docusaurus/theme-search-algolia": "^3.7.0",
                 "@mdx-js/react": "^3.0.0",
                 "@waveterm/docusaurus-og": "https://codeload.github.com/wavetermdev/docusaurus-og/tar.gz/2156619012b8970d922c1ef47789d2f14e47e283",
                 "clsx": "^2.1.1",
@@ -159,9 +160,9 @@
                 "sass": "^1.93.2"
             },
             "devDependencies": {
-                "@docusaurus/module-type-aliases": "3.9.2",
-                "@docusaurus/tsconfig": "3.9.2",
-                "@docusaurus/types": "3.9.2",
+                "@docusaurus/module-type-aliases": "3.7.0",
+                "@docusaurus/tsconfig": "3.7.0",
+                "@docusaurus/types": "3.7.0",
                 "@eslint/js": "^8.57.0",
                 "@mdx-js/typescript-plugin": "^0.1.3",
                 "@types/eslint": "^9.6.1",
@@ -192,6 +193,7 @@
             "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -212,6 +214,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -471,6 +474,7 @@
             "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.37.0.tgz",
             "integrity": "sha512-DAFVUvEg+u7jUs6BZiVz9zdaUebYULPiQ4LM2R4n8Nujzyj7BZzGr2DCd85ip4p/cx7nAZWKM8pLcGtkTRTdsg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@algolia/client-common": "5.37.0",
                 "@algolia/requester-browser-xhr": "5.37.0",
@@ -624,6 +628,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -2482,6 +2487,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -2504,6 +2510,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2613,6 +2620,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -3034,6 +3042,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -3785,6 +3794,42 @@
                 }
             }
         },
+        "node_modules/@docusaurus/bundler/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/bundler/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/@docusaurus/core": {
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
@@ -4028,17 +4073,17 @@
             }
         },
         "node_modules/@docusaurus/module-type-aliases": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
-            "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.7.0.tgz",
+            "integrity": "sha512-g7WdPqDNaqA60CmBrr0cORTrsOit77hbsTj7xE2l71YhBn79sxdm7WMK7wfhcaafkbpIh7jv5ef5TOpf1Xv9Lg==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.9.2",
+                "@docusaurus/types": "3.7.0",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
                 "@types/react-router-dom": "*",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@*",
                 "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
             },
             "peerDependencies": {
@@ -4080,11 +4125,48 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-content-blog/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/@docusaurus/plugin-content-docs": {
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
             "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@docusaurus/core": "3.9.2",
                 "@docusaurus/logger": "3.9.2",
@@ -4113,6 +4195,61 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
+            "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/types": "3.9.2",
+                "@types/history": "^4.7.11",
+                "@types/react": "*",
+                "@types/react-router-config": "*",
+                "@types/react-router-dom": "*",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "react-dom": "*"
+            }
+        },
+        "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/@docusaurus/plugin-content-pages": {
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.2.tgz",
@@ -4136,6 +4273,42 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-content-pages/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/@docusaurus/plugin-debug": {
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.2.tgz",
@@ -4155,6 +4328,42 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-debug/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-ideal-image": {
@@ -4185,6 +4394,28 @@
                 "jimp": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@docusaurus/plugin-ideal-image/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/@docusaurus/plugin-ideal-image/node_modules/detect-libc": {
@@ -4225,6 +4456,20 @@
                 "url": "https://opencollective.com/libvips"
             }
         },
+        "node_modules/@docusaurus/plugin-ideal-image/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/@docusaurus/plugin-sitemap": {
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.2.tgz",
@@ -4249,6 +4494,42 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-sitemap/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/@docusaurus/plugin-svgr": {
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.2.tgz",
@@ -4270,6 +4551,42 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-svgr/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/responsive-loader": {
@@ -4336,6 +4653,61 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
+            "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/types": "3.9.2",
+                "@types/history": "^4.7.11",
+                "@types/react": "*",
+                "@types/react-router-config": "*",
+                "@types/react-router-dom": "*",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "react-dom": "*"
+            }
+        },
+        "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/theme-classic/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/@docusaurus/theme-common": {
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
@@ -4362,6 +4734,61 @@
                 "@docusaurus/plugin-content-docs": "*",
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
+            "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/types": "3.9.2",
+                "@types/history": "^4.7.11",
+                "@types/react": "*",
+                "@types/react-router-config": "*",
+                "@types/react-router-dom": "*",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "react-dom": "*"
+            }
+        },
+        "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/theme-common/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/theme-search-algolia": {
@@ -4409,21 +4836,20 @@
             }
         },
         "node_modules/@docusaurus/tsconfig": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.9.2.tgz",
-            "integrity": "sha512-j6/Fp4Rlpxsc632cnRnl5HpOWeb6ZKssDj6/XzzAzVGXXfm9Eptx3rxCC+fDzySn9fHTS+CWJjPineCR1bB5WQ==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.7.0.tgz",
+            "integrity": "sha512-vRsyj3yUZCjscgfgcFYjIsTcAru/4h4YH2/XAE8Rs7wWdnng98PgWKvP5ovVc4rmRpRg2WChVW0uOy2xHDvDBQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@docusaurus/types": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.7.0.tgz",
+            "integrity": "sha512-kOmZg5RRqJfH31m+6ZpnwVbkqMJrPOG5t0IOl4i/+3ruXyNfWzZ0lVtVrD0u4ONc/0NOsS9sWYaxxWNkH1LdLQ==",
             "license": "MIT",
             "dependencies": {
                 "@mdx-js/mdx": "^3.0.0",
                 "@types/history": "^4.7.11",
-                "@types/mdast": "^4.0.2",
                 "@types/react": "*",
                 "commander": "^5.1.0",
                 "joi": "^17.9.2",
@@ -4496,6 +4922,42 @@
                 "node": ">=20.0"
             }
         },
+        "node_modules/@docusaurus/utils-common/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/utils-common/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/@docusaurus/utils-validation": {
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.2.tgz",
@@ -4513,6 +4975,42 @@
             },
             "engines": {
                 "node": ">=20.0"
+            }
+        },
+        "node_modules/@docusaurus/utils/node_modules/@docusaurus/types": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+            "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/mdx": "^3.0.0",
+                "@types/history": "^4.7.11",
+                "@types/mdast": "^4.0.2",
+                "@types/react": "*",
+                "commander": "^5.1.0",
+                "joi": "^17.9.2",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+                "utility-types": "^3.10.0",
+                "webpack": "^5.95.0",
+                "webpack-merge": "^5.9.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/utils/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@electron/asar": {
@@ -5025,7 +5523,6 @@
             "dev": true,
             "license": "BSD-2-Clause",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "cross-dirname": "^0.1.0",
                 "debug": "^4.3.4",
@@ -5041,13 +5538,12 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-            "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
+            "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -5730,10 +6226,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@img/colour": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+            "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+            "devOptional": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.3.tgz",
-            "integrity": "sha512-ryFMfvxxpQRsgZJqBd4wsttYQbCxsJksrv9Lw/v798JcQ8+w84mBWuXwl+TT0WJ/WrYOLaYpwQXi3sA9nTIaIg==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
             "cpu": [
                 "arm64"
             ],
@@ -5743,7 +6249,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -5751,13 +6256,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.2.0"
+                "@img/sharp-libvips-darwin-arm64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-darwin-x64": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.3.tgz",
-            "integrity": "sha512-yHpJYynROAj12TA6qil58hmPmAwxKKC7reUqtGLzsOHfP7/rniNGTL8tjWX6L3CTV4+5P4ypcS7Pp+7OB+8ihA==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
             "cpu": [
                 "x64"
             ],
@@ -5767,7 +6272,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -5775,13 +6279,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-x64": "1.2.0"
+                "@img/sharp-libvips-darwin-x64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.0.tgz",
-            "integrity": "sha512-sBZmpwmxqwlqG9ueWFXtockhsxefaV6O84BMOrhtg/YqbTaRdqDE7hxraVE3y6gVM4eExmfzW4a8el9ArLeEiQ==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
             "cpu": [
                 "arm64"
             ],
@@ -5791,15 +6295,14 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-darwin-x64": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.0.tgz",
-            "integrity": "sha512-M64XVuL94OgiNHa5/m2YvEQI5q2cl9d/wk0qFTDVXcYzi43lxuiFTftMR1tOnFQovVXNZJ5TURSDK2pNe9Yzqg==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
             "cpu": [
                 "x64"
             ],
@@ -5809,15 +6312,14 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.0.tgz",
-            "integrity": "sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
             "cpu": [
                 "arm"
             ],
@@ -5827,15 +6329,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm64": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.0.tgz",
-            "integrity": "sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
             "cpu": [
                 "arm64"
             ],
@@ -5845,15 +6346,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linux-ppc64": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.0.tgz",
-            "integrity": "sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
             "cpu": [
                 "ppc64"
             ],
@@ -5863,15 +6363,31 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linux-s390x": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.0.tgz",
-            "integrity": "sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
             "cpu": [
                 "s390x"
             ],
@@ -5881,15 +6397,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.0.tgz",
-            "integrity": "sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
             "cpu": [
                 "x64"
             ],
@@ -5899,15 +6414,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.0.tgz",
-            "integrity": "sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
             "cpu": [
                 "arm64"
             ],
@@ -5917,15 +6431,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.0.tgz",
-            "integrity": "sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
             "cpu": [
                 "x64"
             ],
@@ -5935,15 +6448,14 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-linux-arm": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.3.tgz",
-            "integrity": "sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
             "cpu": [
                 "arm"
             ],
@@ -5953,7 +6465,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -5961,13 +6472,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm": "1.2.0"
+                "@img/sharp-libvips-linux-arm": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linux-arm64": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.3.tgz",
-            "integrity": "sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
             "cpu": [
                 "arm64"
             ],
@@ -5977,7 +6488,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -5985,13 +6495,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm64": "1.2.0"
+                "@img/sharp-libvips-linux-arm64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linux-ppc64": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.3.tgz",
-            "integrity": "sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
             "cpu": [
                 "ppc64"
             ],
@@ -6001,7 +6511,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -6009,13 +6518,36 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-ppc64": "1.2.0"
+                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linux-s390x": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.3.tgz",
-            "integrity": "sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
             "cpu": [
                 "s390x"
             ],
@@ -6025,7 +6557,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -6033,13 +6564,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-s390x": "1.2.0"
+                "@img/sharp-libvips-linux-s390x": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linux-x64": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.3.tgz",
-            "integrity": "sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
             "cpu": [
                 "x64"
             ],
@@ -6049,7 +6580,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -6057,13 +6587,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.2.0"
+                "@img/sharp-libvips-linux-x64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linuxmusl-arm64": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.3.tgz",
-            "integrity": "sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
             "cpu": [
                 "arm64"
             ],
@@ -6073,7 +6603,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -6081,13 +6610,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.0"
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.3.tgz",
-            "integrity": "sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
             "cpu": [
                 "x64"
             ],
@@ -6097,7 +6626,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -6105,22 +6633,21 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.0"
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-wasm32": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.3.tgz",
-            "integrity": "sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
             "cpu": [
                 "wasm32"
             ],
             "dev": true,
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
-                "@emnapi/runtime": "^1.4.4"
+                "@emnapi/runtime": "^1.7.0"
             },
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -6130,9 +6657,9 @@
             }
         },
         "node_modules/@img/sharp-win32-arm64": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.3.tgz",
-            "integrity": "sha512-MjnHPnbqMXNC2UgeLJtX4XqoVHHlZNd+nPt1kRPmj63wURegwBhZlApELdtxM2OIZDRv/DFtLcNhVbd1z8GYXQ==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
             "cpu": [
                 "arm64"
             ],
@@ -6142,7 +6669,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -6151,9 +6677,9 @@
             }
         },
         "node_modules/@img/sharp-win32-ia32": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.3.tgz",
-            "integrity": "sha512-xuCdhH44WxuXgOM714hn4amodJMZl3OEvf0GVTm0BEyMeA2to+8HEdRPShH0SLYptJY1uBw+SCFP9WVQi1Q/cw==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
             "cpu": [
                 "ia32"
             ],
@@ -6163,7 +6689,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -6172,9 +6697,9 @@
             }
         },
         "node_modules/@img/sharp-win32-x64": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.3.tgz",
-            "integrity": "sha512-OWwz05d++TxzLEv4VnsTz5CmZ6mI6S05sfQGEMrNrQcOEERbX46332IvE7pO/EUiw7jUrrS40z/M7kPyjfl04g==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
             "cpu": [
                 "x64"
             ],
@@ -6184,7 +6709,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -6571,6 +7095,7 @@
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
             "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdx": "^2.0.0"
             },
@@ -8371,6 +8896,7 @@
             "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -8765,7 +9291,8 @@
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/@table-nav/core/-/core-0.0.7.tgz",
             "integrity": "sha512-pCh18jHDRe3tw9sJZXfKi4cSD6VjHbn40CYdqhp5X91SIX7rakDEQAsTx6F7Fv9TUv265l+5rUDcYNaJ0N0cqQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@table-nav/react": {
             "version": "0.0.7",
@@ -8777,28 +9304,28 @@
             }
         },
         "node_modules/@tailwindcss/cli": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.1.18.tgz",
-            "integrity": "sha512-sMZ+lZbDyxwjD2E0L7oRUjJ01Ffjtme5OtjvvnC+cV4CEDcbqzbp25TCpxHj6kWLU9+DlqJOiNgSOgctC2aZmg==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.1.17.tgz",
+            "integrity": "sha512-jUIxcyUNlCC2aNPnyPEWU/L2/ik3pB4fF3auKGXr8AvN3T3OFESVctFKOBoPZQaZJIeUpPn1uCLp0MRxuek8gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@parcel/watcher": "^2.5.1",
-                "@tailwindcss/node": "4.1.18",
-                "@tailwindcss/oxide": "4.1.18",
+                "@tailwindcss/node": "4.1.17",
+                "@tailwindcss/oxide": "4.1.17",
                 "enhanced-resolve": "^5.18.3",
                 "mri": "^1.2.0",
                 "picocolors": "^1.1.1",
-                "tailwindcss": "4.1.18"
+                "tailwindcss": "4.1.17"
             },
             "bin": {
                 "tailwindcss": "dist/index.mjs"
             }
         },
         "node_modules/@tailwindcss/node": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
-            "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.17.tgz",
+            "integrity": "sha512-csIkHIgLb3JisEFQ0vxr2Y57GUNYh447C8xzwj89U/8fdW8LhProdxvnVH6U8M2Y73QKiTIH+LWbK3V2BBZsAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8808,7 +9335,7 @@
                 "lightningcss": "1.30.2",
                 "magic-string": "^0.30.21",
                 "source-map-js": "^1.2.1",
-                "tailwindcss": "4.1.18"
+                "tailwindcss": "4.1.17"
             }
         },
         "node_modules/@tailwindcss/node/node_modules/jiti": {
@@ -8822,33 +9349,33 @@
             }
         },
         "node_modules/@tailwindcss/oxide": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
-            "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.17.tgz",
+            "integrity": "sha512-F0F7d01fmkQhsTjXezGBLdrl1KresJTcI3DB8EkScCldyKp3Msz4hub4uyYaVnk88BAS1g5DQjjF6F5qczheLA==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
             },
             "optionalDependencies": {
-                "@tailwindcss/oxide-android-arm64": "4.1.18",
-                "@tailwindcss/oxide-darwin-arm64": "4.1.18",
-                "@tailwindcss/oxide-darwin-x64": "4.1.18",
-                "@tailwindcss/oxide-freebsd-x64": "4.1.18",
-                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
-                "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
-                "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
-                "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
-                "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
-                "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
-                "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
-                "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+                "@tailwindcss/oxide-android-arm64": "4.1.17",
+                "@tailwindcss/oxide-darwin-arm64": "4.1.17",
+                "@tailwindcss/oxide-darwin-x64": "4.1.17",
+                "@tailwindcss/oxide-freebsd-x64": "4.1.17",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.17",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.1.17",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.1.17",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.1.17",
+                "@tailwindcss/oxide-linux-x64-musl": "4.1.17",
+                "@tailwindcss/oxide-wasm32-wasi": "4.1.17",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.1.17",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.1.17"
             }
         },
         "node_modules/@tailwindcss/oxide-android-arm64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
-            "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.17.tgz",
+            "integrity": "sha512-BMqpkJHgOZ5z78qqiGE6ZIRExyaHyuxjgrJ6eBO5+hfrfGkuya0lYfw8fRHG77gdTjWkNWEEm+qeG2cDMxArLQ==",
             "cpu": [
                 "arm64"
             ],
@@ -8863,9 +9390,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-arm64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
-            "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.17.tgz",
+            "integrity": "sha512-EquyumkQweUBNk1zGEU/wfZo2qkp/nQKRZM8bUYO0J+Lums5+wl2CcG1f9BgAjn/u9pJzdYddHWBiFXJTcxmOg==",
             "cpu": [
                 "arm64"
             ],
@@ -8880,9 +9407,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-x64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
-            "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.17.tgz",
+            "integrity": "sha512-gdhEPLzke2Pog8s12oADwYu0IAw04Y2tlmgVzIN0+046ytcgx8uZmCzEg4VcQh+AHKiS7xaL8kGo/QTiNEGRog==",
             "cpu": [
                 "x64"
             ],
@@ -8897,9 +9424,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-freebsd-x64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
-            "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.17.tgz",
+            "integrity": "sha512-hxGS81KskMxML9DXsaXT1H0DyA+ZBIbyG/sSAjWNe2EDl7TkPOBI42GBV3u38itzGUOmFfCzk1iAjDXds8Oh0g==",
             "cpu": [
                 "x64"
             ],
@@ -8914,9 +9441,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
-            "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.17.tgz",
+            "integrity": "sha512-k7jWk5E3ldAdw0cNglhjSgv501u7yrMf8oeZ0cElhxU6Y2o7f8yqelOp3fhf7evjIS6ujTI3U8pKUXV2I4iXHQ==",
             "cpu": [
                 "arm"
             ],
@@ -8931,9 +9458,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
-            "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.17.tgz",
+            "integrity": "sha512-HVDOm/mxK6+TbARwdW17WrgDYEGzmoYayrCgmLEw7FxTPLcp/glBisuyWkFz/jb7ZfiAXAXUACfyItn+nTgsdQ==",
             "cpu": [
                 "arm64"
             ],
@@ -8948,9 +9475,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
-            "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.17.tgz",
+            "integrity": "sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==",
             "cpu": [
                 "arm64"
             ],
@@ -8965,9 +9492,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
-            "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.17.tgz",
+            "integrity": "sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==",
             "cpu": [
                 "x64"
             ],
@@ -8982,9 +9509,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
-            "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.17.tgz",
+            "integrity": "sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==",
             "cpu": [
                 "x64"
             ],
@@ -8999,9 +9526,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
-            "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.17.tgz",
+            "integrity": "sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==",
             "bundleDependencies": [
                 "@napi-rs/wasm-runtime",
                 "@emnapi/core",
@@ -9017,10 +9544,10 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1",
+                "@emnapi/core": "^1.6.0",
+                "@emnapi/runtime": "^1.6.0",
                 "@emnapi/wasi-threads": "^1.1.0",
-                "@napi-rs/wasm-runtime": "^1.1.0",
+                "@napi-rs/wasm-runtime": "^1.0.7",
                 "@tybys/wasm-util": "^0.10.1",
                 "tslib": "^2.4.0"
             },
@@ -9029,7 +9556,7 @@
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.7.1",
+            "version": "1.6.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9040,7 +9567,7 @@
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.7.1",
+            "version": "1.6.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9060,14 +9587,14 @@
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.0",
+            "version": "1.0.7",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1",
+                "@emnapi/core": "^1.5.0",
+                "@emnapi/runtime": "^1.5.0",
                 "@tybys/wasm-util": "^0.10.1"
             }
         },
@@ -9089,9 +9616,9 @@
             "optional": true
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
-            "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.17.tgz",
+            "integrity": "sha512-JU5AHr7gKbZlOGvMdb4722/0aYbU+tN6lv1kONx0JK2cGsh7g148zVWLM0IKR3NeKLv+L90chBVYcJ8uJWbC9A==",
             "cpu": [
                 "arm64"
             ],
@@ -9106,9 +9633,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
-            "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.17.tgz",
+            "integrity": "sha512-SKWM4waLuqx0IH+FMDUw6R66Hu4OuTALFgnleKbqhgGU30DY20NORZMZUKgLRjQXNN2TLzKvh48QXTig4h4bGw==",
             "cpu": [
                 "x64"
             ],
@@ -9123,15 +9650,15 @@
             }
         },
         "node_modules/@tailwindcss/vite": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.18.tgz",
-            "integrity": "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.17.tgz",
+            "integrity": "sha512-4+9w8ZHOiGnpcGI6z1TVVfWaX/koK7fKeSYF3qlYg2xpBtbteP2ddBxiarL+HVgfSJGeK5RIxRQmKm4rTJJAwA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@tailwindcss/node": "4.1.18",
-                "@tailwindcss/oxide": "4.1.18",
-                "tailwindcss": "4.1.18"
+                "@tailwindcss/node": "4.1.17",
+                "@tailwindcss/oxide": "4.1.17",
+                "tailwindcss": "4.1.17"
             },
             "peerDependencies": {
                 "vite": "^5.2.0 || ^6 || ^7"
@@ -9800,6 +10327,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.2.tgz",
             "integrity": "sha512-lif9hF9afNk39jMUVYk5eyYEojLZQqaYX61LfuwUJJ1+qiQbh7jVaZXskYgzyjAIFDFQRf5Sd6MVM7EyXkfiRw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -9814,9 +10342,9 @@
             }
         },
         "node_modules/@types/papaparse": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
-            "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.1.tgz",
+            "integrity": "sha512-esEO+VISsLIyE+JZBmb89NzsYYbpwV8lmv2rPo6oX5y9KhBaIP7hhHgjuTut54qjdKVMufTEcrh5fUl9+58huw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9875,6 +10403,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
             "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.0.2"
             }
@@ -10170,6 +10699,7 @@
             "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.49.0",
                 "@typescript-eslint/types": "8.49.0",
@@ -10844,7 +11374,8 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
             "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
@@ -10899,6 +11430,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -11007,6 +11539,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -11071,6 +11604,7 @@
             "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.37.0.tgz",
             "integrity": "sha512-y7gau/ZOQDqoInTQp0IwTOjkrHc4Aq4R8JgpmCleFwiLl+PbN2DMWoDUWZnrK8AhNJwT++dn28Bt4NZYNLAmuA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@algolia/abtesting": "1.3.0",
                 "@algolia/client-abtesting": "5.37.0",
@@ -11901,6 +12435,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -12484,6 +13019,7 @@
             "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
             "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@chevrotain/cst-dts-gen": "11.0.3",
                 "@chevrotain/gast": "11.0.3",
@@ -13366,8 +13902,7 @@
             "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -13535,6 +14070,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -13865,6 +14401,7 @@
             "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
             "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -14274,6 +14811,7 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14719,6 +15257,7 @@
             "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "app-builder-lib": "26.0.12",
                 "builder-util": "26.0.11",
@@ -15194,7 +15733,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@electron/asar": "^3.2.1",
                 "debug": "^4.1.1",
@@ -15215,7 +15753,6 @@
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -15231,7 +15768,6 @@
             "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -15242,7 +15778,6 @@
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -15556,6 +16091,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -17167,9 +17703,9 @@
             }
         },
         "node_modules/gray-matter/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -20480,6 +21016,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/debug": "^4.0.0",
                 "debug": "^4.0.0",
@@ -22878,7 +23415,8 @@
             "version": "0.52.2",
             "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
             "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/monaco-languageserver-types": {
             "version": "0.4.0",
@@ -23563,7 +24101,8 @@
             "version": "2.12.0",
             "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.12.0.tgz",
             "integrity": "sha512-mWJ5MOkcZ/ljHwfLw8+bN0V9ziGCoNoqULcp994j5DTGNQvnkWKWkA7rnO29Kyew5AoHxUnJ4Ndqfcl0HSQjXg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/overlayscrollbars-react": {
             "version": "0.5.6",
@@ -24343,6 +24882,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -25246,6 +25786,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -25845,7 +26386,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "commander": "^9.4.0"
             },
@@ -25863,7 +26403,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": "^12.20.0 || >=14"
             }
@@ -25922,9 +26461,9 @@
             }
         },
         "node_modules/prebuild-install/node_modules/tar-fs": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-            "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+            "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
             "license": "MIT",
             "dependencies": {
                 "chownr": "^1.1.1",
@@ -25964,6 +26503,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
             "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -26115,6 +26655,7 @@
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -26345,6 +26886,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
             "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -26393,6 +26935,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
             "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -26482,6 +27025,7 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
             "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/react": "*"
             },
@@ -26547,6 +27091,7 @@
             "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
             "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.13",
                 "history": "^4.9.0",
@@ -28371,6 +28916,7 @@
             "integrity": "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -28549,6 +29095,7 @@
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.91.0.tgz",
             "integrity": "sha512-aFOZHGf+ur+bp1bCHZ+u8otKGh77ZtmFyXDo4tlYvT7PWql41Kwd8wdkPqhhT+h2879IVblcHFglIMofsFd1EA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "immutable": "^5.0.2",
@@ -28667,6 +29214,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -29059,17 +29607,17 @@
             "license": "MIT"
         },
         "node_modules/sharp": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.3.tgz",
-            "integrity": "sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
-            "optional": true,
             "peer": true,
             "dependencies": {
-                "color": "^4.2.3",
-                "detect-libc": "^2.0.4",
-                "semver": "^7.7.2"
+                "@img/colour": "^1.0.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.7.3"
             },
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -29078,37 +29626,38 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.34.3",
-                "@img/sharp-darwin-x64": "0.34.3",
-                "@img/sharp-libvips-darwin-arm64": "1.2.0",
-                "@img/sharp-libvips-darwin-x64": "1.2.0",
-                "@img/sharp-libvips-linux-arm": "1.2.0",
-                "@img/sharp-libvips-linux-arm64": "1.2.0",
-                "@img/sharp-libvips-linux-ppc64": "1.2.0",
-                "@img/sharp-libvips-linux-s390x": "1.2.0",
-                "@img/sharp-libvips-linux-x64": "1.2.0",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.0",
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.0",
-                "@img/sharp-linux-arm": "0.34.3",
-                "@img/sharp-linux-arm64": "0.34.3",
-                "@img/sharp-linux-ppc64": "0.34.3",
-                "@img/sharp-linux-s390x": "0.34.3",
-                "@img/sharp-linux-x64": "0.34.3",
-                "@img/sharp-linuxmusl-arm64": "0.34.3",
-                "@img/sharp-linuxmusl-x64": "0.34.3",
-                "@img/sharp-wasm32": "0.34.3",
-                "@img/sharp-win32-arm64": "0.34.3",
-                "@img/sharp-win32-ia32": "0.34.3",
-                "@img/sharp-win32-x64": "0.34.3"
+                "@img/sharp-darwin-arm64": "0.34.5",
+                "@img/sharp-darwin-x64": "0.34.5",
+                "@img/sharp-libvips-darwin-arm64": "1.2.4",
+                "@img/sharp-libvips-darwin-x64": "1.2.4",
+                "@img/sharp-libvips-linux-arm": "1.2.4",
+                "@img/sharp-libvips-linux-arm64": "1.2.4",
+                "@img/sharp-libvips-linux-ppc64": "1.2.4",
+                "@img/sharp-libvips-linux-riscv64": "1.2.4",
+                "@img/sharp-libvips-linux-s390x": "1.2.4",
+                "@img/sharp-libvips-linux-x64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+                "@img/sharp-linux-arm": "0.34.5",
+                "@img/sharp-linux-arm64": "0.34.5",
+                "@img/sharp-linux-ppc64": "0.34.5",
+                "@img/sharp-linux-riscv64": "0.34.5",
+                "@img/sharp-linux-s390x": "0.34.5",
+                "@img/sharp-linux-x64": "0.34.5",
+                "@img/sharp-linuxmusl-arm64": "0.34.5",
+                "@img/sharp-linuxmusl-x64": "0.34.5",
+                "@img/sharp-wasm32": "0.34.5",
+                "@img/sharp-win32-arm64": "0.34.5",
+                "@img/sharp-win32-ia32": "0.34.5",
+                "@img/sharp-win32-x64": "0.34.5"
             }
         },
         "node_modules/sharp/node_modules/detect-libc": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-            "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "devOptional": true,
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -30026,7 +30575,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "commander": "^11.1.0",
                 "css-select": "^5.1.0",
@@ -30054,7 +30602,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=16"
             }
@@ -30105,11 +30652,12 @@
             }
         },
         "node_modules/tailwindcss": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-            "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+            "version": "4.1.17",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
+            "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tailwindcss-animate": {
             "version": "1.0.7",
@@ -30135,9 +30683,9 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-            "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+            "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
             "license": "MIT",
             "dependencies": {
                 "pump": "^3.0.0",
@@ -30165,7 +30713,6 @@
             "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "mkdirp": "^0.5.1",
                 "rimraf": "~2.6.2"
@@ -30207,7 +30754,6 @@
             "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -30229,7 +30775,6 @@
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -30243,7 +30788,6 @@
             "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "minimist": "^1.2.6"
             },
@@ -30258,7 +30802,6 @@
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -30756,7 +31299,8 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/tsunami-frontend": {
             "resolved": "tsunami/frontend",
@@ -31337,6 +31881,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -31435,6 +31980,7 @@
             "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
             "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "bail": "^2.0.0",
@@ -32352,6 +32898,7 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -32608,6 +33155,7 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -32850,6 +33398,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
             "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -33772,12 +34321,12 @@
                 "tailwind-merge": "^3.3.1"
             },
             "devDependencies": {
-                "@tailwindcss/cli": "^4.1.18",
-                "@tailwindcss/vite": "^4.1.18",
+                "@tailwindcss/cli": "^4.1.17",
+                "@tailwindcss/vite": "^4.1.17",
                 "@types/react": "^19",
                 "@types/react-dom": "^19",
                 "@vitejs/plugin-react-swc": "^4.2.2",
-                "tailwindcss": "^4.1.18",
+                "tailwindcss": "^4.1.17",
                 "typescript": "^5.9.3",
                 "vite": "^6.4.1"
             }
@@ -33875,6 +34424,7 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
             "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
                 "use-sync-external-store": "^1.4.0"
@@ -33924,7 +34474,8 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "tsunami/frontend/node_modules/redux-thunk": {
             "version": "3.1.0",


### PR DESCRIPTION
## Summary
Fixes issue where TUI applications (vim, htop, opencode, etc.) would lose terminal state when switching between workspaces, causing inability to scroll and display corruption.

## Problem
When switching workspaces, all tab views were being destroyed and recreated. This caused:
- Loss of alternate screen buffer mode state
- Terminal display corruption with TUI apps
- Inability to scroll in terminals after returning to workspace
- Running TUI applications to appear broken

## Root Cause
The switchworkspace operation in emain/emain-window.ts called removeAllChildViews() which destroyed all tab views including their xterm.js terminal instances. When recreated from cache, the terminal state was not properly restored.

## Solution
Cache tab views across workspace switches instead of destroying them:
- Tab views are positioned off-screen but kept alive
- Terminal state fully preserved (buffer modes, scrollback, cursor position)
- Views only destroyed when tab explicitly closed or window closes
- Memory-efficient: ~1-5MB per cached terminal

## Changes
- Added allTabViewsCache map to preserve tab views during workspace switches
- Modified workspace switch logic to cache instead of destroy
- Added cache cleanup when tabs are explicitly closed
- Cache cleared when window closes to prevent memory leaks

## Testing
1. Run a TUI app (vim, htop, opencode) in workspace A
2. Switch to workspace B
3. Switch back to workspace A (even after hours)
4. Terminal state is preserved, scrolling works correctly

## Behavior Match
Now matches macOS Terminal, iTerm2, and other terminal emulators where terminals remain active across tab/workspace switches.

