### PR TITLE
Update Model Mode Docs

### DIFF
--- a/docs/docs/waveai-modes.mdx
+++ b/docs/docs/waveai-modes.mdx
@@ -216,7 +216,7 @@ If you provide only the baseurl, you are likely to get a 404 message.
     "display:order": 2,
     "display:icon": "server",
     "ai:apitype": "openai-chat",
-    "ai:model": "x-ai/grok-4-fast",
+    "ai:model": "grok-4-1-fast-reasoning",
     "ai:endpoint": "https://api.x.ai/v1/chat/completions",
     "ai:apitokensecretname": "XAI_KEY",
     "ai:capabilities": ["tools", "images", "pdfs"]


### PR DESCRIPTION
The original `ai:model` name for xAI's models in the example didn't work as advertised (resulting a 404 error in practice). After some trial and error I've been able to sort out the correct model slug and have updated the documentation accordingly.