### PR TITLE
feat: Tab base directory with VS Code style redesign

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,104 @@
+# Changes Summary: Race Condition Fixes with Optimistic Locking
+
+## Overview
+
+This implementation addresses race conditions in tab metadata updates (spec-004) by implementing optimistic locking with version checking. The changes prevent TOCTOU (Time-Of-Check-Time-Of-Use) vulnerabilities in concurrent metadata operations.
+
+## Files Modified
+
+### Backend (Go)
+
+#### `pkg/wstore/wstore_dbops.go`
+- Added `ErrVersionMismatch` error variable for concurrent modification detection
+- Added `ErrObjectLocked` error variable for lock state rejection
+
+#### `pkg/wstore/wstore.go`
+- Added `UpdateObjectMetaWithVersion()` function:
+  - Performs optimistic locking update with version checking
+  - If `expectedVersion > 0` and doesn't match current version, returns `ErrVersionMismatch`
+  - If `expectedVersion == 0`, behaves like `UpdateObjectMeta` (no version check)
+
+- Added `UpdateObjectMetaIfNotLocked()` function:
+  - Atomically checks lock and updates metadata
+  - Lock is checked INSIDE the transaction, eliminating TOCTOU vulnerability
+  - Returns `ErrObjectLocked` (wrapped in `ErrVersionMismatch`) if locked
+  - Returns `ErrVersionMismatch` if version doesn't match
+
+#### `pkg/service/objectservice/objectservice.go`
+- Added `UpdateObjectMetaWithVersion()` RPC service method
+- Added `UpdateObjectMetaIfNotLocked()` RPC service method
+- Both methods include proper metadata annotations for TypeScript binding generation
+
+### Frontend (TypeScript)
+
+#### `frontend/app/view/term/termwrap.ts`
+- Added debounce map (`osc7DebounceMap`) for OSC 7 updates per tab
+- Added `OSC7_DEBOUNCE_MS = 300` constant for debounce delay
+- Added `clearOsc7Debounce()` helper function
+- Added `cleanupOsc7DebounceForTab()` exported function for memory leak prevention
+- Updated `handleOsc7Command()` to:
+  - Add null safety check for `tabData?.oid`
+  - Use debouncing to reduce race condition window
+  - Use atomic lock-aware update (`UpdateObjectMetaIfNotLocked`) instead of regular update
+  - Gracefully handle version mismatch and locked state errors
+
+#### `frontend/app/tab/tab.tsx`
+- Added `getApi` to imports from `@/app/store/global` (fix for pre-existing missing import)
+
+### Generated Files
+
+#### `frontend/app/store/services.ts`
+- Auto-generated new TypeScript methods:
+  - `UpdateObjectMetaWithVersion(oref, meta, expectedVersion)`
+  - `UpdateObjectMetaIfNotLocked(oref, meta, lockKey, expectedVersion)`
+
+## Key Features Implemented
+
+### 1. Optimistic Locking
+- Uses existing `version` field in WaveObj types
+- Version checked inside transaction to prevent TOCTOU
+- Atomic increment of version on successful update (already implemented in `DBUpdate`)
+
+### 2. Error Types
+- **ErrVersionMismatch**: Indicates concurrent modification detected
+- **ErrObjectLocked**: Indicates update rejected due to lock state
+- Both errors are wrapped appropriately for consistent error handling
+
+### 3. OSC 7 Debouncing
+- 300ms debounce window for rapid directory changes
+- Per-tab debounce timers in a Map
+- Cleanup function to prevent memory leaks on tab close
+
+### 4. Atomic Lock Checking
+- Lock state checked INSIDE database transaction
+- Eliminates race condition between lock check and update
+- If lock is toggled during update, the update is safely rejected
+
+## Acceptance Criteria Status
+
+- [x] `UpdateObjectMetaWithVersion` added to `wstore.go`
+- [x] RPC endpoints added to `objectservice.go`
+- [x] OSC 7 debounce map with cleanup function
+- [x] Null safety guards in `termwrap.ts`
+- [x] `ErrVersionMismatch` error type created
+- [x] `ErrObjectLocked` error type created
+- [x] TypeScript compilation passes (our files)
+- [x] Go compilation passes
+- [x] Changes committed
+
+## Testing Notes
+
+To test the implementation:
+
+1. **Version Mismatch Test**: Open two terminals in the same tab, rapidly change directories in both - the race condition should be handled gracefully
+
+2. **Lock Bypass Test**: Toggle the lock while an OSC 7 update is in flight - the update should be rejected if lock is set
+
+3. **Debounce Test**: Rapidly `cd` between directories - only the final directory should be set as basedir
+
+4. **Memory Leak Test**: Open and close multiple tabs - the debounce map should be cleaned up
+
+## Notes
+
+- The spec mentions retry logic for manual updates (handleSetBaseDir, handleToggleLock) - this was NOT implemented as the spec noted it as optional for Phase 4 and the core race condition fixes are functional without it
+- Pre-existing TypeScript errors in unrelated files (streamdown.tsx, notificationpopover.tsx) remain unfixed as they are not related to this implementation

--- a/docs/docs/tabs.mdx
+++ b/docs/docs/tabs.mdx
@@ -45,6 +45,71 @@ You can switch to an existing tab by clicking on it in the tab bar. You can also
 
 Pinning a tab makes it harder to close accidentally. You can pin a tab by right-clicking on it and selecting "Pin Tab" from the context menu that appears. You can also pin a tab by dragging it to a lesser index than an existing pinned tab. When a tab is pinned, the <i className="fa-sharp fa-xmark-large" title="x"/> button for the tab will be replaced with a <i className="fa-solid fa-sharp fa-thumbtack" title="pin"/> button. Clicking this button will unpin the tab. You can also unpin a tab by dragging it to an index higher than an existing unpinned tab.
 
+### Tab Base Directory
+
+You can set a base directory for each tab to create project-centric workflows. All terminals and file previews launched within the tab will use this directory as their starting point.
+
+#### Setting the Base Directory
+
+1. Right-click on a tab in the tab bar
+2. Select "Base Directory" from the context menu
+3. Click "Set Base Directory..."
+4. Choose a directory using the file picker
+
+Once set, the base directory will be displayed in the tab header with a folder icon. All new terminals opened in that tab will start in this directory.
+
+#### Smart Auto-Detection
+
+Wave Terminal can automatically detect and set the base directory from your terminal's working directory. When you `cd` into a project directory, Wave uses OSC 7 escape sequences to learn this location.
+
+Auto-detection occurs when:
+- The tab has no base directory set yet
+- The base directory is not locked
+
+This means the first directory you navigate to in a new tab becomes the tab's base directory automatically.
+
+#### Locking the Base Directory
+
+To prevent auto-detection from changing your base directory:
+
+1. Right-click on the tab
+2. Select "Base Directory"
+3. Click "Lock (Disable Smart Detection)"
+
+A lock icon will appear next to the base directory indicator in the tab header. When locked, you can still manually change the base directory, but terminal navigation will not affect it. Click the lock icon directly to toggle the lock state.
+
+#### Clearing the Base Directory
+
+To remove the base directory and return to default behavior:
+
+1. Right-click on the tab
+2. Select "Base Directory"
+3. Click "Clear Base Directory"
+
+#### Use Cases
+
+- **Project-centric workflows:** Set tab base directory to project root; all terminals start there
+- **Multi-project organization:** Different tabs for different projects, each with its own base directory
+- **Stable context:** Lock the base directory when navigating to multiple subdirectories
+
+#### Configuration via Presets
+
+You can create presets that include base directory configuration. Add entries to your settings:
+
+```json
+{
+    "presets": {
+        "tabvar@my-project": {
+            "display:name": "My Project",
+            "tab:basedir": "/path/to/my-project",
+            "tab:basedirlock": true
+        }
+    }
+}
+```
+
+Apply presets via the tab's right-click menu: "Tab Variables" > Select preset
+
 ## Tab Layout System
 
 The tabs are comprised of tiled blocks. The contents of each block is a single widget. You can move blocks around and arrange them into layouts that best-suit your workflow. You can also magnify blocks to focus on a specific widget.

--- a/emain/preload.ts
+++ b/emain/preload.ts
@@ -68,6 +68,12 @@ contextBridge.exposeInMainWorld("api", {
     openBuilder: (appId?: string) => ipcRenderer.send("open-builder", appId),
     setBuilderWindowAppId: (appId: string) => ipcRenderer.send("set-builder-window-appid", appId),
     doRefresh: () => ipcRenderer.send("do-refresh"),
+    showOpenDialog: (options: {
+        title?: string;
+        defaultPath?: string;
+        properties?: Array<"openFile" | "openDirectory" | "multiSelections" | "showHiddenFiles">;
+        filters?: Array<{ name: string; extensions: string[] }>;
+    }) => ipcRenderer.invoke("show-open-dialog", options),
 });
 
 // Custom event for "new-window"

--- a/frontend/app/monaco/schemaendpoints.ts
+++ b/frontend/app/monaco/schemaendpoints.ts
@@ -5,6 +5,7 @@ import settingsSchema from "../../../schema/settings.json";
 import connectionsSchema from "../../../schema/connections.json";
 import aipresetsSchema from "../../../schema/aipresets.json";
 import bgpresetsSchema from "../../../schema/bgpresets.json";
+import tabvarspresetsSchema from "../../../schema/tabvarspresets.json";
 import waveaiSchema from "../../../schema/waveai.json";
 import widgetsSchema from "../../../schema/widgets.json";
 
@@ -34,6 +35,11 @@ const MonacoSchemas: SchemaInfo[] = [
         uri: "wave://schema/bgpresets.json",
         fileMatch: ["*/WAVECONFIGPATH/presets/bg.json"],
         schema: bgpresetsSchema,
+    },
+    {
+        uri: "wave://schema/tabvarspresets.json",
+        fileMatch: ["*/WAVECONFIGPATH/presets/tabvars.json", "*/WAVECONFIGPATH/presets/tabvars/*.json"],
+        schema: tabvarspresetsSchema,
     },
     {
         uri: "wave://schema/waveai.json",

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -116,6 +116,13 @@ function initGlobalAtoms(initOpts: GlobalInitOptions) {
     }) as Atom<boolean>;
     // this is *the* tab that this tabview represents.  it should never change.
     const staticTabIdAtom: Atom<string> = atom(initOpts.tabId);
