### PR TITLE
feat: add resizable widgets bar with persisted width

### DIFF
--- a/frontend/app/workspace/widgets.tsx
+++ b/frontend/app/workspace/widgets.tsx
@@ -401,7 +401,7 @@ const Widgets = memo(() => {
         <>
             <div
                 ref={containerRef}
-                className="flex flex-col w-12 overflow-hidden py-1 -ml-1 select-none"
+                className="flex flex-col w-full overflow-hidden py-1 select-none"
                 onContextMenu={handleWidgetsBarContextMenu}
             >
                 {mode === "supercompact" ? (
@@ -504,7 +504,7 @@ const Widgets = memo(() => {
 
             <div
                 ref={measurementRef}
-                className="flex flex-col w-12 py-1 -ml-1 select-none absolute -z-10 opacity-0 pointer-events-none"
+                className="flex flex-col w-full py-1 select-none absolute -z-10 opacity-0 pointer-events-none"
             >
                 {widgets?.map((data, idx) => (
                     <Widget key={`measurement-widget-${idx}`} widget={data} mode="normal" />

--- a/frontend/app/workspace/workspace.tsx
+++ b/frontend/app/workspace/workspace.tsx
@@ -20,6 +20,45 @@ import {
     PanelResizeHandle,
 } from "react-resizable-panels";
 
+const InnerContent = memo(({ tabId }: { tabId: string }) => {
+    const workspaceLayoutModel = WorkspaceLayoutModel.getInstance();
+    const innerContainerWidth = workspaceLayoutModel.getInnerContainerWidth();
+    const initialWidgetsPercentage = workspaceLayoutModel.getWidgetsPercentage(innerContainerWidth);
+    const innerPanelGroupRef = useRef<ImperativePanelGroupHandle>(null);
+
+    useEffect(() => {
+        if (innerPanelGroupRef.current) {
+            workspaceLayoutModel.registerInnerPanelGroupRef(innerPanelGroupRef.current);
+        }
+    }, []);
+
+    const widgetsMinSize = workspaceLayoutModel.getWidgetsMinPercentage(innerContainerWidth);
+    const widgetsMaxSize = workspaceLayoutModel.getWidgetsMaxPercentage(innerContainerWidth);
+
+    return (
+        <PanelGroup
+            direction="horizontal"
+            onLayout={workspaceLayoutModel.handleInnerPanelLayout}
+            ref={innerPanelGroupRef}
+        >
+            <Panel order={1} defaultSize={100 - initialWidgetsPercentage}>
+                <TabContent key={tabId} tabId={tabId} />
+            </Panel>
+            <PanelResizeHandle className="w-0.5 bg-transparent hover:bg-zinc-500/20 transition-colors" />
+            <Panel
+                order={2}
+                defaultSize={initialWidgetsPercentage}
+                minSize={widgetsMinSize}
+                maxSize={widgetsMaxSize}
+            >
+                <Widgets />
+            </Panel>
+        </PanelGroup>
+    );
+});
+
+InnerContent.displayName = "InnerContent";
+
 const WorkspaceElem = memo(() => {
     const workspaceLayoutModel = WorkspaceLayoutModel.getInstance();
     const tabId = useAtomValue(atoms.staticTabId);
@@ -77,10 +116,7 @@ const WorkspaceElem = memo(() => {
                             {tabId === "" ? (
                                 <CenteredDiv>No Active Tab</CenteredDiv>
                             ) : (
-                                <div className="flex flex-row h-full">
-                                    <TabContent key={tabId} tabId={tabId} />
-                                    <Widgets />
-                                </div>
+                                <InnerContent tabId={tabId} />
                             )}
                         </Panel>
                     </PanelGroup>

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1081,6 +1081,7 @@ declare global {
         "waveai:model"?: string;
         "waveai:chatid"?: string;
         "waveai:widgetcontext"?: boolean;
+        "widgets:width"?: number;
         "term:*"?: boolean;
         "term:fontsize"?: number;
         "term:fontfamily"?: string;

--- a/pkg/waveobj/metaconsts.go
+++ b/pkg/waveobj/metaconsts.go
@@ -102,6 +102,8 @@ const (
 	MetaKey_WaveAiChatId                     = "waveai:chatid"
 	MetaKey_WaveAiWidgetContext              = "waveai:widgetcontext"
 
+	MetaKey_WidgetsWidth                     = "widgets:width"
+
 	MetaKey_TermClear                        = "term:*"
 	MetaKey_TermFontSize                     = "term:fontsize"
 	MetaKey_TermFontFamily                   = "term:fontfamily"

--- a/pkg/waveobj/wtypemeta.go
+++ b/pkg/waveobj/wtypemeta.go
@@ -106,6 +106,8 @@ type MetaTSType struct {
 	WaveAiChatId        string `json:"waveai:chatid,omitempty"`
 	WaveAiWidgetContext *bool  `json:"waveai:widgetcontext,omitempty"` // default is true
 
+	WidgetsWidth int `json:"widgets:width,omitempty"`
+
 	TermClear               bool     `json:"term:*,omitempty"`
 	TermFontSize            int      `json:"term:fontsize,omitempty"`
 	TermFontFamily          string   `json:"term:fontfamily,omitempty"`


### PR DESCRIPTION
This pull request introduces a major improvement to the workspace layout by making the width of the widgets panel resizable and persistent per tab. The changes involve both frontend and backend updates to support saving, restoring, and clamping the widgets panel width, as well as updating the UI to use a horizontal split between the main content and the widgets panel.

**Workspace Layout and Widgets Panel Resizing:**

* Added a new resizable horizontal split between the main content (`TabContent`) and the widgets panel (`Widgets`) using a nested `PanelGroup` in `workspace.tsx`, allowing users to adjust the widgets panel width interactively. [[1]](diffhunk://#diff-14bc194ef55d874e0e8c43a9cb1672b9da59779439d2d29af8a52588f9a584abR23-R61) [[2]](diffhunk://#diff-14bc194ef55d874e0e8c43a9cb1672b9da59779439d2d29af8a52588f9a584abL80-R119)
* Implemented logic in `WorkspaceLayoutModel` to store, clamp, and persist the widgets panel width per tab, including new constants for default, min, and max widths, and methods for getting and setting the width. [[1]](diffhunk://#diff-557bef1e5a34537ecbf322e5015234e6e1ae21ad52318165146fa41d5519727dR23-R41) [[2]](diffhunk://#diff-557bef1e5a34537ecbf322e5015234e6e1ae21ad52318165146fa41d5519727dR52-R62) [[3]](diffhunk://#diff-557bef1e5a34537ecbf322e5015234e6e1ae21ad52318165146fa41d5519727dR74-R84) [[4]](diffhunk://#diff-557bef1e5a34537ecbf322e5015234e6e1ae21ad52318165146fa41d5519727dR101) [[5]](diffhunk://#diff-557bef1e5a34537ecbf322e5015234e6e1ae21ad52318165146fa41d5519727dR110-R112) [[6]](diffhunk://#diff-557bef1e5a34537ecbf322e5015234e6e1ae21ad52318165146fa41d5519727dR132-R136) [[7]](diffhunk://#diff-557bef1e5a34537ecbf322e5015234e6e1ae21ad52318165146fa41d5519727dR151-R155) [[8]](diffhunk://#diff-557bef1e5a34537ecbf322e5015234e6e1ae21ad52318165146fa41d5519727dR200) [[9]](diffhunk://#diff-557bef1e5a34537ecbf322e5015234e6e1ae21ad52318165146fa41d5519727dR338-R419)
* Updated the `Widgets` component to use full width instead of a fixed width, so it responds to the resizing logic. [[1]](diffhunk://#diff-ee17b35051d8b03662627a75796f3b2508c173f0aaaafed807864ce831fa60ceL404-R404) [[2]](diffhunk://#diff-ee17b35051d8b03662627a75796f3b2508c173f0aaaafed807864ce831fa60ceL507-R507)

**Persistence and Backend Support:**

* Added a new meta key, `widgets:width`, to the backend (`metaconsts.go`) and updated the tab meta type (`wtypemeta.go`) to support saving and restoring the widgets panel width for each tab. [[1]](diffhunk://#diff-d9ee0ff8efdd7047897a78f14160b1249e2ea2c685617112223e8a3174c61412R105-R106) [[2]](diffhunk://#diff-eeef948650e28ae2b4c9f30b264a71944f1bea44779d054f1e53c2cde70dc60bR109-R110)Wrap TabContent + Widgets in a nested react-resizable-panels PanelGroup so users can drag-resize the bar from 48px up to 300px. Width is persisted per-tab via the new "widgets:width" metadata key, matching the existing AI panel pattern.