### PR TITLE
fix: pass ProxyURL from AI mode config to backend

### DIFF
--- a/pkg/aiusechat/usechat.go
+++ b/pkg/aiusechat/usechat.go
@@ -123,6 +123,7 @@ func getWaveAISettings(premium bool, builderMode bool, rtInfo waveobj.ObjRTInfo,
 		Verbosity:     verbosity,
 		AIMode:        aiMode,
 		Endpoint:      baseUrl,
+		ProxyURL:      config.ProxyURL,
 		Capabilities:  config.Capabilities,
 		WaveAIPremium: config.WaveAIPremium,
 	}

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -286,6 +286,7 @@ type AIModeConfigType struct {
 	APITokenSecretName string   `json:"ai:apitokensecretname,omitempty"`
 	AzureResourceName  string   `json:"ai:azureresourcename,omitempty"`
 	AzureDeployment    string   `json:"ai:azuredeployment,omitempty"`
+	ProxyURL           string   `json:"ai:proxyurl,omitempty"`
 	Capabilities       []string `json:"ai:capabilities,omitempty" jsonschema:"enum=pdfs,enum=images,enum=tools"`
 	SwitchCompat       []string `json:"ai:switchcompat,omitempty"`
 	WaveAICloud        bool     `json:"waveai:cloud,omitempty"`


### PR DESCRIPTION
## Problem

`ai:proxyurl` set in AI mode configurations (Wave AI panel) has no effect.

## Root Cause

`ProxyURL` field is missing from `AIModeConfigType` (the new Wave AI mode config struct), and is not passed through when converting to `AIOptsType` in `buildAIOptsFromMode()`.

The proxy support code already exists in both OpenAI (`openai-backend.go:535`) and Anthropic (`anthropic-backend.go:461`) backends — they read `chatOpts.Config.ProxyURL` — but the value was never populated.

## Fix

Two lines:
1. Add `ProxyURL` field to `AIModeConfigType` in `settingsconfig.go`
2. Pass `config.ProxyURL` to `AIOptsType` in `usechat.go`

## Testing

With this fix, adding `"ai:proxyurl": "http://127.0.0.1:8888"` to an AI mode config correctly routes requests through the specified HTTP proxy.