+    const activeTabAtom: Atom<Tab> = atom((get) => {
+        const staticTabId = get(staticTabIdAtom);
+        if (staticTabId == null) {
+            return null;
+        }
+        return WOS.getObjectValue<Tab>(WOS.makeORef("tab", staticTabId), get);
+    });
     const controlShiftDelayAtom = atom(false);
     const updaterStatusAtom = atom<UpdaterStatus>("up-to-date") as PrimitiveAtom<UpdaterStatus>;
     try {
@@ -169,6 +176,7 @@ function initGlobalAtoms(initOpts: GlobalInitOptions) {
         settingsAtom,
         hasCustomAIPresetsAtom,
         staticTabId: staticTabIdAtom,
+        activeTab: activeTabAtom,
         isFullScreen: isFullScreenAtom,
         zoomFactorAtom,
         controlShiftDelayAtom,

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -85,6 +85,16 @@ class ObjectServiceType {
     }
 
     // @returns object updates
+    UpdateObjectMetaIfNotLocked(oref: string, meta: MetaType, lockKey: string, expectedVersion: number): Promise<void> {
+        return WOS.callBackendService("object", "UpdateObjectMetaIfNotLocked", Array.from(arguments))
+    }
+
+    // @returns object updates
+    UpdateObjectMetaWithVersion(oref: string, meta: MetaType, expectedVersion: number): Promise<void> {
+        return WOS.callBackendService("object", "UpdateObjectMetaWithVersion", Array.from(arguments))
+    }
+
+    // @returns object updates
     UpdateTabName(tabId: string, name: string): Promise<void> {
         return WOS.callBackendService("object", "UpdateTabName", Array.from(arguments))
     }

--- a/frontend/app/store/tab-basedir-validation-hook.ts
+++ b/frontend/app/store/tab-basedir-validation-hook.ts
@@ -1,0 +1,77 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { fireAndForget } from "@/util/util";
+import { globalStore } from "./jotaiStore";
+import { activeTabIdAtom, getTabModelByTabId } from "./tab-model";
+import { validateTabBasedir } from "./tab-basedir-validator";
+import * as WOS from "./wos";
+
+const DEBOUNCE_INTERVAL_MS = 500; // Minimum time between validations
+
+// Validate tab basedir when tab is activated
+async function validateActiveTabBasedir(tabId: string): Promise<void> {
+    if (!tabId) return;
+
+    const tabModel = getTabModelByTabId(tabId);
+    const lastValidationTime = globalStore.get(tabModel.lastValidationTimeAtom);
+    const now = Date.now();
+
+    // Debounce: skip if validated recently
+    if (now - lastValidationTime < DEBOUNCE_INTERVAL_MS) {
+        return;
+    }
+
+    // Get tab data
+    const tabAtom = WOS.getWaveObjectAtom<Tab>(WOS.makeORef("tab", tabId));
+    const tabData = globalStore.get(tabAtom);
+
+    if (!tabData) {
+        return;
+    }
+
+    const basedir = tabData.meta?.["tab:basedir"];
+
+    // Skip validation if no basedir set
+    if (!basedir || basedir.trim() === "") {
+        return;
+    }
+
+    // Update validation state to pending
+    globalStore.set(tabModel.basedirValidationAtom, "pending");
+    globalStore.set(tabModel.lastValidationTimeAtom, now);
+
+    // Perform validation
+    const result = await validateTabBasedir(tabId, basedir);
+
+    if (result.valid) {
+        // Update validation state to valid
+        globalStore.set(tabModel.basedirValidationAtom, "valid");
+    } else {
+        // Update validation state to invalid
+        globalStore.set(tabModel.basedirValidationAtom, "invalid");
+
+        // Handle stale basedir (will clear and notify)
+        if (result.reason) {
+            const { handleStaleBasedir } = await import("./tab-basedir-validator");
+            await handleStaleBasedir(tabId, basedir, result.reason);
+        }
+    }
+}
+
+// Initialize tab validation hook
+export function initTabBasedirValidation(): void {
+    // Subscribe to activeTabIdAtom changes
+    globalStore.sub(activeTabIdAtom, () => {
+        const activeTabId = globalStore.get(activeTabIdAtom);
+        if (activeTabId) {
+            fireAndForget(() => validateActiveTabBasedir(activeTabId));
+        }
+    });
+
+    // Also validate the initial active tab
+    const initialActiveTabId = globalStore.get(activeTabIdAtom);
+    if (initialActiveTabId) {
+        fireAndForget(() => validateActiveTabBasedir(initialActiveTabId));
+    }
+}

--- a/frontend/app/store/tab-basedir-validator.ts
+++ b/frontend/app/store/tab-basedir-validator.ts
@@ -1,0 +1,342 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
+import { fireAndForget } from "@/util/util";
+import { globalStore } from "./jotaiStore";
+import { ObjectService } from "./services";
+import * as WOS from "./wos";
+
+export type StalePathReason =
+    | "not_found" // ENOENT - path does not exist
+    | "not_directory" // Path exists but is not a directory
+    | "access_denied" // EACCES - no permission to access
+    | "network_error" // Timeout or network failure (after retries)
+    | "unknown_error"; // Other errors
+
+export interface PathValidationResult {
+    valid: boolean;
+    path: string;
+    reason?: StalePathReason;
+    fileInfo?: FileInfo;
+}
+
+interface RetryConfig {
+    maxAttempts: number;
+    timeoutPerAttempt: number;
+    delayBetweenRetries: number;
+    totalWindow: number;
+}
+
+const defaultRetryConfig: RetryConfig = {
+    maxAttempts: 3,
+    timeoutPerAttempt: 10000, // 10 seconds per attempt
+    delayBetweenRetries: 1000, // 1 second delay between retries
+    totalWindow: 30000, // Maximum 30 seconds total
+};
+
+// Sleep utility
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Classify error into StalePathReason
+function classifyError(error: any): StalePathReason {
+    const errorStr = String(error?.message || error || "").toLowerCase();
+
+    // ENOENT - file not found
+    if (errorStr.includes("enoent") || errorStr.includes("not found") || errorStr.includes("no such file")) {
+        return "not_found";
+    }
+
+    // EACCES - access denied
+    if (errorStr.includes("eacces") || errorStr.includes("permission denied") || errorStr.includes("access denied")) {
+        return "access_denied";
+    }
+
+    // Network/timeout errors
+    if (
+        errorStr.includes("etimedout") ||
+        errorStr.includes("timeout") ||
+        errorStr.includes("econnrefused") ||
+        errorStr.includes("ehostunreach") ||
+        errorStr.includes("enetunreach") ||
+        errorStr.includes("network")
+    ) {
+        return "network_error";
+    }
+
+    return "unknown_error";
+}
+
+// Check if a path looks like a network path
+function isNetworkPath(path: string): boolean {
+    if (!path) return false;
+
+    // UNC paths (Windows): \\server\share or //server/share
+    if (path.startsWith("\\\\") || path.startsWith("//")) {
+        return true;
+    }
+
+    // SMB/CIFS: smb:// or cifs://
+    if (path.startsWith("smb://") || path.startsWith("cifs://")) {
+        return true;
+    }
+
+    // NFS paths (common patterns)
+    // - server:/path (NFS)
+    // - /net/server/path (automounter)
+    if (/^[^\/\\]+:\//.test(path) || path.startsWith("/net/")) {
+        return true;
+    }
+
+    return false;
+}
+
+// Validate path with timeout
+async function validatePathWithTimeout(
+    basedir: string,
+    timeout: number
+): Promise<PathValidationResult> {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("ETIMEDOUT")), timeout);
+    });
+
+    try {
+        const validationPromise = RpcApi.FileInfoCommand(TabRpcClient, { info: { path: basedir } }, null);
+        const fileInfo = await Promise.race([validationPromise, timeoutPromise]);
+
+        // Check if path was not found
+        if (fileInfo.notfound) {
+            return { valid: false, path: basedir, reason: "not_found" };
+        }
+
+        // Check if path is not a directory
+        if (!fileInfo.isdir) {
+            return { valid: false, path: basedir, reason: "not_directory" };
+        }
+
+        // Valid directory
+        return { valid: true, path: basedir, fileInfo };
+    } catch (error) {
+        const reason = classifyError(error);
+        return { valid: false, path: basedir, reason };
+    }
+}
+
+// Validate with network retry mechanism
+async function validateWithNetworkRetry(
+    basedir: string,
+    config: RetryConfig = defaultRetryConfig
+): Promise<PathValidationResult> {
+    let lastError: StalePathReason | null = null;
+
+    for (let attempt = 1; attempt <= config.maxAttempts; attempt++) {
+        try {
+            const result = await validatePathWithTimeout(basedir, config.timeoutPerAttempt);
+
+            if (result.valid) {
+                return result; // Success on any attempt
+            }
+
+            // Non-network errors fail immediately (no retry)
+            if (result.reason !== "network_error") {
+                return result;
+            }
+
+            lastError = result.reason;
+
+            // Don't delay after final attempt
+            if (attempt < config.maxAttempts) {
+                await sleep(config.delayBetweenRetries);
+            }
+        } catch (error) {
+            lastError = classifyError(error);
+
+            // Only retry network errors
+            if (lastError !== "network_error" || attempt === config.maxAttempts) {
+                return { valid: false, path: basedir, reason: lastError };
+            }
+
+            await sleep(config.delayBetweenRetries);
+        }
+    }
+
+    // All retries exhausted
+    return { valid: false, path: basedir, reason: "network_error" };
+}
+
+// Main validation function
+export async function validateTabBasedir(
+    tabId: string,
+    basedir: string
+): Promise<PathValidationResult> {
+    if (!basedir || basedir.trim() === "") {
+        return { valid: true, path: basedir }; // Empty path is considered valid (no validation needed)
+    }
+
+    // Detect if this is a network path
+    const isNetwork = isNetworkPath(basedir);
+
+    if (isNetwork) {
+        // Use retry logic for network paths
+        return await validateWithNetworkRetry(basedir);
+    } else {
+        // Single attempt for local paths
+        return await validatePathWithTimeout(basedir, 5000); // 5 second timeout for local
+    }
+}
+
+// Get user-friendly message for a stale path reason
+function getReasonMessage(reason: StalePathReason, path: string): string {
+    switch (reason) {
+        case "not_found":
+            return `Path no longer valid (not found): ${path}`;
+        case "not_directory":
+            return `Path is no longer a directory: ${path}`;
+        case "access_denied":
+            return `Cannot access directory (permission denied): ${path}`;
+        case "network_error":
+            return `Cannot reach network path (after retries): ${path}`;
+        case "unknown_error":
+            return `Path no longer accessible: ${path}`;
+        default:
+            return `Path validation failed: ${path}`;
+    }
+}
+
+// Clear stale path and notify user
+export async function handleStaleBasedir(
+    tabId: string,
+    path: string,
+    reason: StalePathReason
+): Promise<void> {
+    const tabORef = WOS.makeORef("tab", tabId);
+
+    try {
+        // Clear both basedir and basedirlock
+        await ObjectService.UpdateObjectMeta(tabORef, {
+            "tab:basedir": null,
+            "tab:basedirlock": false,
+        });
+
+        // Push notification
+        const { pushNotification } = await import("./global");
+        pushNotification({
+            id: `stale-basedir-${tabId}`,
+            icon: "triangle-exclamation",
+            type: "warning",
+            title: "Tab base directory cleared",
+            message: getReasonMessage(reason, path),
+            timestamp: new Date().toISOString(),
+            expiration: Date.now() + 10000, // 10 second auto-dismiss
+            persistent: false,
+        });
+
+        console.log(`[TabBasedir] Cleared stale basedir for tab ${tabId}: ${path} (${reason})`);
+    } catch (error) {
+        console.error(`[TabBasedir] Failed to clear stale basedir for tab ${tabId}:`, error);
+    }
+}
+
+// Batch notification for multiple stale paths
+export async function handleMultipleStaleBasedirs(
+    staleTabs: Array<{ tabId: string; path: string; reason: StalePathReason }>
+): Promise<void> {
+    if (staleTabs.length === 0) return;
+
+    // Clear all stale paths
+    const clearPromises = staleTabs.map(({ tabId }) => {
+        const tabORef = WOS.makeORef("tab", tabId);
+        return ObjectService.UpdateObjectMeta(tabORef, {
+            "tab:basedir": null,
+            "tab:basedirlock": false,
+        });
+    });
+
+    try {
+        await Promise.all(clearPromises);
+
+        // Push batched notification
+        const { pushNotification } = await import("./global");
+        pushNotification({
+            id: "stale-basedir-batch",
+            icon: "triangle-exclamation",
+            type: "warning",
+            title: `Cleared base directory for ${staleTabs.length} tabs`,
+            message: "Multiple tabs had stale paths. See logs for details.",
+            timestamp: new Date().toISOString(),
+            expiration: Date.now() + 15000, // 15 second auto-dismiss
+            persistent: false,
+        });
+
+        // Log individual paths for debugging
+        staleTabs.forEach(({ tabId, path, reason }) => {
+            console.log(`[TabBasedir] Cleared stale basedir for tab ${tabId}: ${path} (${reason})`);
+        });
+    } catch (error) {
+        console.error("[TabBasedir] Failed to clear multiple stale basedirs:", error);
+    }
+}
+
+// Batching state for tab validations
+interface BatchingState {
+    staleTabs: Array<{ tabId: string; path: string; reason: StalePathReason }>;
+    timer: NodeJS.Timeout | null;
+}
+
+const batchingState: BatchingState = {
+    staleTabs: [],
+    timer: null,
+};
+
+const BATCHING_WINDOW_MS = 5000; // 5 second window for batching
+const BATCH_THRESHOLD = 4; // Batch if 4+ tabs have stale paths
+
+// Validate and handle stale basedir with batching support
+export async function validateAndHandleStale(tabId: string): Promise<void> {
+    const tabAtom = WOS.getWaveObjectAtom<Tab>(WOS.makeORef("tab", tabId));
+    const tabData = globalStore.get(tabAtom);
+
+    if (!tabData) {
+        return;
+    }
+
+    const basedir = tabData.meta?.["tab:basedir"];
+
+    // Skip validation if no basedir set
+    if (!basedir || basedir.trim() === "") {
+        return;
+    }
+
+    // Perform validation
+    const result = await validateTabBasedir(tabId, basedir);
+
+    if (!result.valid && result.reason) {
+        // Add to batching queue
+        batchingState.staleTabs.push({ tabId, path: basedir, reason: result.reason });
+
+        // Clear existing timer if any
+        if (batchingState.timer) {
+            clearTimeout(batchingState.timer);
+        }
+
+        // Set timer to process batch
+        batchingState.timer = setTimeout(() => {
+            const staleTabs = [...batchingState.staleTabs];
+            batchingState.staleTabs = [];
+            batchingState.timer = null;
+
+            // Process batch
+            if (staleTabs.length >= BATCH_THRESHOLD) {
+                fireAndForget(() => handleMultipleStaleBasedirs(staleTabs));
+            } else {
+                // Process individually
+                staleTabs.forEach(({ tabId, path, reason }) => {
+                    fireAndForget(() => handleStaleBasedir(tabId, path, reason));
+                });
+            }
+        }, BATCHING_WINDOW_MS);
+    }
+}

--- a/frontend/app/store/tab-model.ts
+++ b/frontend/app/store/tab-model.ts
@@ -9,12 +9,39 @@ import * as WOS from "./wos";
 const tabModelCache = new Map<string, TabModel>();
 export const activeTabIdAtom = atom<string>(null) as PrimitiveAtom<string>;
 
+// Tab status types based on terminal block states
+export type TabStatusType = "stopped" | "finished" | "running" | null;
+
+// Per-block terminal status for aggregation
+export interface BlockTerminalStatus {
+    shellProcStatus: string | null; // "running", "done", "init", etc.
+    shellProcExitCode: number | null;
+    shellIntegrationStatus: string | null; // "running-command", "ready", etc.
+}
+
 export class TabModel {
     tabId: string;
     tabAtom: Atom<Tab>;
     tabNumBlocksAtom: Atom<number>;
     isTermMultiInput = atom(false) as PrimitiveAtom<boolean>;
     metaCache: Map<string, Atom<any>> = new Map();
+
+    // Validation state atoms for tab base directory
+    basedirValidationAtom = atom<"pending" | "valid" | "invalid" | null>(null) as PrimitiveAtom<
+        "pending" | "valid" | "invalid" | null
+    >;
+    lastValidationTimeAtom = atom<number>(0) as PrimitiveAtom<number>;
+
+    // Tracks when a process completes while this tab is in the background
+    // This enables the "finished" status icon to show unread completions
+    finishedUnreadAtom = atom(false) as PrimitiveAtom<boolean>;
+
+    // Map of blockId -> terminal status for reactive status tracking
+    private terminalStatusMap = new Map<string, BlockTerminalStatus>();
+
+    // Atom that holds the computed aggregate terminal status
+    // This is updated whenever any terminal block's status changes
+    terminalStatusAtom = atom<TabStatusType>(null) as PrimitiveAtom<TabStatusType>;
 
     constructor(tabId: string) {
         this.tabId = tabId;
@@ -37,6 +64,80 @@ export class TabModel {
             this.metaCache.set(metaKey, metaAtom);
         }
         return metaAtom;
+    }
+
+    getBasedirValidationState(): "pending" | "valid" | "invalid" | null {
+        return globalStore.get(this.basedirValidationAtom);
+    }
+
+    /**
+     * Clears the finishedUnread state when the tab becomes active.
+     * This removes the "finished" status icon indicating unread completions.
+     */
+    clearFinishedUnread(): void {
+        globalStore.set(this.finishedUnreadAtom, false);
+    }
+
+    /**
+     * Marks the tab as having unread process completions.
+     * Called when a process completes while this tab is in the background.
+     */
+    setFinishedUnread(): void {
+        globalStore.set(this.finishedUnreadAtom, true);
+    }
+
+    /**
+     * Updates the terminal status for a specific block and recomputes aggregate status.
+     * Called by terminal blocks when their shell proc status or shell integration status changes.
+     */
+    updateBlockTerminalStatus(blockId: string, status: BlockTerminalStatus): void {
+        this.terminalStatusMap.set(blockId, status);
+        this.recomputeTerminalStatus();
+    }
+
+    /**
+     * Removes a block from terminal status tracking (e.g., when block is deleted).
+     */
+    removeBlockTerminalStatus(blockId: string): void {
+        this.terminalStatusMap.delete(blockId);
+        this.recomputeTerminalStatus();
+    }
+
+    /**
+     * Recomputes the aggregate terminal status from all tracked blocks.
+     * Priority (highest to lowest):
+     * 1. stopped - Any block exited with error (exitcode != 0)
+     * 2. running - A command is actively executing (via shell integration)
+     * 3. finished - Process completed in background (unread) - handled separately
+     * 4. null - Idle (no special status to show)
+     */
+    private recomputeTerminalStatus(): void {
+        let hasRunningCommand = false;
+        let hasStopped = false;
+
+        for (const status of this.terminalStatusMap.values()) {
+            // Priority 1: Any error exit code (shell exited with error)
+            if (status.shellProcStatus === "done" && status.shellProcExitCode !== 0) {
+                hasStopped = true;
+            }
+
+            // Check for running commands via shell integration
+            if (status.shellIntegrationStatus === "running-command") {
+                hasRunningCommand = true;
+            }
+        }
+
+        // Compute status with priority
+        let newStatus: TabStatusType = null;
+        if (hasStopped) {
+            newStatus = "stopped";
+        } else if (hasRunningCommand) {
+            newStatus = "running";
+        } else if (globalStore.get(this.finishedUnreadAtom)) {
+            newStatus = "finished";
+        }
+
+        globalStore.set(this.terminalStatusAtom, newStatus);
     }
 }
 

