### PR TITLE
change IME composing handling order to support implicitly confirming IME

### DIFF
--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -616,31 +616,32 @@ export class TermWrap {
             return;
         }
 
-        // IME Composition Handling
-        // Block all data during composition - only send the final text after compositionend
-        // This prevents xterm.js from sending intermediate composition data (e.g., during compositionupdate)
-        if (this.isComposing) {
-            dlog("Blocked data during composition:", data);
-            return;
-        }
-
         if (this.pasteActive) {
             if (this.multiInputCallback) {
                 this.multiInputCallback(data);
             }
         }
 
-        // IME Deduplication (for Capslock input method switching)
-        // When switching input methods with Capslock during composition, some systems send the
-        // composed text twice. We allow the first send and block subsequent duplicates.
+        // IME handling: Check if this is confirmed text from a recent compositionend
+        // This must be checked BEFORE isComposing, because when implicitly confirming IME
+        // (e.g., typing next char), the event order is:
+        //   compositionend → compositionstart (new) → xterm onData
+        // By the time onData fires, a new composition has started (isComposing=true),
+        // but we still need to send the confirmed text from the previous composition.
+        //
+        // We also handle deduplication here: when switching input methods with Capslock
+        // during composition, some systems send the composed text twice. We allow the
+        // first send and block subsequent duplicates within the dedup window.
         const IMEDedupWindowMs = 50;
         const now = Date.now();
         const timeSinceCompositionEnd = now - this.lastCompositionEnd;
         if (timeSinceCompositionEnd < IMEDedupWindowMs && data === this.lastComposedText && this.lastComposedText) {
             if (!this.firstDataAfterCompositionSent) {
-                // First send after composition - allow it but mark as sent
+                // First send after composition - allow it even if isComposing is true
                 this.firstDataAfterCompositionSent = true;
                 dlog("First data after composition, allowing:", data);
+                this.sendDataHandler?.(data);
+                return;
             } else {
                 // Second send of the same data - this is a duplicate from Capslock switching, block it
                 dlog("Blocked duplicate IME data:", data);
@@ -648,6 +649,12 @@ export class TermWrap {
                 this.firstDataAfterCompositionSent = false;
                 return;
             }
+        }
+
+        // Block intermediate composition data (e.g., during compositionupdate)
+        if (this.isComposing) {
+            dlog("Blocked data during composition:", data);
+            return;
         }
 
         this.sendDataHandler?.(data);


### PR DESCRIPTION
## Problem
When using IME with Japanese in the terminal panel, implicitly confirming IME does not work properly.

## Environment
- MacOS 26.2
- Wave Terminal 0.13.1 (202512170503)
- Google Japanese IME 2.32.5990

## Step to reproduce
1. Input `てすと`
2. Input Tab (or Space)
3. IME changes the status to confirming (showing some candidates) and the text changes to `テスト`
4. Input next chars like `あ`
5. IME closes candidates for `てすと`
    - **Expected**: Confirm `テスト` and continue with next chars composition
    - **Actual**: `テスト` is lost, only next chars composition continues

## Cause
I added some logs and check the behavior, the event triggering order seems complicated.

- When explicitly confirming IME (Input Enter)
  - compositionend -> handleTermData
- When implicitly confirming IME (Input Tab + Input next char)
  - compositionend -> compositionstart -> handleTermData

## DEMO
Current|This PR|Reference (Chrome's textarea)
-|-|-
<video src="https://github.com/user-attachments/assets/ee7bd9b0-5689-4ea5-839c-72e126069722">|<video src="https://github.com/user-attachments/assets/9e27ff36-0017-4a05-96fb-dfa0c4b239b9">|<video src="https://github.com/user-attachments/assets/cfa3d218-4692-4548-8428-467341d86fe9">

## Note
I'm not familiar with other CJK languages and IME itself. There may be patterns I'm unaware of.