### PR TITLE
add OSC 52 clipboard support for terminal applications

### DIFF
--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -286,6 +286,7 @@ const TerminalView = ({ blockId, model }: ViewComponentProps<TermViewModel>) => 
                 keydownHandler: model.handleTerminalKeydown.bind(model),
                 useWebGl: !termSettings?.["term:disablewebgl"],
                 sendDataHandler: model.sendDataToController.bind(model),
+                nodeModel: model.nodeModel,
             }
         );
         (window as any).term = termWrap;


### PR DESCRIPTION
  ## Summary
  - Implements OSC 52 escape sequence handling for clipboard operations
  - Allows terminal apps like zellij, tmux, and neovim to copy to system clipboard
  - Fixes #2140

  ## Features
  - Write-only clipboard access (read queries blocked for security)
  - 75KB size limit matching common terminal implementations
  - Base64 whitespace handling per RFC 4648

  ## Additional Fix
  Also fixes StreamCancelFn type mismatch from #2709 where the implementations were updated but the type definition was not.

 - Tested with zellij mouse selection