### PR TITLE
fix: notify Electron when active tab changes via SetActiveTab

### DIFF
--- a/pkg/service/workspaceservice/workspaceservice.go
+++ b/pkg/service/workspaceservice/workspaceservice.go
@@ -197,6 +197,7 @@ func (svc *WorkspaceService) SetActiveTab(workspaceId string, tabId string) (wav
 	if err != nil {
 		return nil, fmt.Errorf("error setting active tab: %w", err)
 	}
+	wcore.SendActiveTabUpdate(ctx, workspaceId, tabId)
 	// check all blocks in tab and start controllers (if necessary)
 	tab, err := wstore.DBMustGet[*waveobj.Tab](ctx, tabId)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `SetActiveTab` service method was missing the `SendActiveTabUpdate` call to notify Electron about the active tab change
- This caused the frontend to not reflect the tab switch when `SetActiveTab` was called programmatically (e.g., via the API)
- Adds the missing `wcore.SendActiveTabUpdate(ctx, workspaceId, tabId)` call, consistent with how other tab-switching paths work

## Test plan
- [ ] Call `SetActiveTab` via the API and verify the UI switches to the correct tab
- [ ] Verify normal tab clicking still works as expected
- [ ] Verify no duplicate notifications are sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)