### PR TITLE
feat: cmd+click to open file paths in terminal

### DIFF
--- a/frontend/app/view/term/term-link-provider.ts
+++ b/frontend/app/view/term/term-link-provider.ts
@@ -18,7 +18,10 @@ const FILE_PATH_REGEX =
 
 // File extensions we recognize for bare relative paths (the ones without ./ prefix)
 const KNOWN_EXTENSIONS =
-    /\.(ts|tsx|js|jsx|mjs|cjs|py|rb|go|rs|java|c|cpp|h|hpp|css|scss|less|html|json|yaml|yml|toml|md|txt|sh|bash|zsh|fish|lua|zig|swift|kt|scala|ex|exs|erl|hrl|vue|svelte|astro|sql|graphql|gql|proto|Makefile|Dockerfile|conf|cfg|ini|env|xml|csv|log)$/;
+    /\.(ts|tsx|js|jsx|mjs|cjs|py|rb|go|rs|java|c|cpp|h|hpp|css|scss|less|html|json|yaml|yml|toml|md|txt|sh|bash|zsh|fish|lua|zig|swift|kt|scala|ex|exs|erl|hrl|vue|svelte|astro|sql|graphql|gql|proto|conf|cfg|ini|env|xml|csv|log)$/;
+
+// Well-known filenames without extensions (these need exact basename match, not dot-prefix)
+const KNOWN_FILENAMES = /(^|\/)(Makefile|Dockerfile|Rakefile|Gemfile|Justfile|Vagrantfile|Procfile|Brewfile)$/;
 
 function getLineText(terminal: Terminal, lineNumber: number): string {
     const buffer = terminal.buffer.active;
@@ -97,8 +100,8 @@ export class FilePathLinkProvider implements ILinkProvider {
             const fullMatch = match[0];
             const pathPart = match[1];
 
-            // For bare relative paths (group 5), require a known file extension
-            if (match[5] && !KNOWN_EXTENSIONS.test(match[5])) {
+            // For bare relative paths (group 5), require a known file extension or filename
+            if (match[5] && !KNOWN_EXTENSIONS.test(match[5]) && !KNOWN_FILENAMES.test(match[5])) {
                 continue;
             }
 

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -172,7 +172,9 @@ export class TermWrap {
         this.terminal.parser.registerOscHandler(16162, (data: string) => {
             return handleOsc16162Command(data, this.blockId, this.loaded, this);
         });
-        this.terminal.registerLinkProvider(new FilePathLinkProvider(this.terminal, this.blockId));
+        this.toDispose.push(
+            this.terminal.registerLinkProvider(new FilePathLinkProvider(this.terminal, this.blockId))
+        );
         this.toDispose.push(
             this.terminal.onBell(() => {
                 if (!this.loaded) {


### PR DESCRIPTION
## Summary

Added cmd+click detection for file paths in the terminal. Click any file path and it opens in Wave's preview block. Way more useful than I expected — especially when Claude or build tools spit out file paths in error messages.

Implementation:
- Custom `FilePathLinkProvider` registered via xterm.js `registerLinkProvider` API
- Matches absolute paths, relative paths, `~/` paths, and `file:line:col` patterns
- Opens files in Wave's preview block (not an external editor) using the existing `preview:` block type
- Registered in `termwrap.ts`, provider logic in new file `term-link-provider.ts`

Patterns matched:
- `/absolute/path/to/file.ts`
- `./relative/path`
- `~/home/path`
- `/path/to/file.ts:42:10` (file:line:col)

Builds on the hyperlink support from #1357.

## Test plan
- Cmd+click an absolute file path in terminal output — should open in preview
- Cmd+click a `~/` path — should resolve and open
- Cmd+click a `file:line:col` pattern (e.g., from TypeScript errors) — should open
- Verify regular text selection still works (no false path matches on normal text)
- Verify link underline appears on hover with Cmd held