### PR TITLE
fix: terminal scroll preservation on tab switch and alt buffer exit

### DIFF
--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -433,7 +433,7 @@ export class WaveBrowserWindow extends BaseWindow {
             await Promise.all([p1, p2]);
         } else {
             console.log("reusing an existing tab, calling wave-init", tabView.waveTabId);
-            const p1 = this.repositionTabsSlowly(35);
+            const p1 = this.repositionTabsSlowly(35, true);
             const p2 = tabView.webContents.send("wave-init", tabView.savedInitOpts); // reinit
             await Promise.all([p1, p2]);
         }
@@ -452,13 +452,16 @@ export class WaveBrowserWindow extends BaseWindow {
         }, 30);
     }
 
-    private async repositionTabsSlowly(delayMs: number) {
+    private async repositionTabsSlowly(delayMs: number, skipIntermediate: boolean = false) {
         const activeTabView = this.activeTabView;
         const winBounds = this.getContentBounds();
         if (activeTabView == null) {
             return;
         }
-        if (activeTabView.isOnScreen()) {
+        if (skipIntermediate || activeTabView.isOnScreen()) {
+            // For already-initialized tabs (skipIntermediate=true) or tabs already on screen,
+            // go directly to final bounds to avoid an intermediate resize that causes
+            // xterm.js buffer reflow and scroll position loss.
             activeTabView.setBounds({
                 x: 0,
                 y: 0,

--- a/frontend/app/view/term/osc-handlers.ts
+++ b/frontend/app/view/term/osc-handlers.ts
@@ -318,6 +318,12 @@ export function handleOsc16162Command(data: string, blockId: string, loaded: boo
         case "R":
             globalStore.set(termWrap.shellIntegrationStatusAtom, null);
             if (terminal.buffer.active.type === "alternate") {
+                // Save scroll position before alternate buffer exit (only if user scrolled up)
+                const normalBuffer = terminal.buffer.normal;
+                const isAtBottom = normalBuffer.baseY >= normalBuffer.length - terminal.rows;
+                if (!isAtBottom) {
+                    termWrap.savedBaseY = normalBuffer.baseY;
+                }
                 terminal.write("\x1b[?1049l");
             }
             break;


### PR DESCRIPTION
Fixes #2384, fixes #2790

Switching tabs or quitting a fullscreen app (vim, htop, less) resets the scroll position to the top.

Tab switch: the intermediate repositioning during switch was triggering resize events that nuked the viewport. Now skips repositioning for initialized tabs and only restores scroll if dimensions actually changed.

Alt buffer exit: saves `baseY` before the buffer swap via `onBufferChange` and restores it after. Won't interfere if you were already at the bottom.

Mostly fixed — still see occasional jumps in edge cases.