--- a/frontend/app/tab/tab-menu.ts
+++ b/frontend/app/tab/tab-menu.ts
@@ -1,0 +1,168 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ObjectService } from "@/app/store/services";
+import { validatePresetBeforeApply, sanitizePreset } from "@/util/presetutil";
+import { fireAndForget } from "@/util/util";
+
+/**
+ * Configuration for building preset menu items.
+ */
+export interface PresetMenuConfig {
+    /** Prefix to filter presets (e.g., "tabvar@", "bg@") */
+    prefix: string;
+
+    /** Whether to sort by display:order (default: false) */
+    sortByOrder?: boolean;
+
+    /** Whether to strip prefix from fallback label (default: false) */
+    stripPrefixFromLabel?: boolean;
+
+    /** Additional callback to execute after applying preset */
+    onApply?: (presetName: string) => void;
+}
+
+/**
+ * Filter preset keys by prefix from the full configuration.
+ *
+ * @param presets - The presets map from fullConfig
+ * @param prefix - Prefix to filter by
+ * @returns Array of matching preset keys
+ */
+function filterPresetsByPrefix(presets: { [key: string]: MetaType } | undefined, prefix: string): string[] {
+    if (!presets) {
+        return [];
+    }
+    const matching: string[] = [];
+    for (const key in presets) {
+        if (key.startsWith(prefix)) {
+            matching.push(key);
+        }
+    }
+    return matching;
+}
+
+/**
+ * Build context menu items from presets matching the specified prefix.
+ *
+ * @param fullConfig - The full configuration containing presets
+ * @param oref - Object reference to apply presets to
+ * @param config - Configuration for filtering and building menu items
+ * @returns Array of context menu items (empty if no matching presets)
+ *
+ * @example
+ * // Tab variables presets
+ * const tabVarItems = buildPresetMenuItems(fullConfig, oref, {
+ *     prefix: "tabvar@",
+ *     stripPrefixFromLabel: true,
+ * });
+ *
+ * @example
+ * // Background presets with sorting and callback
+ * const bgItems = buildPresetMenuItems(fullConfig, oref, {
+ *     prefix: "bg@",
+ *     sortByOrder: true,
+ *     onApply: () => {
+ *         RpcApi.ActivityCommand(TabRpcClient, { settabtheme: 1 }, { noresponse: true });
+ *         recordTEvent("action:settabtheme");
+ *     },
+ * });
+ */
+export function buildPresetMenuItems(
+    fullConfig: FullConfigType | null,
+    oref: string,
+    config: PresetMenuConfig
+): ContextMenuItem[] {
+    if (!fullConfig?.presets) {
+        return [];
+    }
+
+    const { prefix, sortByOrder = false, stripPrefixFromLabel = false, onApply } = config;
+
+    // Filter presets by prefix
+    let presetKeys = filterPresetsByPrefix(fullConfig.presets, prefix);
+
+    if (presetKeys.length === 0) {
+        return [];
+    }
+
+    // Sort by display:order if requested
+    if (sortByOrder) {
+        presetKeys.sort((a, b) => {
+            const aOrder = fullConfig.presets[a]?.["display:order"] ?? 0;
+            const bOrder = fullConfig.presets[b]?.["display:order"] ?? 0;
+            return aOrder - bOrder;
+        });
+    }
+
+    // Build menu items
+    const menuItems: ContextMenuItem[] = [];
+
+    for (const presetName of presetKeys) {
+        const preset = fullConfig.presets[presetName];
+        if (preset == null) {
+            continue;
+        }
+
+        // Frontend validation (defense in depth)
+        const validation = validatePresetBeforeApply(presetName, preset);
+        if (!validation.valid) {
+            console.warn(`[Preset] Skipping invalid preset "${presetName}": ${validation.error}`);
+            continue;
+        }
+        if (validation.warnings?.length) {
+            console.info(`[Preset] Warnings for "${presetName}":`, validation.warnings);
+        }
+
+        // Determine display label
+        let label: string;
+        if (preset["display:name"]) {
+            label = preset["display:name"] as string;
+        } else if (stripPrefixFromLabel) {
+            label = presetName.replace(prefix, "");
+        } else {
+            label = presetName;
+        }
+
+        menuItems.push({
+            label,
+            click: () =>
+                fireAndForget(async () => {
+                    // Sanitize preset to ensure only allowed keys are sent
+                    const sanitizedPreset = sanitizePreset(presetName, preset);
+                    await ObjectService.UpdateObjectMeta(oref, sanitizedPreset);
+                    onApply?.(presetName);
+                }),
+        });
+    }
+
+    return menuItems;
+}
+
+/**
+ * Add preset submenu to an existing menu array if presets exist.
+ * This is a convenience wrapper around buildPresetMenuItems that handles
+ * the common pattern of adding a labeled submenu with separator.
+ *
+ * @param menu - Menu array to add to (modified in place)
+ * @param fullConfig - The full configuration containing presets
+ * @param oref - Object reference to apply presets to
+ * @param label - Label for the submenu
+ * @param config - Configuration for filtering and building menu items
+ * @returns The modified menu array (for chaining)
+ */
+export function addPresetSubmenu(
+    menu: ContextMenuItem[],
+    fullConfig: FullConfigType | null,
+    oref: string,
+    label: string,
+    config: PresetMenuConfig
+): ContextMenuItem[] {
+    const submenuItems = buildPresetMenuItems(fullConfig, oref, config);
+
+    if (submenuItems.length > 0) {
+        menu.push({ label, type: "submenu", submenu: submenuItems }, { type: "separator" });
+    }
+
+    return menu;
+}

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -4,7 +4,7 @@
 .tab {
     position: absolute;
     width: 130px;
-    height: calc(100% - 1px);
+    height: 100%;
     padding: 0 0 0 0;
     box-sizing: border-box;
     font-weight: bold;
@@ -13,6 +13,39 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    // Inactive tab: 25% white overlay on tab bar background
+    background: rgb(255 255 255 / 0.04);
+
+    // Tab color stripe - shows manual color ONLY (VS Code style top stripe)
+    .tab-color-stripe {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 2px;
+        border-radius: 0;
+        z-index: var(--zindex-tab-name);
+    }
+
+    // Status text colors (VS Code style)
+    &.status-running .name {
+        color: #3b82f6 !important;
+        animation: text-pulse 1.5s ease-in-out infinite;
+    }
+
+    &.status-finished .name {
+        color: #22c55e !important;
+    }
+
+    &.status-stopped .name {
+        color: #ef4444 !important;
+    }
+
+    &.status-attention .name {
+        color: #eab308 !important;
+        animation: text-pulse 1.5s ease-in-out infinite;
+    }
+
 
     &::after {
         content: "";
@@ -28,7 +61,7 @@
         width: calc(100% - 6px);
         height: 100%;
         white-space: nowrap;
-        border-radius: 6px;
+        border-radius: 0;
     }
 
     &.animate {
@@ -38,14 +71,22 @@
     }
 
     &.active {
+        // Active tab: 75% white overlay on tab bar background (brightest)
+        background: rgb(255 255 255 / 0.12);
+
         .tab-inner {
             border-color: transparent;
-            border-radius: 6px;
-            background: rgb(from var(--main-text-color) r g b / 0.1);
+            border-radius: 0;
         }
 
         .name {
             color: var(--main-text-color);
+            opacity: 1;
+        }
+
+        // Always show close button on active tab
+        .close {
+            visibility: visible;
         }
 
         & + .tab::after,
@@ -58,20 +99,29 @@
         content: none;
     }
 
-    .name {
+    .tab-name-wrapper {
         position: absolute;
         top: 50%;
         left: 50%;
         transform: translate3d(-50%, -50%, 0);
-        user-select: none;
+        width: calc(100% - 10px);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
         z-index: var(--zindex-tab-name);
+    }
+
+    .name {
+        user-select: none;
         font-size: 11px;
         font-weight: 500;
         text-shadow: 0px 0px 4px rgb(from var(--main-bg-color) r g b / 0.25);
         overflow: hidden;
-        width: calc(100% - 10px);
         text-overflow: ellipsis;
         text-align: center;
+        // Inactive tabs have more muted text
+        opacity: 0.7;
 
         &.focused {
             outline: none;
@@ -110,9 +160,11 @@ body:not(.nohover) .tab.dragging {
         content: none;
     }
 
+    // Hover tab: 50% white overlay on tab bar background (middle brightness)
+    background: rgb(255 255 255 / 0.08);
+
     .tab-inner {
         border-color: transparent;
-        background: rgb(from var(--main-text-color) r g b / 0.1);
     }
     .close {
         visibility: visible;
@@ -120,6 +172,11 @@ body:not(.nohover) .tab.dragging {
             color: var(--main-text-color);
         }
     }
+}
+
+// Active tab hover shouldn't change the background
+body:not(.nohover) .tab.active:hover {
+    background: rgb(255 255 255 / 0.12);
 }
 
 // When in nohover mode, always show the close button on the active tab. This prevents the close button of the active tab from flickering when nohover is toggled.
@@ -191,4 +248,22 @@ body.nohover .tab.active .close {
 
 .pin.jiggling i {
     animation: jigglePinIcon 0.5s ease-in-out;
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes text-pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
 }

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -1,17 +1,31 @@
 // Copyright 2025, Command Line Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { atoms, globalStore, recordTEvent, refocusNode } from "@/app/store/global";
+import { atoms, getApi, globalStore, recordTEvent, refocusNode } from "@/app/store/global";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
 import { Button } from "@/element/button";
 import { ContextMenuModel } from "@/store/contextmenu";
 import { fireAndForget } from "@/util/util";
 import clsx from "clsx";
-import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import React, { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { ObjectService } from "../store/services";
+import { TabStatusType } from "../store/tab-model";
 import { makeORef, useWaveObjectValue } from "../store/wos";
+import { addPresetSubmenu } from "./tab-menu";
 import "./tab.scss";
+
+// Tab color palette for the context menu
+const TAB_COLORS = [
+    { name: "Red", value: "#ef4444" },
+    { name: "Orange", value: "#f97316" },
+    { name: "Yellow", value: "#eab308" },
+    { name: "Green", value: "#22c55e" },
+    { name: "Cyan", value: "#06b6d4" },
+    { name: "Blue", value: "#3b82f6" },
+    { name: "Purple", value: "#a855f7" },
+    { name: "Pink", value: "#ec4899" },
+];
 
 interface TabProps {
     id: string;
@@ -41,6 +55,39 @@ const Tab = memo(
             const editableTimeoutRef = useRef<NodeJS.Timeout>(null);
             const loadedRef = useRef(false);
             const tabRef = useRef<HTMLDivElement>(null);
+
+            // Read terminal status from tab metadata (synced across webviews)
+            // Status shown on ALL tabs including active
+            const tabStatus = (tabData?.meta?.["tab:termstatus"] as TabStatusType) || null;
+
+            // Clear status after a delay when tab becomes active AND webview is visible
+            // "finished" clears after 2 seconds, "stopped" clears after 3 seconds
+            // We must check document.visibilityState because each tab has its own webview,
+            // and the "active" prop is always true for the owning webview even when in background
+            const [isDocVisible, setIsDocVisible] = useState(document.visibilityState === "visible");
+            useEffect(() => {
+                const handleVisibilityChange = () => {
+                    setIsDocVisible(document.visibilityState === "visible");
+                };
+                document.addEventListener("visibilitychange", handleVisibilityChange);
+                return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+            }, []);
+
+            useEffect(() => {
+                // Only clear status when:
+                // 1. This tab is marked as active (matches this webview's staticTabId)
+                // 2. This webview is actually visible to the user (not a background webview)
+                // 3. Status is finished or stopped
+                if (active && isDocVisible && (tabStatus === "finished" || tabStatus === "stopped")) {
+                    const delay = tabStatus === "stopped" ? 3000 : 2000;
+                    const timer = setTimeout(() => {
+                        ObjectService.UpdateObjectMeta(makeORef("tab", id), {
+                            "tab:termstatus": null,
+                        });
+                    }, delay);
+                    return () => clearTimeout(timer);
+                }
+            }, [active, isDocVisible, tabStatus, id]);
 
             useImperativeHandle(ref, () => tabRef.current as HTMLDivElement);
 
@@ -133,9 +180,99 @@ const Tab = memo(
                 event.stopPropagation();
             };
 
+            /**
+             * Opens a native directory picker dialog and sets the tab's base directory.
+             *
+             * The selected directory becomes the default working directory for all
+             * terminals and file preview widgets launched within this tab.
+             *
+             * @remarks
+             * - Uses Electron's native dialog for cross-platform file picking
+             * - Defaults to current base directory if set, otherwise home (~)
+             * - Does NOT set the lock flag - allows smart auto-detection to continue
+             *
+             * @see handleClearBaseDir - To remove the base directory
+             * @see handleToggleLock - To prevent auto-detection
+             */
+            const handleSetBaseDir = useCallback(() => {
+                const currentDir = tabData?.meta?.["tab:basedir"] || "";
+                fireAndForget(async () => {
+                    const newDir = await getApi().showOpenDialog({
+                        title: "Set Tab Base Directory",
+                        defaultPath: currentDir || "~",
+                        properties: ["openDirectory"],
+                    });
+                    if (newDir && newDir.length > 0) {
+                        await ObjectService.UpdateObjectMeta(makeORef("tab", id), {
+                            "tab:basedir": newDir[0],
+                        });
+                    }
+                });
+            }, [id, tabData]);
+
+            /**
+             * Clears the tab's base directory, restoring default behavior.
+             *
+             * After clearing:
+             * - New terminals use the default directory (typically home ~)
+             * - Smart auto-detection from OSC 7 is re-enabled
+             *
+             * @remarks
+             * Only clears `tab:basedir`, does NOT touch `tab:basedirlock`
+             */
+            const handleClearBaseDir = useCallback(() => {
+                fireAndForget(async () => {
+                    await ObjectService.UpdateObjectMeta(makeORef("tab", id), {
+                        "tab:basedir": null,
+                    });
+                });
+            }, [id]);
+
+            /**
+             * Toggles the base directory lock state.
+             *
+             * Lock semantics:
+             * - **Unlocked (default):** OSC 7 smart auto-detection can update `tab:basedir`
+             * - **Locked:** OSC 7 updates are blocked; only manual setting changes directory
+             *
+             * Use cases for locking:
+             * - Working in multiple directories within same tab
+             * - Preventing cd commands from changing tab context
+             * - Maintaining a fixed project root despite navigation
+             *
+             * @see tab:basedirlock - The underlying metadata key
+             */
+            const handleToggleLock = useCallback(() => {
+                const currentLock = tabData?.meta?.["tab:basedirlock"] || false;
+                fireAndForget(async () => {
+                    await ObjectService.UpdateObjectMeta(makeORef("tab", id), {
+                        "tab:basedirlock": !currentLock,
+                    });
+                });
+            }, [id, tabData]);
+
+            /**
+             * Sets the tab's color for visual identification.
+             *
+             * @param color - Hex color value or null to clear
+             */
+            const handleSetTabColor = useCallback(
+                (color: string | null) => {
+                    fireAndForget(async () => {
+                        await ObjectService.UpdateObjectMeta(makeORef("tab", id), {
+                            "tab:color": color,
+                        });
+                    });
+                },
+                [id]
+            );
+
             const handleContextMenu = useCallback(
                 (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
                     e.preventDefault();
+                    const currentBaseDir = tabData?.meta?.["tab:basedir"];
+                    const isLocked = tabData?.meta?.["tab:basedirlock"] || false;
+
                     let menu: ContextMenuItem[] = [
                         { label: "Rename Tab", click: () => handleRenameTab(null) },
                         {
@@ -144,69 +281,120 @@ const Tab = memo(
                         },
                         { type: "separator" },
                     ];
-                    const fullConfig = globalStore.get(atoms.fullConfigAtom);
-                    const bgPresets: string[] = [];
-                    for (const key in fullConfig?.presets ?? {}) {
-                        if (key.startsWith("bg@")) {
-                            bgPresets.push(key);
-                        }
+
+                    // Base Directory submenu
+                    const baseDirSubmenu: ContextMenuItem[] = [
+                        {
+                            label: "Set Base Directory...",
+                            click: handleSetBaseDir,
+                        },
+                    ];
+
+                    if (currentBaseDir) {
+                        baseDirSubmenu.push({
+                            label: "Clear Base Directory",
+                            click: handleClearBaseDir,
+                        });
+                        baseDirSubmenu.push({ type: "separator" });
+                        baseDirSubmenu.push({
+                            label: isLocked ? "Unlock (Enable Smart Detection)" : "Lock (Disable Smart Detection)",
+                            click: handleToggleLock,
+                        });
                     }
-                    bgPresets.sort((a, b) => {
-                        const aOrder = fullConfig.presets[a]["display:order"] ?? 0;
-                        const bOrder = fullConfig.presets[b]["display:order"] ?? 0;
-                        return aOrder - bOrder;
+
+                    menu.push({ label: "Base Directory", type: "submenu", submenu: baseDirSubmenu }, { type: "separator" });
+
+                    // Tab Color submenu
+                    const currentTabColor = tabData?.meta?.["tab:color"];
+                    const colorSubmenu: ContextMenuItem[] = TAB_COLORS.map((color) => ({
+                        label: color.name,
+                        type: "checkbox" as const,
+                        checked: currentTabColor === color.value,
+                        click: () => handleSetTabColor(color.value),
+                    }));
+                    colorSubmenu.push({ type: "separator" });
+                    colorSubmenu.push({
+                        label: "Clear",
+                        click: () => handleSetTabColor(null),
                     });
-                    if (bgPresets.length > 0) {
-                        const submenu: ContextMenuItem[] = [];
-                        const oref = makeORef("tab", id);
-                        for (const presetName of bgPresets) {
-                            const preset = fullConfig.presets[presetName];
-                            if (preset == null) {
-                                continue;
-                            }
-                            submenu.push({
-                                label: preset["display:name"] ?? presetName,
-                                click: () =>
-                                    fireAndForget(async () => {
-                                        await ObjectService.UpdateObjectMeta(oref, preset);
-                                        RpcApi.ActivityCommand(TabRpcClient, { settabtheme: 1 }, { noresponse: true });
-                                        recordTEvent("action:settabtheme");
-                                    }),
-                            });
-                        }
-                        menu.push({ label: "Backgrounds", type: "submenu", submenu }, { type: "separator" });
-                    }
+
+                    menu.push({ label: "Tab Color", type: "submenu", submenu: colorSubmenu }, { type: "separator" });
+
+                    const fullConfig = globalStore.get(atoms.fullConfigAtom);
+                    const oref = makeORef("tab", id);
+
+                    // Tab Variables presets
+                    addPresetSubmenu(menu, fullConfig, oref, "Tab Variables", {
+                        prefix: "tabvar@",
+                        stripPrefixFromLabel: true,
+                    });
+
+                    // Background presets
+                    addPresetSubmenu(menu, fullConfig, oref, "Backgrounds", {
+                        prefix: "bg@",
+                        sortByOrder: true,
+                        onApply: () => {
+                            RpcApi.ActivityCommand(TabRpcClient, { settabtheme: 1 }, { noresponse: true });
+                            recordTEvent("action:settabtheme");
+                        },
+                    });
                     menu.push({ label: "Close Tab", click: () => onClose(null) });
                     ContextMenuModel.showContextMenu(menu, e);
                 },
-                [handleRenameTab, id, onClose]
+                [handleRenameTab, id, onClose, tabData, handleSetBaseDir, handleClearBaseDir, handleToggleLock, handleSetTabColor]
             );
+
+            const tabColor = tabData?.meta?.["tab:color"];
+
+            /**
+             * Gets the status class name for the tab element.
+             * Used for VS Code style text coloring.
+             */
+            const getStatusClassName = (): string | null => {
+                switch (tabStatus) {
+                    case "stopped":
+                        return "status-stopped";
+                    case "finished":
+                        return "status-finished";
+                    case "running":
+                        return "status-running";
+                    default:
+                        return null;
+                }
+            };
+
+            const statusClassName = getStatusClassName();
 
             return (
                 <div
                     ref={tabRef}
-                    className={clsx("tab", {
+                    className={clsx("tab", statusClassName, {
                         active,
                         dragging: isDragging,
                         "before-active": isBeforeActive,
                         "new-tab": isNew,
+                        "has-color": !!tabColor,
                     })}
                     onMouseDown={onDragStart}
                     onClick={onSelect}
                     onContextMenu={handleContextMenu}
                     data-tab-id={id}
                 >
+                    {/* Top stripe for manual color only (VS Code style) */}
+                    {tabColor && <div className="tab-color-stripe" style={{ backgroundColor: tabColor }} />}
                     <div className="tab-inner">
-                        <div
-                            ref={editableRef}
-                            className={clsx("name", { focused: isEditable })}
-                            contentEditable={isEditable}
-                            onDoubleClick={handleRenameTab}
-                            onBlur={handleBlur}
-                            onKeyDown={handleKeyDown}
-                            suppressContentEditableWarning={true}
-                        >
-                            {tabData?.name}
+                        <div className="tab-name-wrapper">
+                            <div
+                                ref={editableRef}
+                                className={clsx("name", { focused: isEditable })}
+                                contentEditable={isEditable}
+                                onDoubleClick={handleRenameTab}
+                                onBlur={handleBlur}
+                                onKeyDown={handleKeyDown}
+                                suppressContentEditableWarning={true}
+                            >
+                                {tabData?.name}
+                            </div>
                         </div>
                         <Button
                             className="ghost grey close"

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -11,6 +11,8 @@
     width: 100vw;
     -webkit-app-region: drag;
     height: max(33px, calc(33px * var(--zoomfactor-inv)));
+    // Darker background for tab bar area (VS Code style)
+    background: color-mix(in srgb, var(--main-bg-color) 70%, black);
 
     button {
         -webkit-app-region: no-drag;

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -52,7 +52,7 @@ const WaveAIButton = memo(() => {
 
     return (
         <div
-            className={`flex h-[26px] px-1.5 justify-end items-center rounded-md mr-1 box-border cursor-pointer bg-hover hover:bg-hoverbg transition-colors text-[12px] ${aiPanelOpen ? "text-accent" : "text-secondary"}`}
+            className={`flex h-[24px] px-1.5 justify-end items-center rounded-md mr-1 mb-0.5 box-border cursor-pointer hover:bg-white/5 transition-colors text-[12px] ${aiPanelOpen ? "text-accent" : "text-secondary"}`}
             style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
             onClick={onClick}
         >
@@ -185,7 +185,6 @@ const TabBar = memo(({ workspace }: TabBarProps) => {
     const draggerLeftRef = useRef<HTMLDivElement>(null);
     const draggerRightRef = useRef<HTMLDivElement>(null);
     const workspaceSwitcherRef = useRef<HTMLDivElement>(null);
-    const appMenuButtonRef = useRef<HTMLDivElement>(null);
     const tabWidthRef = useRef<number>(TabDefaultWidth);
     const scrollableRef = useRef<boolean>(false);
     const updateStatusBannerRef = useRef<HTMLButtonElement>(null);
@@ -194,7 +193,6 @@ const TabBar = memo(({ workspace }: TabBarProps) => {
     const activeTabId = useAtomValue(atoms.staticTabId);
     const isFullScreen = useAtomValue(atoms.isFullScreen);
     const zoomFactor = useAtomValue(atoms.zoomFactorAtom);
-    const settings = useAtomValue(atoms.settingsAtom);
 
     let prevDelta: number;
     let prevDragDirection: string;
@@ -244,7 +242,6 @@ const TabBar = memo(({ workspace }: TabBarProps) => {
         const addBtnWidth = addBtnRef.current.getBoundingClientRect().width;
         const updateStatusLabelWidth = updateStatusBannerRef.current?.getBoundingClientRect().width ?? 0;
         const configErrorWidth = configErrorButtonRef.current?.getBoundingClientRect().width ?? 0;
-        const appMenuButtonWidth = appMenuButtonRef.current?.getBoundingClientRect().width ?? 0;
         const workspaceSwitcherWidth = workspaceSwitcherRef.current?.getBoundingClientRect().width ?? 0;
 
         const nonTabElementsWidth =
@@ -253,7 +250,6 @@ const TabBar = memo(({ workspace }: TabBarProps) => {
             addBtnWidth +
             updateStatusLabelWidth +
             configErrorWidth +
-            appMenuButtonWidth +
             workspaceSwitcherWidth;
         const spaceForTabs = tabbarWrapperWidth - nonTabElementsWidth;
 
@@ -606,12 +602,7 @@ const TabBar = memo(({ workspace }: TabBarProps) => {
         return tabIds.indexOf(tabId) === tabIds.indexOf(activeTabId) - 1;
     };
 
-    function onEllipsisClick() {
-        getApi().showWorkspaceAppMenu(workspace.oid);
-    }
-
     const tabsWrapperWidth = tabIds.length * tabWidthRef.current;
-    const showAppMenuButton = isWindows() || (!isMacOS() && !settings["window:showmenubar"]);
 
     // Calculate window drag left width based on platform and state
     let windowDragLeftWidth = 10;
@@ -646,16 +637,6 @@ const TabBar = memo(({ workspace }: TabBarProps) => {
                 className="h-full shrink-0 z-window-drag"
                 style={{ width: windowDragLeftWidth, WebkitAppRegion: "drag" } as any}
             />
-            {showAppMenuButton && (
-                <div
-                    ref={appMenuButtonRef}
-                    className="flex items-center justify-center pr-1.5 text-[26px] select-none cursor-pointer text-secondary hover:text-primary"
-                    style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
-                    onClick={onEllipsisClick}
-                >
-                    <i className="fa fa-ellipsis" />
-                </div>
-            )}
             <WaveAIButton />
             <WorkspaceSwitcher ref={workspaceSwitcherRef} />
             <div className="tab-bar" ref={tabBarRef} data-overlayscrollbars-initialize>

--- a/frontend/app/tab/workspaceswitcher.scss
+++ b/frontend/app/tab/workspaceswitcher.scss
@@ -3,18 +3,21 @@
 
 .workspace-switcher-button {
     display: flex;
-    height: 26px;
+    height: 24px;
     padding: 0px 12px;
     justify-content: flex-end;
     align-items: center;
     gap: 12px;
     border-radius: 6px;
     margin-right: 6px;
+    margin-bottom: 2px;
     box-sizing: border-box;
-    background-color: rgb(from var(--main-text-color) r g b / 0.1) !important;
+    // No background - icon only with tab bar background showing through
+    background-color: transparent !important;
 
     &:hover {
-        background-color: rgb(from var(--main-text-color) r g b / 0.14) !important;
+        // Subtle hover effect
+        background-color: rgb(255 255 255 / 0.05) !important;
     }
 
     .workspace-icon {

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -302,6 +302,12 @@ const TerminalView = ({ blockId, model }: ViewComponentProps<TermViewModel>) => 
         );
         (window as any).term = termWrap;
         model.termRef.current = termWrap;
+
+        // Set up callback to update tab terminal status when shell integration status changes
+        termWrap.onShellIntegrationStatusChange = () => {
+            model.updateTabTerminalStatus();
+        };
+
         const rszObs = new ResizeObserver(() => {
             termWrap.handleResize_debounced();
         });

--- a/frontend/app/workspace/widgets.tsx
+++ b/frontend/app/workspace/widgets.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from "@/app/element/tooltip";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
-import { atoms, createBlock, isDev } from "@/store/global";
+import { atoms, createBlock, globalStore, isDev } from "@/store/global";
 import { fireAndForget, isBlank, makeIconClass } from "@/util/util";
 import {
     FloatingPortal,
@@ -33,6 +33,46 @@ function sortByDisplayOrder(wmap: { [key: string]: WidgetConfigType }): WidgetCo
 
 async function handleWidgetSelect(widget: WidgetConfigType) {
     const blockDef = widget.blockdef;
+
+    // ===== Tab Base Directory Inheritance for Widgets =====
+    // When launching widgets from the sidebar, inherit the tab's base directory.
+    // This applies to:
+    // - Terminal widgets: Sets cmd:cwd to tab:basedir
+    // - File preview widgets: Sets default browse path to tab:basedir (if currently "~")
+    //
+    // This ensures all blocks within a tab share the same project context,
+    // enabling project-centric workflows where users set tab = project root.
+    const tabData = globalStore.get(atoms.activeTab);
+    let tabBaseDir = tabData?.meta?.["tab:basedir"];
+
+    // Pre-use validation: quickly validate tab basedir before using it
+    if (tabBaseDir && tabBaseDir.trim() !== "") {
+        try {
+            const { validateTabBasedir } = await import("@/store/tab-basedir-validator");
+            const validationResult = await validateTabBasedir(tabData.oid, tabBaseDir);
+            if (!validationResult.valid) {
+                console.warn(
+                    `[widgets] Tab basedir validation failed at use-time: ${tabBaseDir} (${validationResult.reason}). Not using for widget.`
+                );
+                tabBaseDir = null; // Don't use invalid basedir
+            }
+        } catch (error) {
+            console.error("[widgets] Failed to validate tab basedir:", error);
+            tabBaseDir = null; // Don't use basedir on error
+        }
+    }
+
+    if (tabBaseDir) {
+        // For terminal blocks, set the working directory
+        if (blockDef?.meta?.view === "term" && !blockDef.meta["cmd:cwd"]) {
+            blockDef.meta["cmd:cwd"] = tabBaseDir;
+        }
+        // For file preview blocks, set the default file path (only if currently set to home)
+        if (blockDef?.meta?.view === "preview" && blockDef.meta.file === "~") {
+            blockDef.meta.file = tabBaseDir;
+        }
+    }
+
     createBlock(blockDef, widget.magnified);
 }
 

--- a/frontend/app/workspace/workspace.scss
+++ b/frontend/app/workspace/workspace.scss
@@ -1,0 +1,72 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+.tab-breadcrumb {
+    height: 24px;
+    padding: 0 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 12px;
+    color: var(--secondary-text-color);
+    // Computed solid color matching active tab visual appearance:
+    // Active tab = 12% white overlay on tab-bar-wrapper (70% main-bg + 30% black)
+    // This computes the same result as a solid color for seamless connection
+    background: color-mix(in srgb, color-mix(in srgb, var(--main-bg-color) 70%, black) 88%, white);
+    flex-shrink: 0;
+    // Darker shadow to be visible against dark content area
+    box-shadow: 0 2px 4px rgb(0 0 0 / 0.5);
+
+    .breadcrumb-content {
+        display: flex;
+        align-items: center;
+        overflow: hidden;
+    }
+
+    .separator {
+        margin: 0 6px;
+        opacity: 0.5;
+    }
+
+    .segment {
+        white-space: nowrap;
+
+        &:hover {
+            color: var(--main-text-color);
+            cursor: pointer;
+        }
+
+        &:last-child {
+            color: var(--main-text-color);
+        }
+    }
+
+    .breadcrumb-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-left: auto;
+        padding-left: 12px;
+    }
+
+    .menu-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 18px;
+        cursor: pointer;
+        color: var(--secondary-text-color);
+        border-radius: 3px;
+        transition: background-color 0.15s ease;
+
+        &:hover {
+            color: var(--main-text-color);
+            background: rgb(from var(--main-text-color) r g b / 0.1);
+        }
+
+        i {
+            font-size: 14px;
+        }
+    }
+}

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -17,6 +17,7 @@ declare global {
         settingsAtom: jotai.Atom<SettingsType>; // derrived from fullConfig
         hasCustomAIPresetsAtom: jotai.Atom<boolean>; // derived from fullConfig
         staticTabId: jotai.Atom<string>;
+        activeTab: jotai.Atom<Tab>;
         isFullScreen: jotai.PrimitiveAtom<boolean>;
         zoomFactorAtom: jotai.PrimitiveAtom<number>;
         controlShiftDelayAtom: jotai.PrimitiveAtom<boolean>;
@@ -134,6 +135,7 @@ declare global {
         openBuilder: (appId?: string) => void; // open-builder
         setBuilderWindowAppId: (appId: string) => void; // set-builder-window-appid
         doRefresh: () => void; // do-refresh
+        showOpenDialog: (options: OpenDialogOptions) => Promise<string[]>; // show-open-dialog
     };
 
     type ElectronContextMenuItem = {
@@ -504,6 +506,15 @@ declare global {
           };
 
     type AIModeConfigWithMode = { mode: string } & AIModeConfigType;
+
+    type OpenDialogOptions = {
+        title?: string;
+        defaultPath?: string;
+        properties?: Array<"openFile" | "openDirectory" | "multiSelections" | "showHiddenFiles">;
+        filters?: Array<{ name: string; extensions: string[] }>;
+        message?: string;
+        buttonLabel?: string;
+    };
 }
 
 export {};

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -895,6 +895,9 @@ declare global {
         "bg:blendmode"?: string;
         "bg:bordercolor"?: string;
         "bg:activebordercolor"?: string;
+        "tab:basedir"?: string;
+        "tab:basedirlock"?: boolean;
+        "tab:color"?: string;
         "waveai:panelopen"?: boolean;
         "waveai:panelwidth"?: number;
         "waveai:model"?: string;

--- a/frontend/util/pathutil.ts
+++ b/frontend/util/pathutil.ts
@@ -1,0 +1,287 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Path validation utilities for sanitizing untrusted paths from terminal output.
+ * Provides defense against path traversal, injection, and other security attacks.
+ *
+ * Security checks performed:
+ * - Null byte detection (prevents path truncation attacks)
+ * - Path traversal pattern detection (../ sequences)
+ * - UNC path blocking on Windows (prevents network data exfiltration)
+ * - Windows device name blocking (CON, NUL, AUX, etc.)
+ * - Length limit enforcement (prevents DoS via long paths)
+ * - Blocked sensitive directory detection
+ */
+
+import { PLATFORM, PlatformWindows } from "@/util/platformutil";
+
+// Maximum allowed path length (prevent DoS via extremely long paths)
+const MAX_PATH_LENGTH = 4096;
+
+// Windows device names (special files that can cause issues)
+const WINDOWS_DEVICE_NAMES = [
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9",
+];
+
+// Blocked directory patterns by platform
+const BLOCKED_PATHS_UNIX = [
+    "/etc",
+    "/root",
+    "/var/log",
+    "/boot",
+    "/sys",
+    "/proc",
+    "/dev",
+    "/private/etc", // macOS
+    "/private/var", // macOS
+    "/System", // macOS
+    "/Library/System",
+];
+
+const BLOCKED_PATHS_WINDOWS = [
+    "C:\\Windows",
+    "C:\\Windows\\System32",
+    "C:\\Windows\\SysWOW64",
+    "C:\\Program Files",
+    "C:\\Program Files (x86)",
+    "C:\\ProgramData",
+    "C:\\Recovery",
+    "C:\\$Recycle.Bin",
+];
+
+/**
+ * Checks if a string contains null bytes (injection attack).
+ */
+export function hasNullBytes(str: string): boolean {
+    return str.includes("\0");
+}
+
+/**
+ * Checks if a path contains path traversal sequences.
+ * Detects both Unix (..) and Windows-style traversal patterns.
+ */
+export function containsPathTraversal(path: string): boolean {
+    // Check for .. sequences in various forms
+    // Unix: ../ or /..
+    // Windows: ..\ or \..
+    // Exact match: just ".."
+    // Trailing: ends with ".."
+
+    // Pattern: .. followed by / or \
+    if (/\.\.[\/\\]/.test(path)) {
+        return true;
+    }
+
+    // Pattern: / or \ followed by ..
+    if (/[\/\\]\.\./.test(path)) {
+        return true;
+    }
+
+    // Pattern: exactly ".."
+    if (path === "..") {
+        return true;
+    }
+
+    // Pattern: ends with ".." (Windows trailing dots attack vector)
+    if (path.endsWith("..")) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Checks if a path is a UNC path (Windows network path).
+ * UNC paths start with \\ and can be used for data exfiltration.
+ */
+export function isUncPath(path: string): boolean {
+    // Standard UNC: \\server\share
+    if (path.startsWith("\\\\")) {
+        return true;
+    }
+
+    // URL-style UNC that might slip through: //server/share
+    // (if it starts with // followed by non-slash)
+    if (/^\/\/[^\/]/.test(path)) {
+        return true;
+    }
+
+    // UNC path that was prefixed with / (from URL parsing)
+    if (path.startsWith("/\\\\")) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Checks if a path contains invalid characters for the platform.
+ * On Windows, checks for reserved characters.
+ */
+export function hasInvalidChars(path: string, platform: string): boolean {
+    if (platform === PlatformWindows) {
+        // Windows reserved characters (except \ and / which are path separators)
+        // < > : " | ? * and control characters
+        // Note: : is allowed as second char for drive letter
+        const pathWithoutDrive = path.length >= 2 && path[1] === ":" ? path.substring(2) : path;
+        if (/[<>"|?*]/.test(pathWithoutDrive)) {
+            return true;
+        }
+        // Control characters (0x00-0x1F)
+        if (/[\x00-\x1F]/.test(path)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Checks if a path matches a Windows device name.
+ * Device names like CON, NUL, AUX can cause issues.
+ */
+function isWindowsDeviceName(path: string): boolean {
+    // Get just the filename/last component
+    const parts = path.split(/[\/\\]/);
+    const filename = parts[parts.length - 1] || path;
+
+    // Extract name without extension
+    const nameWithoutExt = filename.split(".")[0].toUpperCase();
+
+    return WINDOWS_DEVICE_NAMES.includes(nameWithoutExt);
+}
+
+/**
+ * Checks if a normalized path starts with or equals a blocked path.
+ */
+export function isBlockedPath(normalizedPath: string): boolean {
+    const blockedPaths = PLATFORM === PlatformWindows ? BLOCKED_PATHS_WINDOWS : BLOCKED_PATHS_UNIX;
+
+    const lowerPath = normalizedPath.toLowerCase();
+
+    for (const blocked of blockedPaths) {
+        const lowerBlocked = blocked.toLowerCase();
+        // Check exact match or path starts with blocked + separator
+        if (
+            lowerPath === lowerBlocked ||
+            lowerPath.startsWith(lowerBlocked + "/") ||
+            lowerPath.startsWith(lowerBlocked + "\\")
+        ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export type PathValidationResult = {
+    valid: boolean;
+    reason?: string;
+};
+
+/**
+ * Performs quick synchronous validation of a path without filesystem access.
+ * This is the first line of defense against obviously malicious paths.
+ *
+ * @param rawPath - The untrusted path to validate
+ * @returns Validation result with valid flag and optional reason for rejection
+ */
+export function quickValidatePath(rawPath: string): PathValidationResult {
+    // Check for empty/whitespace
+    if (!rawPath || rawPath.trim() === "") {
+        return { valid: false, reason: "empty path" };
+    }
+
+    // Check length limit
+    if (rawPath.length > MAX_PATH_LENGTH) {
+        return { valid: false, reason: "path too long" };
+    }
+
+    // Check for null bytes (path truncation attack)
+    if (hasNullBytes(rawPath)) {
+        return { valid: false, reason: "null byte detected" };
+    }
+
+    // Check for path traversal patterns
+    if (containsPathTraversal(rawPath)) {
+        return { valid: false, reason: "path traversal detected" };
+    }
+
+    // Check for UNC paths (Windows network paths - security risk)
+    if (isUncPath(rawPath)) {
+        return { valid: false, reason: "UNC path detected" };
+    }
+
+    // Check for Windows device names
+    if (PLATFORM === PlatformWindows) {
+        if (isWindowsDeviceName(rawPath)) {
+            return { valid: false, reason: "Windows device name" };
+        }
+
+        // Check for invalid characters on Windows
+        if (hasInvalidChars(rawPath, PlatformWindows)) {
+            return { valid: false, reason: "invalid characters" };
+        }
+    }
+
+    return { valid: true };
+}
+
+/**
+ * Sanitizes a path from OSC 7 terminal escape sequence.
+ * Returns the validated path or null if the path should be rejected.
+ *
+ * This function performs:
+ * 1. Quick synchronous validation (pattern-based)
+ * 2. Blocked path checking
+ *
+ * Note: Filesystem-based validation (symlink resolution, existence check)
+ * is handled separately via IPC to the main process.
+ *
+ * @param rawPath - The untrusted path from terminal output (already URL-decoded)
+ * @returns Validated path string or null if rejected
+ */
+export function sanitizeOsc7Path(rawPath: string): string | null {
+    // Quick synchronous checks first
+    const quickResult = quickValidatePath(rawPath);
+    if (!quickResult.valid) {
+        console.warn(`[Security] OSC 7 path rejected (${quickResult.reason}):`, rawPath);
+        return null;
+    }
+
+    // Normalize the path for blocked path checking
+    // Note: We don't resolve symlinks here - that requires filesystem access
+    let normalizedPath = rawPath;
+
+    // Check against blocked paths
+    if (isBlockedPath(normalizedPath)) {
+        console.warn("[Security] OSC 7 blocked path rejected:", normalizedPath);
+        return null;
+    }
+
+    // Path passed all synchronous checks
+    // Non-existent paths are allowed per spec-005 - they will be warned about
+    // when used, but not rejected here
+    return normalizedPath;
+}

--- a/frontend/util/presetutil.ts
+++ b/frontend/util/presetutil.ts
@@ -1,0 +1,127 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Preset validation utilities for frontend defense-in-depth.
+ * These provide early feedback before backend validation.
+ */
+
+export interface PresetValidationResult {
+    valid: boolean;
+    error?: string;
+    warnings?: string[];
+}
+
+/**
+ * Key allowlists by preset type prefix.
+ * Defines which metadata keys each preset type is allowed to set.
+ */
+export const PRESET_KEY_ALLOWLISTS: Record<string, Set<string>> = {
+    "tabvar@": new Set([
+        "tab:basedir",
+        "tab:basedirlock",
+        "display:name",
+        "display:order"
+    ]),
+    "bg@": new Set([
+        "bg:*",
+        "bg",
+        "bg:opacity",
+        "bg:blendmode",
+        "bg:bordercolor",
+        "bg:activebordercolor",
+        "bg:text",
+        "display:name",
+        "display:order"
+    ]),
+};
+
+/**
+ * Validates a preset before application.
+ * Returns validation result with error details if invalid.
+ */
+export function validatePresetBeforeApply(
+    presetName: string,
+    presetData: Record<string, any>
+): PresetValidationResult {
+    const warnings: string[] = [];
+
+    // Determine preset type from name prefix
+    let presetType: string | null = null;
+    for (const prefix of Object.keys(PRESET_KEY_ALLOWLISTS)) {
+        if (presetName.startsWith(prefix)) {
+            presetType = prefix;
+            break;
+        }
+    }
+
+    // If preset type not recognized, allow but warn
+    if (!presetType) {
+        warnings.push(`Unknown preset type: ${presetName}`);
+        return { valid: true, warnings };
+    }
+
+    const allowedKeys = PRESET_KEY_ALLOWLISTS[presetType];
+    const disallowedKeys: string[] = [];
+
+    // Check each key in the preset
+    for (const key of Object.keys(presetData)) {
+        // Skip display keys (always allowed)
+        if (key.startsWith("display:")) {
+            continue;
+        }
+
+        if (!allowedKeys.has(key)) {
+            disallowedKeys.push(key);
+        }
+    }
+
+    if (disallowedKeys.length > 0) {
+        return {
+            valid: false,
+            error: `Preset "${presetName}" contains keys not allowed for its type: ${disallowedKeys.join(", ")}`
+        };
+    }
+
+    return { valid: true, warnings: warnings.length > 0 ? warnings : undefined };
+}
+
+/**
+ * Sanitizes a preset by removing disallowed keys.
+ * Returns a new preset object with only allowed keys.
+ */
+export function sanitizePreset(
+    presetName: string,
+    presetData: Record<string, any>
+): Record<string, any> {
+    // Determine preset type from name prefix
+    let presetType: string | null = null;
+    for (const prefix of Object.keys(PRESET_KEY_ALLOWLISTS)) {
+        if (presetName.startsWith(prefix)) {
+            presetType = prefix;
+            break;
+        }
+    }
+
+    // If preset type not recognized, return as-is (backend will validate)
+    if (!presetType) {
+        return presetData;
+    }
+
+    const allowedKeys = PRESET_KEY_ALLOWLISTS[presetType];
+    const sanitized: Record<string, any> = {};
+
+    for (const [key, value] of Object.entries(presetData)) {
+        // Always allow display keys
+        if (key.startsWith("display:")) {
+            sanitized[key] = value;
+            continue;
+        }
+
+        if (allowedKeys.has(key)) {
+            sanitized[key] = value;
+        }
+    }
+
+    return sanitized;
+}

--- a/frontend/wave.ts
+++ b/frontend/wave.ts
@@ -190,6 +190,11 @@ async function initWave(initOpts: WaveInitOpts) {
     registerGlobalKeys();
     registerElectronReinjectKeyHandler();
     registerControlShiftStateUpdateHandler();
+
+    // Initialize tab base directory validation
+    const { initTabBasedirValidation } = await import("@/store/tab-basedir-validation-hook");
+    initTabBasedirValidation();
+
     await loadMonaco();
     const fullConfig = await RpcApi.GetFullConfigCommand(TabRpcClient);
     console.log("fullconfig", fullConfig);

--- a/pkg/util/shellutil/shellintegration/pwsh_wavepwsh.sh
+++ b/pkg/util/shellutil/shellintegration/pwsh_wavepwsh.sh
@@ -13,10 +13,12 @@ Remove-Item Env:WAVETERM_SWAPTOKEN
 wsh completion powershell | Out-String | Invoke-Expression
 
 if ($PSVersionTable.PSVersion.Major -lt 7) {
-    return  # skip OSC setup entirely
+    return  # skip OSC setup entirely - PSReadLine hooks require PS7+
 }
 
 $Global:_WAVETERM_SI_FIRSTPROMPT = $true
+$Global:_WAVETERM_SI_LASTEXITCODE = 0
+$Global:_WAVETERM_SI_COMMAND_STARTED = $false
 
 # shell integration
 function Global:_waveterm_si_blocked {
@@ -26,28 +28,97 @@ function Global:_waveterm_si_blocked {
 
 function Global:_waveterm_si_osc7 {
     if (_waveterm_si_blocked) { return }
-    
+
     # Percent-encode the raw path as-is (handles UNC, drive letters, etc.)
     $encoded_pwd = [System.Uri]::EscapeDataString($PWD.Path)
-    
+
     # OSC 7 - current directory
     Write-Host -NoNewline "`e]7;file://localhost/$encoded_pwd`a"
 }
 
-function Global:_waveterm_si_prompt {
+# OSC 16162 commands for full shell integration
+# A = ready (at prompt)
+# C = command started (with base64 encoded command)
+# D = command done (with exit code)
+
+function Global:_waveterm_si_send_ready {
     if (_waveterm_si_blocked) { return }
-    
-    if ($Global:_WAVETERM_SI_FIRSTPROMPT) {
-		# not sending uname
-		       $shellversion = $PSVersionTable.PSVersion.ToString()
-		       Write-Host -NoNewline "`e]16162;M;{`"shell`":`"pwsh`",`"shellversion`":`"$shellversion`",`"integration`":false}`a"
-        $Global:_WAVETERM_SI_FIRSTPROMPT = $false
-    }
-    
-    _waveterm_si_osc7
+    Write-Host -NoNewline "`e]16162;A`a"
 }
 
-# Add the OSC 7 call to the prompt function
+function Global:_waveterm_si_send_command {
+    param([string]$Command)
+    if (_waveterm_si_blocked) { return }
+    if ([string]::IsNullOrWhiteSpace($Command)) { return }
+
+    # Base64 encode the command
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($Command)
+    $cmd64 = [System.Convert]::ToBase64String($bytes)
+
+    # Limit command length to avoid issues
+    if ($cmd64.Length -gt 8192) {
+        Write-Host -NoNewline "`e]16162;C`a"
+    } else {
+        Write-Host -NoNewline "`e]16162;C;{`"cmd64`":`"$cmd64`"}`a"
+    }
+    $Global:_WAVETERM_SI_COMMAND_STARTED = $true
+}
+
+function Global:_waveterm_si_send_done {
+    param([int]$ExitCode)
+    if (_waveterm_si_blocked) { return }
+    if (-not $Global:_WAVETERM_SI_COMMAND_STARTED) { return }
+
+    Write-Host -NoNewline "`e]16162;D;{`"exitcode`":$ExitCode}`a"
+    $Global:_WAVETERM_SI_COMMAND_STARTED = $false
+}
+
+function Global:_waveterm_si_prompt {
+    if (_waveterm_si_blocked) { return }
+
+    # Capture exit code immediately (before any other commands change it)
+    $currentExitCode = if ($?) { 0 } else { if ($LASTEXITCODE) { $LASTEXITCODE } else { 1 } }
+
+    if ($Global:_WAVETERM_SI_FIRSTPROMPT) {
+        # Send metadata on first prompt
+        $shellversion = $PSVersionTable.PSVersion.ToString()
+        Write-Host -NoNewline "`e]16162;M;{`"shell`":`"pwsh`",`"shellversion`":`"$shellversion`",`"integration`":true}`a"
+        $Global:_WAVETERM_SI_FIRSTPROMPT = $false
+    } else {
+        # Send command done for previous command (if any)
+        _waveterm_si_send_done -ExitCode $currentExitCode
+    }
+
+    # Send OSC 7 for current directory
+    _waveterm_si_osc7
+
+    # Send ready signal
+    _waveterm_si_send_ready
+}
+
+# Hook into PSReadLine to detect when commands are executed
+# This is called just before a command is accepted and executed
+if (Get-Module PSReadLine) {
+    # Save any existing AcceptLine handler
+    $existingHandler = (Get-PSReadLineKeyHandler -Chord Enter | Where-Object { $_.Function -eq 'AcceptLine' })
+
+    # Create a wrapper that sends command notification before executing
+    Set-PSReadLineKeyHandler -Chord Enter -ScriptBlock {
+        $line = $null
+        $cursor = $null
+        [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
+
+        # Send command started notification
+        if (-not [string]::IsNullOrWhiteSpace($line)) {
+            _waveterm_si_send_command -Command $line
+        }
+
+        # Call the original AcceptLine function
+        [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+    }
+}
+
+# Add the prompt hooks
 if (Test-Path Function:\prompt) {
     $global:_waveterm_original_prompt = $function:prompt
     function Global:prompt {

--- a/pkg/waveobj/metaconsts.go
+++ b/pkg/waveobj/metaconsts.go
@@ -94,6 +94,11 @@ const (
 	MetaKey_BgBlendMode                      = "bg:blendmode"
 	MetaKey_BgBorderColor                    = "bg:bordercolor"
 	MetaKey_BgActiveBorderColor              = "bg:activebordercolor"
+	MetaKey_BgText                           = "bg:text"
+
+	MetaKey_TabBaseDir                       = "tab:basedir"
+	MetaKey_TabBaseDirLock                   = "tab:basedirlock"
+	MetaKey_TabColor                         = "tab:color"
 
 	MetaKey_WaveAiPanelOpen                  = "waveai:panelopen"
 	MetaKey_WaveAiPanelWidth                 = "waveai:panelwidth"

--- a/pkg/waveobj/validators.go
+++ b/pkg/waveobj/validators.go
@@ -1,0 +1,921 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package waveobj
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/wavetermdev/waveterm/pkg/wavebase"
+)
+
+// Validation constants
+const (
+	MaxPathLength      = 4096
+	MaxStringLength    = 256
+	MaxURLLength       = 2048
+	MaxCommandLength   = 65536   // 64KB
+	MaxScriptLength    = 1048576 // 1MB
+	MaxArrayItems      = 256
+	MaxMapEntries      = 1024
+	MaxArrayItemLength = 4096
+	MaxMapKeyLength    = 256
+	MaxMapValueLength  = 4096
+)
+
+// ValidationError provides detailed error information
+type ValidationError struct {
+	Key     string
+	Value   interface{}
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("invalid metadata %s: %s", e.Key, e.Message)
+}
+
+// ValidationFunc is the signature for field validators
+type ValidationFunc func(key string, value interface{}) error
+
+// ValidateMetadata validates metadata for a specific object type
+func ValidateMetadata(oref ORef, meta MetaMapType) error {
+	validators := getValidatorsForOType(oref.OType)
+
+	for key, value := range meta {
+		if value == nil {
+			// Null means delete - always allowed
+			continue
+		}
+
+		if validator, ok := validators[key]; ok {
+			if err := validator(key, value); err != nil {
+				return err
+			}
+		}
+		// Unknown keys pass through without validation (extensibility)
+	}
+
+	return nil
+}
+
+func getValidatorsForOType(otype string) map[string]ValidationFunc {
+	switch otype {
+	case OType_Tab:
+		return tabValidators
+	case OType_Block:
+		return blockValidators
+	case OType_Workspace:
+		return workspaceValidators
+	case OType_Window:
+		return windowValidators
+	default:
+		return commonValidators
+	}
+}
+
+// ValidatePath checks path fields for security and validity
+func ValidatePath(key string, value interface{}, mustBeDir bool) error {
+	// Allow clearing (nil handled by caller)
+	if value == nil {
+		return nil
+	}
+
+	path, ok := value.(string)
+	if !ok {
+		return &ValidationError{
+			Key:     key,
+			Value:   value,
+			Message: fmt.Sprintf("must be a string, got %T", value),
+		}
+	}
+
+	// Allow empty to clear
+	if path == "" {
+		return nil
+	}
+
+	// Length check (DoS protection)
+	if len(path) > MaxPathLength {
+		return &ValidationError{
+			Key:     key,
+			Value:   truncateForError(path, 50),
+			Message: fmt.Sprintf("path too long (max %d characters)", MaxPathLength),
+		}
+	}
+
+	// Null byte check (security)
+	if strings.Contains(path, "\x00") {
+		return &ValidationError{
+			Key:     key,
+			Value:   "[contains null byte]",
+			Message: "path contains null byte",
+		}
+	}
+
+	// Path traversal check using absolute path comparison
+	if err := checkPathTraversal(path); err != nil {
+		return &ValidationError{
+			Key:     key,
+			Value:   path,
+			Message: err.Error(),
+		}
+	}
+
+	// Expand home directory for existence checks
+	expandedPath := path
+	if strings.HasPrefix(path, "~") {
+		expanded, err := wavebase.ExpandHomeDir(path)
+		if err != nil {
+			// ExpandHomeDir already checks for traversal
+			return &ValidationError{
+				Key:     key,
+				Value:   path,
+				Message: err.Error(),
+			}
+		}
+		expandedPath = expanded
+	}
+
+	// Check existence and type (soft validation - warn but allow)
+	info, err := os.Stat(expandedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Log warning but allow non-existent paths
+			// This enables setting paths before directories are created
+			log.Printf("[validation] warning: %s path does not exist: %s", key, expandedPath)
+			return nil
+		}
+		if os.IsPermission(err) {
+			// Permission error - also warn but allow
+			log.Printf("[validation] warning: %s path not accessible: %s", key, expandedPath)
+			return nil
+		}
+		// Other errors - allow with warning
+		log.Printf("[validation] warning: %s path check failed: %s: %v", key, expandedPath, err)
+		return nil
+	}
+
+	// Directory check (hard validation if file exists)
+	if mustBeDir && !info.IsDir() {
+		return &ValidationError{
+			Key:     key,
+			Value:   path,
+			Message: "path is not a directory",
+		}
+	}
+
+	return nil
+}
+
+// checkPathTraversal performs absolute path comparison to detect traversal
+func checkPathTraversal(path string) error {
+	// Clean the path first
+	cleanPath := filepath.Clean(path)
+
+	// Convert to absolute path for comparison
+	absPath := cleanPath
+	if !filepath.IsAbs(cleanPath) {
+		// For relative paths starting with ~, expand first
+		if strings.HasPrefix(cleanPath, "~") {
+			var err error
+			absPath, err = wavebase.ExpandHomeDir(cleanPath)
+			if err != nil {
+				return fmt.Errorf("path expansion failed: %w", err)
+			}
+		} else {
+			// Get absolute path relative to cwd
+			cwd, err := os.Getwd()
+			if err != nil {
+				// If we can't get cwd, fall back to string check
+				if strings.Contains(cleanPath, "..") {
+					return fmt.Errorf("path traversal sequence detected")
+				}
+				return nil
+			}
+			absPath = filepath.Join(cwd, cleanPath)
+		}
+	}
+
+	// For Windows UNC paths (\\server\share\path)
+	if runtime.GOOS == "windows" && strings.HasPrefix(path, "\\\\") {
+		// UNC paths should not traverse above the share
+		parts := strings.Split(filepath.Clean(path), string(filepath.Separator))
+		if len(parts) >= 4 { // \\server\share\...
+			sharePath := filepath.Join(parts[0], parts[1], parts[2], parts[3])
+			if !strings.HasPrefix(filepath.Clean(path), sharePath) {
+				return fmt.Errorf("path traversal detected in UNC path")
+			}
+		}
+	}
+
+	// Final check: compare cleaned path segments
+	// If ".." appears after cleaning, it's traversing
+	absPathClean := filepath.Clean(absPath)
+	segments := strings.Split(absPathClean, string(filepath.Separator))
+	for _, seg := range segments {
+		if seg == ".." {
+			return fmt.Errorf("path traversal sequence detected after normalization")
+		}
+	}
+
+	return nil
+}
+
+// ValidateBool ensures value is a boolean
+func ValidateBool(key string, value interface{}) error {
+	if value == nil {
+		return nil
+	}
+
+	if _, ok := value.(bool); !ok {
+		return &ValidationError{
+			Key:     key,
+			Value:   value,
+			Message: fmt.Sprintf("must be a boolean, got %T", value),
+		}
+	}
+	return nil
+}
+
+// ValidateNullableBool ensures value is nil or boolean
+func ValidateNullableBool(key string, value interface{}) error {
+	if value == nil {
+		return nil // nil is valid for pointer types
+	}
+
+	if _, ok := value.(bool); !ok {
+		return &ValidationError{
+			Key:     key,
+			Value:   value,
+			Message: fmt.Sprintf("must be a boolean or null, got %T", value),
+		}
+	}
+	return nil
+}
+
+// ValidateString ensures value is a string within length limits
+func ValidateString(key string, value interface{}, maxLen int) error {
+	if value == nil {
+		return nil
+	}
+
+	s, ok := value.(string)
+	if !ok {
+		return &ValidationError{
+			Key:     key,
+			Value:   value,
+			Message: fmt.Sprintf("must be a string, got %T", value),
+		}
+	}
+
+	if maxLen > 0 && len(s) > maxLen {
+		return &ValidationError{
+			Key:     key,
+			Value:   truncateForError(s, 50),
+			Message: fmt.Sprintf("exceeds maximum length of %d characters", maxLen),
+		}
+	}
+
+	if strings.Contains(s, "\x00") {
+		return &ValidationError{
+			Key:     key,
+			Value:   "[contains null byte]",
+			Message: "contains null byte",
+		}
+	}
+
+	return nil
+}
+
+// ValidateInt ensures value is an integer within range
+func ValidateInt(key string, value interface{}, minVal, maxVal int) error {
+	if value == nil {
+		return nil
+	}
+
+	// JSON numbers come as float64
+	f, ok := value.(float64)
+	if !ok {
+		return &ValidationError{
+			Key:     key,
+			Value:   value,
+			Message: fmt.Sprintf("must be a number, got %T", value),
+		}
+	}
+
+	i := int(f)
+	if i < minVal || i > maxVal {
+		return &ValidationError{
+			Key:     key,
+			Value:   i,
+			Message: fmt.Sprintf("must be between %d and %d", minVal, maxVal),
+		}
+	}
+
+	return nil
+}
+
+// ValidateNullableInt ensures value is nil or integer within range
+func ValidateNullableInt(key string, value interface{}, minVal, maxVal int) error {
+	if value == nil {
+		return nil // nil is valid for pointer types
+	}
+
+	// JSON numbers come as float64
+	f, ok := value.(float64)
+	if !ok {
+		return &ValidationError{
+			Key:     key,
+			Value:   value,
+			Message: fmt.Sprintf("must be a number or null, got %T", value),
+		}
+	}
+
+	i := int(f)
+	if i < minVal || i > maxVal {
+		return &ValidationError{
+			Key:     key,
+			Value:   i,
+			Message: fmt.Sprintf("must be between %d and %d", minVal, maxVal),
+		}
+	}
+
+	return nil
+}
+
+// ValidateFloat ensures value is a float within range
+func ValidateFloat(key string, value interface{}, minVal, maxVal float64) error {
+	if value == nil {
+		return nil
+	}
+
+	f, ok := value.(float64)
+	if !ok {
+		return &ValidationError{
+			Key:     key,
+			Value:   value,
+			Message: fmt.Sprintf("must be a number, got %T", value),
+		}
+	}
+
+	if f < minVal || f > maxVal {
+		return &ValidationError{
+			Key:     key,
+			Value:   f,
+			Message: fmt.Sprintf("must be between %.2f and %.2f", minVal, maxVal),
+		}
+	}
+
+	return nil
+}
+
+// ValidateNullableFloat ensures value is nil or float within range
+func ValidateNullableFloat(key string, value interface{}, minVal, maxVal float64) error {
+	if value == nil {
+		return nil // nil is valid for pointer types
+	}
+
+	f, ok := value.(float64)
+	if !ok {
+		return &ValidationError{
+			Key:     key,
+			Value:   value,
+			Message: fmt.Sprintf("must be a number or null, got %T", value),
+		}
+	}
+
+	if f < minVal || f > maxVal {
+		return &ValidationError{
+			Key:     key,
+			Value:   f,
+			Message: fmt.Sprintf("must be between %.2f and %.2f", minVal, maxVal),
+		}
+	}
+
+	return nil
+}
+
+// ValidateURL ensures value is a valid URL
+func ValidateURL(key string, value interface{}, allowedSchemes []string) error {
+	if value == nil {
+		return nil
+	}
+
+	s, ok := value.(string)
+	if !ok {
+		return &ValidationError{
+			Key:     key,
+			Value:   value,
+			Message: fmt.Sprintf("must be a string, got %T", value),
+		}
+	}
+
+	if s == "" {
+		return nil
+	}
+
+	if len(s) > MaxURLLength {
+		return &ValidationError{
+			Key:     key,
+			Value:   truncateForError(s, 50),
+			Message: fmt.Sprintf("URL too long (max %d characters)", MaxURLLength),
+		}
+	}
+
+	parsed, err := url.Parse(s)
+	if err != nil {
+		return &ValidationError{
+			Key:     key,
+			Value:   s,
+			Message: fmt.Sprintf("invalid URL: %v", err),
+		}
+	}
+
+	if len(allowedSchemes) > 0 {
+		schemeAllowed := false
+		for _, scheme := range allowedSchemes {
+			if parsed.Scheme == scheme {
+				schemeAllowed = true
+				break
+			}
+		}
+		if !schemeAllowed {
+			return &ValidationError{
+				Key:     key,
+				Value:   s,
+				Message: fmt.Sprintf("URL scheme must be one of: %v", allowedSchemes),
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateStringArray validates array fields like cmd:args
+func ValidateStringArray(key string, value interface{}, maxLen, maxItems int) error {
+	if value == nil {
+		return nil
+	}
+
+	arr, ok := value.([]interface{})
+	if !ok {
+		return &ValidationError{
+			Key:     key,
+			Value:   value,
+			Message: fmt.Sprintf("must be an array, got %T", value),
+		}
+	}
+
+	if len(arr) > maxItems {
+		return &ValidationError{
+			Key:     key,
+			Value:   fmt.Sprintf("[%d items]", len(arr)),
+			Message: fmt.Sprintf("array exceeds maximum of %d items", maxItems),
+		}
+	}
+
+	for i, item := range arr {
+		s, ok := item.(string)
+		if !ok {
+			return &ValidationError{
+				Key:     key,
+				Value:   fmt.Sprintf("item[%d]", i),
+				Message: fmt.Sprintf("array item must be string, got %T", item),
+			}
+		}
+
+		if len(s) > maxLen {
+			return &ValidationError{
+				Key:     key,
+				Value:   fmt.Sprintf("item[%d]", i),
+				Message: fmt.Sprintf("array item exceeds maximum length of %d", maxLen),
+			}
+		}
+
+		if strings.Contains(s, "\x00") {
+			return &ValidationError{
+				Key:     key,
+				Value:   fmt.Sprintf("item[%d]", i),
+				Message: "array item contains null byte",
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateStringMap validates map fields like cmd:env
+func ValidateStringMap(key string, value interface{}, maxKeyLen, maxValueLen int) error {
+	if value == nil {
+		return nil
+	}
+
+	m, ok := value.(map[string]interface{})
+	if !ok {
+		return &ValidationError{
+			Key:     key,
+			Value:   value,
+			Message: fmt.Sprintf("must be an object/map, got %T", value),
+		}
+	}
+
+	if len(m) > MaxMapEntries {
+		return &ValidationError{
+			Key:     key,
+			Value:   fmt.Sprintf("{%d entries}", len(m)),
+			Message: fmt.Sprintf("map exceeds maximum of %d entries", MaxMapEntries),
+		}
+	}
+
+	for k, v := range m {
+		// Validate key
+		if len(k) > maxKeyLen {
+			return &ValidationError{
+				Key:     key,
+				Value:   fmt.Sprintf("key: %s", truncateForError(k, 20)),
+				Message: fmt.Sprintf("map key exceeds maximum length of %d", maxKeyLen),
+			}
+		}
+
+		if strings.Contains(k, "\x00") {
+			return &ValidationError{
+				Key:     key,
+				Value:   fmt.Sprintf("key: %s", k),
+				Message: "map key contains null byte",
+			}
+		}
+
+		// Validate value - allow nil for deletion
+		if v == nil {
+			continue
+		}
+
+		vs, ok := v.(string)
+		if !ok {
+			return &ValidationError{
+				Key:     key,
+				Value:   fmt.Sprintf("value for key: %s", k),
+				Message: fmt.Sprintf("map value must be string, got %T", v),
+			}
+		}
+
+		if len(vs) > maxValueLen {
+			return &ValidationError{
+				Key:     key,
+				Value:   fmt.Sprintf("value for key: %s", k),
+				Message: fmt.Sprintf("map value exceeds maximum length of %d", maxValueLen),
+			}
+		}
+
+		if strings.Contains(vs, "\x00") {
+			return &ValidationError{
+				Key:     key,
+				Value:   fmt.Sprintf("value for key: %s", k),
+				Message: "map value contains null byte",
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateCommand validates command execution strings
+func ValidateCommand(key string, value interface{}) error {
+	return ValidateString(key, value, MaxCommandLength)
+}
+
+// ValidateScript validates script content
+func ValidateScript(key string, value interface{}) error {
+	return ValidateString(key, value, MaxScriptLength)
+}
+
+// truncateForError truncates a string for display in error messages
+func truncateForError(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// Common validators for all object types
+var commonValidators = map[string]ValidationFunc{
+	MetaKey_DisplayName: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxStringLength)
+	},
+	MetaKey_Icon: func(k string, v interface{}) error {
+		return ValidateString(k, v, 128)
+	},
+	MetaKey_IconColor: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+}
+
+// Tab-specific validators
+var tabValidators = map[string]ValidationFunc{
+	MetaKey_TabBaseDir: func(k string, v interface{}) error {
+		return ValidatePath(k, v, true) // must be directory
+	},
+	MetaKey_TabBaseDirLock: ValidateBool,
+	MetaKey_Bg: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxURLLength)
+	},
+	MetaKey_BgOpacity: func(k string, v interface{}) error {
+		return ValidateFloat(k, v, 0.0, 1.0)
+	},
+}
+
+// Workspace-specific validators
+var workspaceValidators = map[string]ValidationFunc{
+	MetaKey_Bg: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxURLLength)
+	},
+	MetaKey_BgOpacity: func(k string, v interface{}) error {
+		return ValidateFloat(k, v, 0.0, 1.0)
+	},
+}
+
+// Window-specific validators
+var windowValidators = map[string]ValidationFunc{
+	MetaKey_Bg: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxURLLength)
+	},
+	MetaKey_BgOpacity: func(k string, v interface{}) error {
+		return ValidateFloat(k, v, 0.0, 1.0)
+	},
+}
+
+// Block-specific validators
+var blockValidators = map[string]ValidationFunc{
+	// HIGH RISK: Command execution fields
+	MetaKey_Cmd:               ValidateCommand,
+	MetaKey_CmdInitScript:     ValidateScript,
+	MetaKey_CmdInitScriptSh:   ValidateScript,
+	MetaKey_CmdInitScriptBash: ValidateScript,
+	MetaKey_CmdInitScriptZsh:  ValidateScript,
+	MetaKey_CmdInitScriptPwsh: ValidateScript,
+	MetaKey_CmdInitScriptFish: ValidateScript,
+	MetaKey_CmdArgs: func(k string, v interface{}) error {
+		return ValidateStringArray(k, v, MaxArrayItemLength, MaxArrayItems)
+	},
+	MetaKey_CmdEnv: func(k string, v interface{}) error {
+		return ValidateStringMap(k, v, MaxMapKeyLength, MaxMapValueLength)
+	},
+
+	// Path fields
+	MetaKey_CmdCwd: func(k string, v interface{}) error {
+		return ValidatePath(k, v, true) // must be directory
+	},
+	MetaKey_File: func(k string, v interface{}) error {
+		return ValidatePath(k, v, false) // can be file or directory
+	},
+	MetaKey_TsunamiAppPath: func(k string, v interface{}) error {
+		return ValidatePath(k, v, true)
+	},
+	MetaKey_TsunamiScaffoldPath: func(k string, v interface{}) error {
+		return ValidatePath(k, v, true)
+	},
+	MetaKey_TsunamiSdkReplacePath: func(k string, v interface{}) error {
+		return ValidatePath(k, v, true)
+	},
+	MetaKey_TermLocalShellPath: func(k string, v interface{}) error {
+		return ValidatePath(k, v, false) // executable file
+	},
+
+	// URL fields
+	MetaKey_Url: func(k string, v interface{}) error {
+		return ValidateURL(k, v, []string{"http", "https", "file"})
+	},
+	MetaKey_PinnedUrl: func(k string, v interface{}) error {
+		return ValidateURL(k, v, []string{"http", "https", "file"})
+	},
+	MetaKey_AiBaseURL: func(k string, v interface{}) error {
+		return ValidateURL(k, v, []string{"http", "https"})
+	},
+
+	// String fields
+	MetaKey_View: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_Controller: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_Connection: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxStringLength)
+	},
+	MetaKey_FrameTitle: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxStringLength)
+	},
+	MetaKey_FrameIcon: func(k string, v interface{}) error {
+		return ValidateString(k, v, 128)
+	},
+	MetaKey_FrameText: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxStringLength)
+	},
+	MetaKey_FrameBorderColor: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_FrameActiveBorderColor: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_AiPresetKey: func(k string, v interface{}) error {
+		return ValidateString(k, v, 128)
+	},
+	MetaKey_AiApiType: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_AiApiToken: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxURLLength) // API tokens can be long
+	},
+	MetaKey_AiName: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxStringLength)
+	},
+	MetaKey_AiModel: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxStringLength)
+	},
+	MetaKey_AiOrgID: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxStringLength)
+	},
+	MetaKey_AIApiVersion: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_TermFontFamily: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxStringLength)
+	},
+	MetaKey_TermMode: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_TermTheme: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxStringLength)
+	},
+	MetaKey_SysinfoType: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_BgBlendMode: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_BgBorderColor: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_BgActiveBorderColor: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_WebPartition: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxStringLength)
+	},
+	MetaKey_WebUserAgentType: func(k string, v interface{}) error {
+		return ValidateString(k, v, 64)
+	},
+	MetaKey_VDomCorrelationId: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxStringLength)
+	},
+	MetaKey_VDomRoute: func(k string, v interface{}) error {
+		return ValidateString(k, v, MaxURLLength)
+	},
+
+	// Numeric fields
+	MetaKey_TermFontSize: func(k string, v interface{}) error {
+		return ValidateInt(k, v, 6, 72)
+	},
+	MetaKey_EditorFontSize: func(k string, v interface{}) error {
+		return ValidateFloat(k, v, 6.0, 72.0)
+	},
+	MetaKey_WebZoom: func(k string, v interface{}) error {
+		return ValidateFloat(k, v, 0.25, 5.0)
+	},
+	MetaKey_GraphNumPoints: func(k string, v interface{}) error {
+		return ValidateInt(k, v, 10, 10000)
+	},
+	MetaKey_BgOpacity: func(k string, v interface{}) error {
+		return ValidateFloat(k, v, 0.0, 1.0)
+	},
+	MetaKey_TermTransparency: func(k string, v interface{}) error {
+		return ValidateFloat(k, v, 0.0, 1.0)
+	},
+	MetaKey_TermScrollback: func(k string, v interface{}) error {
+		return ValidateInt(k, v, 100, 100000)
+	},
+	MetaKey_AiMaxTokens: func(k string, v interface{}) error {
+		return ValidateInt(k, v, 1, 1000000)
+	},
+	MetaKey_AiTimeoutMs: func(k string, v interface{}) error {
+		return ValidateInt(k, v, 1000, 600000)
+	},
+	MetaKey_MarkdownFontSize: func(k string, v interface{}) error {
+		return ValidateFloat(k, v, 6.0, 72.0)
+	},
+	MetaKey_MarkdownFixedFontSize: func(k string, v interface{}) error {
+		return ValidateFloat(k, v, 6.0, 72.0)
+	},
+	MetaKey_WaveAiPanelWidth: func(k string, v interface{}) error {
+		return ValidateFloat(k, v, 100, 2000)
+	},
+	MetaKey_DisplayOrder: func(k string, v interface{}) error {
+		return ValidateFloat(k, v, -1000000, 1000000)
+	},
+
+	// Nullable pointer fields
+	MetaKey_CmdCloseOnExitDelay: func(k string, v interface{}) error {
+		return ValidateNullableInt(k, v, 0, 60000)
+	},
+
+	// Boolean fields
+	MetaKey_Edit:                    ValidateBool,
+	MetaKey_Frame:                   ValidateBool,
+	MetaKey_CmdInteractive:          ValidateBool,
+	MetaKey_CmdLogin:                ValidateBool,
+	MetaKey_CmdRunOnStart:           ValidateBool,
+	MetaKey_CmdClearOnStart:         ValidateBool,
+	MetaKey_CmdRunOnce:              ValidateBool,
+	MetaKey_CmdCloseOnExit:          ValidateBool,
+	MetaKey_CmdCloseOnExitForce:     ValidateBool,
+	MetaKey_CmdNoWsh:                ValidateBool,
+	MetaKey_CmdShell:                ValidateBool,
+	MetaKey_CmdAllowConnChange:      ValidateBool,
+	MetaKey_EditorMinimapEnabled:    ValidateBool,
+	MetaKey_EditorStickyScrollEnabled: ValidateBool,
+	MetaKey_EditorWordWrap:          ValidateBool,
+	MetaKey_WebHideNav:              ValidateBool,
+	MetaKey_VDomInitialized:         ValidateBool,
+	MetaKey_VDomPersist:             ValidateBool,
+	MetaKey_TermAllowBracketedPaste: ValidateBool,
+	MetaKey_TermShiftEnterNewline:   ValidateBool,
+	MetaKey_TermMacOptionIsMeta:     ValidateBool,
+	MetaKey_TermConnDebug:           ValidateBool,
+	MetaKey_WaveAiPanelOpen:         ValidateBool,
+}
+
+// PresetKeyScope defines which keys are allowed for each preset type
+var PresetKeyScope = map[string]map[string]bool{
+	"tabvar@": {
+		MetaKey_TabBaseDir:     true,
+		MetaKey_TabBaseDirLock: true,
+		MetaKey_DisplayName:    true,
+		MetaKey_DisplayOrder:   true,
+	},
+	"bg@": {
+		MetaKey_BgClear:             true,
+		MetaKey_Bg:                  true,
+		MetaKey_BgOpacity:           true,
+		MetaKey_BgBlendMode:         true,
+		MetaKey_BgBorderColor:       true,
+		MetaKey_BgActiveBorderColor: true,
+		MetaKey_BgText:              true,
+		MetaKey_DisplayName:         true,
+		MetaKey_DisplayOrder:        true,
+	},
+}
+
+// ValidatePresetScope checks if preset keys are within allowed scope
+// This is called during config load, not during UpdateObjectMeta
+func ValidatePresetScope(presetName string, meta MetaMapType) error {
+	// Determine preset type from name prefix
+	var allowedKeys map[string]bool
+	for prefix, keys := range PresetKeyScope {
+		if strings.HasPrefix(presetName, prefix) {
+			allowedKeys = keys
+			break
+		}
+	}
+
+	if allowedKeys == nil {
+		// Unknown preset type - log warning but allow
+		log.Printf("[validation] warning: unknown preset type for %s", presetName)
+		return nil
+	}
+
+	for key := range meta {
+		if !allowedKeys[key] {
+			return &ValidationError{
+				Key:     key,
+				Value:   meta[key],
+				Message: fmt.Sprintf("key not allowed in %s presets", presetName),
+			}
+		}
+	}
+
+	return nil
+}
+
+// init merges common validators into specific validators
+func init() {
+	for k, v := range commonValidators {
+		if _, exists := tabValidators[k]; !exists {
+			tabValidators[k] = v
+		}
+		if _, exists := blockValidators[k]; !exists {
+			blockValidators[k] = v
+		}
+		if _, exists := workspaceValidators[k]; !exists {
+			workspaceValidators[k] = v
+		}
+		if _, exists := windowValidators[k]; !exists {
+			windowValidators[k] = v
+		}
+	}
+}

--- a/pkg/waveobj/wtypemeta.go
+++ b/pkg/waveobj/wtypemeta.go
@@ -97,6 +97,9 @@ type MetaTSType struct {
 	BgBlendMode         string  `json:"bg:blendmode,omitempty"`
 	BgBorderColor       string  `json:"bg:bordercolor,omitempty"`       // frame:bordercolor
 	BgActiveBorderColor string  `json:"bg:activebordercolor,omitempty"` // frame:activebordercolor
+	TabBaseDir          string  `json:"tab:basedir,omitempty"`          // base directory for tab context
+	TabBaseDirLock      bool    `json:"tab:basedirlock,omitempty"`      // lock basedir to prevent smart auto-detection
+	TabColor            string  `json:"tab:color,omitempty"`            // custom color for tab (hex value)
 
 	// for tabs+waveai
 	WaveAiPanelOpen     bool   `json:"waveai:panelopen,omitempty"`

--- a/pkg/wconfig/defaultconfig/presets/tabvars.json
+++ b/pkg/wconfig/defaultconfig/presets/tabvars.json
@@ -1,0 +1,10 @@
+{
+    "tabvar@waveterm-dev": {
+        "tab:basedir": "~/Code/waveterm",
+        "tab:basedirlock": false
+    },
+    "tabvar@example-project": {
+        "tab:basedir": "~/Projects/myapp",
+        "tab:basedirlock": true
+    }
+}

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -616,6 +616,19 @@ func ReadFullConfig() FullConfigType {
 			utilfn.ReUnmarshal(fieldPtr, configPart)
 		}
 	}
+
+	// Validate preset scopes
+	if fullConfig.Presets != nil {
+		for presetName, presetMeta := range fullConfig.Presets {
+			if err := waveobj.ValidatePresetScope(presetName, presetMeta); err != nil {
+				fullConfig.ConfigErrors = append(fullConfig.ConfigErrors, ConfigError{
+					File: "presets/*.json",
+					Err:  fmt.Sprintf("preset %s: %v", presetName, err),
+				})
+			}
+		}
+	}
+
 	return fullConfig
 }
 

--- a/pkg/wshrpc/wshserver/wshserver.go
+++ b/pkg/wshrpc/wshserver/wshserver.go
@@ -154,6 +154,10 @@ func (ws *WshServer) GetMetaCommand(ctx context.Context, data wshrpc.CommandGetM
 func (ws *WshServer) SetMetaCommand(ctx context.Context, data wshrpc.CommandSetMetaData) error {
 	log.Printf("SetMetaCommand: %s | %v\n", data.ORef, data.Meta)
 	oref := data.ORef
+	// Validate metadata before persistence
+	if err := waveobj.ValidateMetadata(oref, data.Meta); err != nil {
+		return fmt.Errorf("metadata validation failed: %w", err)
+	}
 	err := wstore.UpdateObjectMeta(ctx, oref, data.Meta, false)
 	if err != nil {
 		return fmt.Errorf("error updating object meta: %w", err)

--- a/pkg/wstore/wstore_dbops.go
+++ b/pkg/wstore/wstore_dbops.go
@@ -18,6 +18,8 @@ import (
 )
 
 var ErrNotFound = fmt.Errorf("not found")
+var ErrVersionMismatch = fmt.Errorf("version mismatch: concurrent modification detected")
+var ErrObjectLocked = fmt.Errorf("object is locked")
 
 func waveObjTableName(w waveobj.WaveObj) string {
 	return "db_" + w.GetOType()

--- a/schema/tabvarspresets.json
+++ b/schema/tabvarspresets.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "wave://schema/tabvarspresets.json",
+  "title": "Tab Variables Presets",
+  "description": "Schema for tab:basedir and related tab variable presets",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^tabvar@[a-zA-Z0-9_-]+$": {
+      "$ref": "#/$defs/TabVarPreset"
+    }
+  },
+  "$defs": {
+    "TabVarPreset": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tab:basedir": {
+          "type": "string",
+          "maxLength": 4096,
+          "pattern": "^[^\\x00]+$",
+          "description": "Base directory for the tab context"
+        },
+        "tab:basedirlock": {
+          "type": "boolean",
+          "description": "Lock basedir to prevent smart auto-detection"
+        },
+        "display:name": {
+          "type": "string",
+          "maxLength": 256,
+          "description": "Display name shown in context menu"
+        },
+        "display:order": {
+          "type": "number",
+          "description": "Order in context menu (lower = higher)"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR consolidates multiple improvements to the tab system:

### Tab Base Directory Feature
- Per-tab base directory context (`tab:basedir`, `tab:basedirlock` metadata)
- Smart auto-detection from terminal OSC 7 sequences
- All terminals and widgets inherit the tab's base directory
- Tab context menu for configuration

### Security & Validation
- Path validation for OSC 7 terminal escape sequences
- Backend metadata validation to prevent injection attacks
- Optimistic locking for metadata updates (race condition fix)
- Preset metadata validation

### VS Code Style Tab Redesign
- Tab backgrounds use relative white overlays (active=12%, hover=8%, inactive=4%)
- Tab stripe moved from left to top horizontal (manual color only)
- Status indicated via text color (running=blue, finished=green, stopped=red)
- Breadcrumb bar below tabs showing active tab's base directory
- App menu moved from tab bar to breadcrumb bar (far right)
- Transparent button styling with subtle hover effects

### Other Improvements
- Stale path detection and recovery after restart
- Reusable preset menu builder (reduces code duplication)
- Tab color customization via context menu
- Reactive tab status icons using Jotai atoms

## Relationship to Other PRs

- **Supersedes PR #2771** - The tab base directory feature has evolved significantly with security fixes and improvements
- **Independent of PR #2770** - Terminal history duplication fix is separate

## Test plan

- [ ] Verify tab base directory auto-detection from terminal `cd` commands
- [ ] Verify lock icon prevents auto-detection
- [ ] Verify tab color stripe appears at top when color is set
- [ ] Verify tab status text colors (running/finished/stopped)
- [ ] Verify breadcrumb bar displays active tab's base directory
- [ ] Verify three-dot menu in breadcrumb bar opens app menu
- [ ] Verify path validation rejects malicious OSC 7 sequences
- [ ] Verify preset metadata validation prevents injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)