### PR TITLE
Fix StreamCancelFn type definition

### DIFF
--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -373,7 +373,7 @@ type RpcOpts struct {
 	NoResponse bool   `json:"noresponse,omitempty"`
 	Route      string `json:"route,omitempty"`
 
-	StreamCancelFn func() `json:"-"` // this is an *output* parameter, set by the handler
+	StreamCancelFn func(context.Context) error `json:"-"` // this is an *output* parameter, set by the handler
 }
 
 const (


### PR DESCRIPTION
## Summary
Fixes build errors introduced in #2709 by correcting the `StreamCancelFn` type definition.

## Build Errors
```
pkg/wshrpc/wshclient/wshclientutil.go:66:24: cannot use func(ctx context.Context) error 
as func() value in assignment

pkg/web/web.go:255:59: cannot use rpcOpts.StreamCancelFn (variable of type func()) 
as func(context.Context) error value in argument
```

## Root Cause
`StreamCancelFn` was defined as `func()` in `wshrpctypes.go:376`, but is actually used throughout the codebase as `func(context.Context) error`:
- In `web.go:276`: `streamCancelFn(ctx)` - called with context parameter
- In `wshclientutil.go:67`: Returns error from `reqHandler.SendCancel(ctx)`

## Fix
Correct the type definition to match actual usage:
```go
// Before:
StreamCancelFn func() `json:"-"`

// After:
StreamCancelFn func(context.Context) error `json:"-"`
```

## Files Changed
- `pkg/wshrpc/wshrpctypes.go` - Corrected type definition

## Testing
Build now succeeds without type errors.

## Related
- Introduced in: #2709
- Comment: https://github.com/wavetermdev/waveterm/pull/2709#issuecomment-3691587427