### PR TITLE
fix: file browser shows newest files first, bump limit to 5000

### DIFF
--- a/pkg/wshrpc/wshremote/wshremote_file.go
+++ b/pkg/wshrpc/wshremote/wshremote_file.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -57,6 +58,17 @@ func (impl *ServerImpl) remoteStreamFileDir(ctx context.Context, path string, by
 	if err != nil {
 		return fmt.Errorf("cannot open dir %q: %w", path, err)
 	}
+	sort.Slice(innerFilesEntries, func(i, j int) bool {
+		iInfo, iErr := innerFilesEntries[i].Info()
+		jInfo, jErr := innerFilesEntries[j].Info()
+		if iErr != nil {
+			return false
+		}
+		if jErr != nil {
+			return true
+		}
+		return iInfo.ModTime().After(jInfo.ModTime())
+	})
 	if byteRange.All {
 		if len(innerFilesEntries) > wshrpc.MaxDirSize {
 			innerFilesEntries = innerFilesEntries[:wshrpc.MaxDirSize]

--- a/pkg/wshrpc/wshrpctypes_const.go
+++ b/pkg/wshrpc/wshrpctypes_const.go
@@ -8,7 +8,7 @@ const (
 	// MaxFileSize is the maximum file size that can be read
 	MaxFileSize = 50 * 1024 * 1024 // 50M
 	// MaxDirSize is the maximum number of entries that can be read in a directory
-	MaxDirSize = 1024
+	MaxDirSize = 5000
 	// FileChunkSize is the size of the file chunk to read
 	FileChunkSize = 64 * 1024
 	// DirChunkSize is the size of the directory chunk to read


### PR DESCRIPTION
Fixes #2830

The file browser caps at 1024 entries with no indication anything's missing. My screenshots folder has ~1300 files and I didn't even notice half were gone until I went looking for something recent.

Bumped the limit to 5000 and added mtime sort before truncation so if you do hit the cap, at least your newest files show up. Uses `DirEntry.Info()` instead of `os.Stat()` to keep it fast.