### PR TITLE
fix(ssh): SSH agent IdentitiesOnly logic and public key parsing

### DIFF
--- a/pkg/blockcontroller/shellcontroller.go
+++ b/pkg/blockcontroller/shellcontroller.go
@@ -383,7 +383,7 @@ func (bc *ShellController) setupAndStartShellProcess(logCtx context.Context, rc 
 	if err != nil {
 		return nil, err
 	}
-	blocklogger.Infof(logCtx, "[conndebug] remoteName: %q, connType: %s, wshEnabled: %v, shell: %q, shellType: %s\n", remoteName, connUnion.ConnType, connUnion.WshEnabled, connUnion.ShellPath, connUnion.ShellType)
+	blocklogger.Infof(logCtx, "[conndebug] remoteName: %q, connType: %s, wshEnabled: %v, shell: %q, shellType: %s\n", remote.MaskString(remoteName), connUnion.ConnType, connUnion.WshEnabled, remote.MaskString(connUnion.ShellPath), connUnion.ShellType)
 	var cmdStr string
 	var cmdOpts shellexec.CommandOptsType
 	if bc.ControllerType == BlockController_Shell {

--- a/pkg/remote/conncontroller/conncontroller.go
+++ b/pkg/remote/conncontroller/conncontroller.go
@@ -550,7 +550,7 @@ func (conn *SSHConn) Connect(ctx context.Context, connFlags *wconfig.ConnKeyword
 		conn.Infof(ctx, "cannot connect to %q when status is %q\n", conn.GetName(), conn.GetStatus())
 		return fmt.Errorf("cannot connect to %q when status is %q", conn.GetName(), conn.GetStatus())
 	}
-	conn.Infof(ctx, "trying to connect to %q...\n", conn.GetName())
+	conn.Infof(ctx, "trying to connect to %q...\n", remote.MaskString(conn.GetName()))
 	conn.FireConnChangeEvent()
 	err := conn.connectInternal(ctx, connFlags)
 	conn.WithLock(func() {
@@ -748,7 +748,7 @@ func (conn *SSHConn) persistWshInstalled(ctx context.Context, result WshCheckRes
 
 // returns (connect-error)
 func (conn *SSHConn) connectInternal(ctx context.Context, connFlags *wconfig.ConnKeywords) error {
-	conn.Infof(ctx, "connectInternal %s\n", conn.GetName())
+	conn.Infof(ctx, "connectInternal %s\n", remote.MaskString(conn.GetName()))
 	client, _, err := remote.ConnectToClient(ctx, conn.Opts, nil, 0, connFlags)
 	if err != nil {
 		conn.Infof(ctx, "ERROR ConnectToClient: %s\n", remote.SimpleMessageFromPossibleConnectionError(err))
@@ -765,7 +765,7 @@ func (conn *SSHConn) connectInternal(ctx context.Context, connFlags *wconfig.Con
 		conn.waitForDisconnect()
 	}()
 	fmtAddr := knownhosts.Normalize(fmt.Sprintf("%s@%s", client.User(), client.RemoteAddr().String()))
-	conn.Infof(ctx, "normalized knownhosts address: %s\n", fmtAddr)
+	conn.Infof(ctx, "normalized knownhosts address: %s\n", remote.MaskString(fmtAddr))
 	clientDisplayName := fmt.Sprintf("%s (%s)", conn.GetName(), fmtAddr)
 	wshResult := conn.tryEnableWsh(ctx, clientDisplayName)
 	if !wshResult.WshEnabled {

--- a/pkg/remote/sshclient.go
+++ b/pkg/remote/sshclient.go
@@ -162,7 +162,12 @@ func maskIdentityFile(path string) string {
 		if len(parts) >= 3 {
 			maskedUsername := MaskString(parts[2])
 			if len(parts) >= 4 {
-				maskedDir = "/home/" + maskedUsername + "/" + filepath.Dir(parts[3])
+				subDir := filepath.Dir(parts[3])
+				if subDir == "." {
+					maskedDir = "/home/" + maskedUsername
+				} else {
+					maskedDir = "/home/" + maskedUsername + "/" + subDir
+				}
 			} else {
 				maskedDir = "/home/" + maskedUsername
 			}
@@ -176,7 +181,12 @@ func maskIdentityFile(path string) string {
 		if len(parts) >= 1 {
 			maskedUsername := MaskString(parts[0])
 			if len(parts) >= 2 {
-				maskedDir = prefix + "/Users/" + maskedUsername + "/" + filepath.Dir(parts[1])
+				subDir := filepath.Dir(parts[1])
+				if subDir == "." {
+					maskedDir = prefix + "/Users/" + maskedUsername
+				} else {
+					maskedDir = prefix + "/Users/" + maskedUsername + "/" + subDir
+				}
 			} else {
 				maskedDir = prefix + "/Users/" + maskedUsername
 			}

--- a/pkg/remote/sshclient.go
+++ b/pkg/remote/sshclient.go
@@ -74,9 +74,9 @@ type ConnectionError struct {
 
 func (ce ConnectionError) Error() string {
 	if ce.CurrentClient == nil {
-		return fmt.Sprintf("Connecting to %s, Error: %v", ce.NextOpts, ce.Err)
+		return fmt.Sprintf("Connecting to %s, Error: %v", MaskString(ce.NextOpts.String()), ce.Err)
 	}
-	return fmt.Sprintf("Connecting from %v to %s (jump number %d), Error: %v", ce.CurrentClient, ce.NextOpts, ce.JumpNum, ce.Err)
+	return fmt.Sprintf("Connecting from client to %s (jump number %d), Error: %v", MaskString(ce.NextOpts.String()), ce.JumpNum, ce.Err)
 }
 
 func SimpleMessageFromPossibleConnectionError(err error) string {
@@ -91,37 +91,102 @@ func SimpleMessageFromPossibleConnectionError(err error) string {
 
 // logSSHKeywords logs SSH configuration in a sanitized way (DEBUG level)
 func logSSHKeywords(ctx context.Context, sshKeywords *wconfig.ConnKeywords) {
-	blocklogger.Debugf(ctx, "[ssh-config] User: %s\n", utilfn.SafeDeref(sshKeywords.SshUser))
-	blocklogger.Debugf(ctx, "[ssh-config] HostName: %s\n", maskHostName(utilfn.SafeDeref(sshKeywords.SshHostName)))
+	blocklogger.Debugf(ctx, "[ssh-config] User: %s\n", MaskString(utilfn.SafeDeref(sshKeywords.SshUser)))
+	blocklogger.Debugf(ctx, "[ssh-config] HostName: %s\n", MaskString(utilfn.SafeDeref(sshKeywords.SshHostName)))
 	blocklogger.Debugf(ctx, "[ssh-config] Port: %s\n", utilfn.SafeDeref(sshKeywords.SshPort))
-	blocklogger.Debugf(ctx, "[ssh-config] IdentityAgent: %s\n", utilfn.SafeDeref(sshKeywords.SshIdentityAgent))
+	blocklogger.Debugf(ctx, "[ssh-config] IdentityAgent: %s\n", filepath.Base(utilfn.SafeDeref(sshKeywords.SshIdentityAgent)))
 	blocklogger.Debugf(ctx, "[ssh-config] IdentitiesOnly: %v\n", utilfn.SafeDeref(sshKeywords.SshIdentitiesOnly))
 	blocklogger.Debugf(ctx, "[ssh-config] IdentityFile count: %d\n", len(sshKeywords.SshIdentityFile))
-	// Only log file basename, not full path for privacy
+	// Log masked identity file paths for privacy
 	for i, f := range sshKeywords.SshIdentityFile {
-		blocklogger.Debugf(ctx, "[ssh-config]   IdentityFile[%d]: %s\n", i, filepath.Base(f))
+		blocklogger.Debugf(ctx, "[ssh-config]   IdentityFile[%d]: %s\n", i, maskIdentityFile(f))
 	}
 	blocklogger.Debugf(ctx, "[ssh-config] PubkeyAuthentication: %v\n", utilfn.SafeDeref(sshKeywords.SshPubkeyAuthentication))
 	blocklogger.Debugf(ctx, "[ssh-config] PasswordAuthentication: %v\n", utilfn.SafeDeref(sshKeywords.SshPasswordAuthentication))
 	blocklogger.Debugf(ctx, "[ssh-config] KbdInteractiveAuthentication: %v\n", utilfn.SafeDeref(sshKeywords.SshKbdInteractiveAuthentication))
 	blocklogger.Debugf(ctx, "[ssh-config] PreferredAuthentications: %v\n", sshKeywords.SshPreferredAuthentications)
 	blocklogger.Debugf(ctx, "[ssh-config] AddKeysToAgent: %v\n", utilfn.SafeDeref(sshKeywords.SshAddKeysToAgent))
-	blocklogger.Debugf(ctx, "[ssh-config] ProxyJump: %v\n", sshKeywords.SshProxyJump)
+	blocklogger.Debugf(ctx, "[ssh-config] ProxyJump count: %d\n", len(sshKeywords.SshProxyJump))
 	// Note: do not log PasswordSecretName value, only indicate if configured
 	if sshKeywords.SshPasswordSecretName != nil && *sshKeywords.SshPasswordSecretName != "" {
 		blocklogger.Debugf(ctx, "[ssh-config] PasswordSecretName: <configured>\n")
 	}
 }
 
-// maskHostName masks hostname for privacy, showing only first 3 and last 3 characters
-func maskHostName(hostname string) string {
-	if hostname == "" {
+// MaskString masks a string for privacy, showing only first 3 and last 3 characters.
+// Uses rune-based slicing to properly handle multi-byte UTF-8 characters.
+func MaskString(s string) string {
+	if s == "" {
 		return "<empty>"
 	}
-	if len(hostname) <= 6 {
+	runes := []rune(s)
+	if len(runes) <= 6 {
 		return "***"
 	}
-	return hostname[:3] + "***" + hostname[len(hostname)-3:]
+	return string(runes[:3]) + "***" + string(runes[len(runes)-3:])
+}
+
+// maskIdentityFile masks an identity file path for privacy.
+// It masks the username in home directory paths (/home/user/ or C:\Users\user\)
+// and masks the filename while preserving .pub suffix if present.
+func maskIdentityFile(path string) string {
+	if path == "" {
+		return "<empty>"
+	}
+
+	// Normalize path separators for consistent handling
+	normalizedPath := filepath.ToSlash(path)
+
+	// Extract directory and filename
+	dir := filepath.Dir(path)
+	filename := filepath.Base(path)
+
+	// Check for .pub suffix
+	hasPubSuffix := strings.HasSuffix(filename, ".pub")
+	if hasPubSuffix {
+		filename = strings.TrimSuffix(filename, ".pub")
+	}
+
+	// Mask the filename
+	maskedFilename := MaskString(filename)
+	if hasPubSuffix {
+		maskedFilename += ".pub"
+	}
+
+	// Mask username in home directory paths
+	// Unix: /home/username/... or /Users/username/...
+	// Windows: C:\Users\username\... (normalized to C:/Users/username/...)
+	maskedDir := dir
+	if strings.HasPrefix(normalizedPath, "/home/") {
+		parts := strings.SplitN(normalizedPath, "/", 4) // ["", "home", "username", "rest..."]
+		if len(parts) >= 3 {
+			maskedUsername := MaskString(parts[2])
+			if len(parts) >= 4 {
+				maskedDir = "/home/" + maskedUsername + "/" + filepath.Dir(parts[3])
+			} else {
+				maskedDir = "/home/" + maskedUsername
+			}
+		}
+	} else if strings.Contains(normalizedPath, "/Users/") {
+		// Handle both Unix /Users/ and Windows C:/Users/
+		idx := strings.Index(normalizedPath, "/Users/")
+		prefix := normalizedPath[:idx]
+		rest := normalizedPath[idx+7:] // Skip "/Users/"
+		parts := strings.SplitN(rest, "/", 2)
+		if len(parts) >= 1 {
+			maskedUsername := MaskString(parts[0])
+			if len(parts) >= 2 {
+				maskedDir = prefix + "/Users/" + maskedUsername + "/" + filepath.Dir(parts[1])
+			} else {
+				maskedDir = prefix + "/Users/" + maskedUsername
+			}
+		}
+	}
+
+	// Convert back to native path separators
+	maskedDir = filepath.FromSlash(maskedDir)
+
+	return filepath.Join(maskedDir, maskedFilename)
 }
 
 // This exists to trick the ssh library into continuing to try
@@ -653,15 +718,15 @@ func createClientConfig(connCtx context.Context, sshKeywords *wconfig.ConnKeywor
 	// TODO: Update if we decide to support PKCS11Provider and SecurityKeyProvider
 	agentPath := strings.TrimSpace(utilfn.SafeDeref(sshKeywords.SshIdentityAgent))
 	if !utilfn.SafeDeref(sshKeywords.SshIdentitiesOnly) && agentPath != "" {
-		blocklogger.Debugf(connCtx, "[ssh-agent] attempting to connect to agent at %q\n", agentPath)
+		blocklogger.Debugf(connCtx, "[ssh-agent] attempting to connect to agent at %q\n", filepath.Base(agentPath))
 		conn, err := dialIdentityAgent(agentPath)
 		if err != nil {
-			blocklogger.Infof(connCtx, "[ssh-agent] ERROR failed to connect to agent at %q: %v\n", agentPath, err)
+			blocklogger.Infof(connCtx, "[ssh-agent] ERROR failed to connect to agent at %q: %v\n", filepath.Base(agentPath), err)
 			if runtime.GOOS == "windows" {
 				blocklogger.Infof(connCtx, "[ssh-agent] hint: ensure OpenSSH Authentication Agent service is running (Get-Service ssh-agent)\n")
 			}
 		} else {
-			blocklogger.Infof(connCtx, "[ssh-agent] successfully connected to agent at %q\n", agentPath)
+			blocklogger.Infof(connCtx, "[ssh-agent] successfully connected to agent at %q\n", filepath.Base(agentPath))
 			agentClient = agent.NewClient(conn)
 			blocklogger.Debugf(connCtx, "[ssh-agent] requesting key list from agent...\n")
 			var signerErr error
@@ -674,7 +739,7 @@ func createClientConfig(connCtx context.Context, sshKeywords *wconfig.ConnKeywor
 				for i, signer := range authSockSigners {
 					pubKey := signer.PublicKey()
 					fingerprint := ssh.FingerprintSHA256(pubKey)
-					blocklogger.Debugf(connCtx, "[ssh-agent]   key[%d]: type=%s fingerprint=%s\n", i, pubKey.Type(), fingerprint)
+					blocklogger.Debugf(connCtx, "[ssh-agent]   key[%d]: type=%s fingerprint=%s\n", i, pubKey.Type(), MaskString(fingerprint))
 				}
 			}
 		}
@@ -750,14 +815,14 @@ func connectInternal(ctx context.Context, networkAddr string, clientConfig *ssh.
 	var err error
 	if currentClient == nil {
 		d := net.Dialer{Timeout: clientConfig.Timeout}
-		blocklogger.Infof(ctx, "[conndebug] ssh dial %s\n", networkAddr)
+		blocklogger.Infof(ctx, "[conndebug] ssh dial %s\n", MaskString(networkAddr))
 		clientConn, err = d.DialContext(ctx, "tcp", networkAddr)
 		if err != nil {
 			blocklogger.Infof(ctx, "[conndebug] ERROR dial error: %v\n", err)
 			return nil, err
 		}
 	} else {
-		blocklogger.Infof(ctx, "[conndebug] ssh dial (from client) %s\n", networkAddr)
+		blocklogger.Infof(ctx, "[conndebug] ssh dial (from client) %s\n", MaskString(networkAddr))
 		clientConn, err = currentClient.DialContext(ctx, "tcp", networkAddr)
 		if err != nil {
 			blocklogger.Infof(ctx, "[conndebug] ERROR dial error: %v\n", err)
@@ -769,12 +834,12 @@ func connectInternal(ctx context.Context, networkAddr string, clientConfig *ssh.
 		blocklogger.Infof(ctx, "[conndebug] ERROR ssh auth/negotiation: %s\n", SimpleMessageFromPossibleConnectionError(err))
 		return nil, err
 	}
-	blocklogger.Infof(ctx, "[conndebug] successful ssh connection to %s\n", networkAddr)
+	blocklogger.Infof(ctx, "[conndebug] successful ssh connection to %s\n", MaskString(networkAddr))
 	return ssh.NewClient(c, chans, reqs), nil
 }
 
 func ConnectToClient(connCtx context.Context, opts *SSHOpts, currentClient *ssh.Client, jumpNum int32, connFlags *wconfig.ConnKeywords) (*ssh.Client, int32, error) {
-	blocklogger.Infof(connCtx, "[conndebug] ConnectToClient %s (jump:%d)...\n", opts.String(), jumpNum)
+	blocklogger.Infof(connCtx, "[conndebug] ConnectToClient %s (jump:%d)...\n", MaskString(opts.String()), jumpNum)
 	debugInfo := &ConnectionDebugInfo{
 		CurrentClient: currentClient,
 		NextOpts:      opts,
@@ -793,7 +858,7 @@ func ConnectToClient(connCtx context.Context, opts *SSHOpts, currentClient *ssh.
 
 	var sshConfigKeywords *wconfig.ConnKeywords
 	if utilfn.SafeDeref(internalSshConfigKeywords.ConnIgnoreSshConfig) {
-		blocklogger.Debugf(connCtx, "[ssh-config] loading config for host %q (ignoresshconfig=true, using defaults only)\n", opts.SSHHost)
+		blocklogger.Debugf(connCtx, "[ssh-config] loading config for host %q (ignoresshconfig=true, using defaults only)\n", MaskString(opts.SSHHost))
 		var err error
 		sshConfigKeywords, err = findSshDefaults(opts.SSHHost)
 		if err != nil {
@@ -801,7 +866,7 @@ func ConnectToClient(connCtx context.Context, opts *SSHOpts, currentClient *ssh.
 			return nil, debugInfo.JumpNum, ConnectionError{ConnectionDebugInfo: debugInfo, Err: err}
 		}
 	} else {
-		blocklogger.Debugf(connCtx, "[ssh-config] loading config for host %q (using ssh_config + internal)\n", opts.SSHHost)
+		blocklogger.Debugf(connCtx, "[ssh-config] loading config for host %q (using ssh_config + internal)\n", MaskString(opts.SSHHost))
 		var err error
 		sshConfigKeywords, err = findSshConfigKeywords(opts.SSHHost)
 		if err != nil {

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -373,7 +373,7 @@ type RpcOpts struct {
 	NoResponse bool   `json:"noresponse,omitempty"`
 	Route      string `json:"route,omitempty"`
 
-	StreamCancelFn func(ctx context.Context) error `json:"-"` // this is an *output* parameter, set by the handler
+	StreamCancelFn func() `json:"-"` // this is an *output* parameter, set by the handler
 }
 
 const (

--- a/pkg/wshrpc/wshrpctypes.go
+++ b/pkg/wshrpc/wshrpctypes.go
@@ -373,7 +373,7 @@ type RpcOpts struct {
 	NoResponse bool   `json:"noresponse,omitempty"`
 	Route      string `json:"route,omitempty"`
 
-	StreamCancelFn func() `json:"-"` // this is an *output* parameter, set by the handler
+	StreamCancelFn func(ctx context.Context) error `json:"-"` // this is an *output* parameter, set by the handler
 }
 
 const (


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where enabling IdentitiesOnly would prevent the SSH agent from being used entirely.
It also corrects the default SSH agent path on Windows and fixes a type mismatch in wshrpc.

## Problem
IdentitiesOnly Conflict: The previous implementation checked !sshKeywords.SshIdentitiesOnly before connecting to the agent. 
https://github.com/wavetermdev/waveterm/blob/f622c658b07881499b470c133c68cdf10f73aa6c/pkg/remote/sshclient.go#L617-L625
If IdentitiesOnly was set to yes (to restrict key usage), Wave would skip the agent entirely, leading to authentication failures.

## Changes
1. Removed the IdentitiesOnly check from the agent connection logic. 
2. Smart Filtering: Implemented logic in `createPublicKeyCallback`. If IdentitiesOnly is true, Wave will fetch the agent's keys but filter them to only use keys that fingerprint-match the locally configured.
3. Minor fixes:
    - IdentityFile Enhanced Parsing: Updated key parsing to try ssh.ParseAuthorizedKey first (for .pub files), then raw, then private keys.
    - Windows Defaults: Updated `findSshDefaults` to support Windows as well.

## Out of Scope
SSH Config Match Keyword: The underlying SSH configuration parser library used by Wave does not currently support the Match keyword. Consequently, settings (like IdentityFile or IdentitiesOnly) must be explicitly defined within Host blocks. Match blocks will be ignored and are not addressed by this PR.

## Conflicts
This branch is based on https://github.com/wavetermdev/waveterm/pull/2748