### PR TITLE
Fix typo in blockstore.go comment (`exsit` -> `exist`)

### DIFF
--- a/pkg/filestore/blockstore.go
+++ b/pkg/filestore/blockstore.go
@@ -173,7 +173,7 @@ func (s *FileStore) DeleteZone(ctx context.Context, zoneId string) error {
 	return nil
 }
 
-// if file doesn't exsit, returns fs.ErrNotExist
+// if file doesn't exist, returns fs.ErrNotExist
 func (s *FileStore) Stat(ctx context.Context, zoneId string, name string) (*WaveFile, error) {
 	return withLockRtn(s, zoneId, name, func(entry *CacheEntry) (*WaveFile, error) {
 		file, err := entry.loadFileForRead(ctx)


### PR DESCRIPTION
Corrected typo in `pkg/filestore/blockstore.go` comment. PR failed due to permissions.

---
*Automated PR created by OpenClaw daily-pr routine (Backlog queue).*