### PR TITLE
feat: add tab:newtablayout setting for custom new tab layouts

### DIFF
--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -135,6 +135,7 @@ type SettingsType struct {
 	PreviewDefaultSort     string `json:"preview:defaultsort,omitempty" jsonschema:"enum=name,enum=modtime"`
 
 	TabPreset       string `json:"tab:preset,omitempty"`
+	TabNewTabLayout any    `json:"tab:newtablayout,omitempty"`
 	TabConfirmClose bool   `json:"tab:confirmclose,omitempty"`
 	TabBackground   string `json:"tab:background,omitempty"`
 

--- a/pkg/wcore/workspace.go
+++ b/pkg/wcore/workspace.go
@@ -5,6 +5,7 @@ package wcore
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"regexp"
@@ -195,6 +196,23 @@ func getTabBackground() string {
 	return config.Settings.TabPreset
 }
 
+// getNewTabLayoutFromConfig returns the user-configured layout for new tabs,
+// falling back to the default single-terminal layout if not configured.
+func getNewTabLayoutFromConfig() PortableLayout {
+	settings := wconfig.GetWatcher().GetFullConfig()
+	rawLayout := settings.Settings.TabNewTabLayout
+	if rawLayout != nil {
+		barr, err := json.Marshal(rawLayout)
+		if err == nil {
+			var layout PortableLayout
+			if json.Unmarshal(barr, &layout) == nil && len(layout) > 0 {
+				return layout
+			}
+		}
+	}
+	return GetNewTabLayout()
+}
+
 var tabNameRe = regexp.MustCompile(`^T(\d+)$`)
 
 // getNextTabName returns the next auto-generated tab name (e.g. "T3") given a
@@ -250,7 +268,7 @@ func CreateTab(ctx context.Context, workspaceId string, tabName string, activate
 
 	// No need to apply an initial layout for the initial launch, since the starter layout will get applied after onboarding modal dismissal
 	if !isInitialLaunch {
-		err = ApplyPortableLayout(ctx, tab.OID, GetNewTabLayout(), true)
+		err = ApplyPortableLayout(ctx, tab.OID, getNewTabLayoutFromConfig(), true)
 		if err != nil {
 			return tab.OID, fmt.Errorf("error applying new tab layout: %w", err)
 		}

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -229,6 +229,28 @@
         "tab:preset": {
           "type": "string"
         },
+        "tab:newtablayout": {
+          "type": "array",
+          "description": "Custom block layout for new tabs. Each element defines a block with its position in the tile tree. If not set, defaults to a single terminal block.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "indexarr": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "Path in the tile tree (e.g. [0] = first child, [1] = second child, [1,1] = second child of second child)"
+              },
+              "size": {"type": "integer", "description": "Relative size/weight of the block"},
+              "blockdef": {
+                "type": "object",
+                "properties": {"meta": {"type": "object"}},
+                "description": "Block definition with meta (view, controller, file, url, etc.)"
+              },
+              "focused": {"type": "boolean", "description": "Whether this block should receive focus"}
+            },
+            "required": ["indexarr", "blockdef"]
+          }
+        },
         "tab:confirmclose": {
           "type": "boolean"
         },


### PR DESCRIPTION
## Summary

- Add `tab:newtablayout` setting that allows users to define a custom block layout for new tabs via `settings.json`
- When not set, the default single-terminal layout is preserved (fully backward compatible)
- Layout format reuses the existing `PortableLayout` structure used internally by Wave (same as `GetStarterLayout()`)

## Motivation

Currently, every new tab in Wave opens with a single terminal block. There is no way to configure a custom default layout. Users who want a consistent workflow (e.g., file browser + terminal side by side) must manually set up the layout each time. This is a frequently requested feature (e.g., #2057).

## Example Usage

Add to `~/.config/waveterm/settings.json`:

```json
{
  "tab:newtablayout": [
    {
      "indexarr": [0],
      "blockdef": {
        "meta": {
          "view": "preview",
          "file": "~"
        }
      },
      "size": 20
    },
    {
      "indexarr": [1],
      "blockdef": {
        "meta": {
          "view": "term",
          "controller": "shell"
        }
      },
      "focused": true
    }
  ]
}
```

This creates a split layout with a file browser on the left (20% width) and a terminal on the right (focused by default).

### Available view types for blockdef meta

- `term` — Terminal (with optional `controller: "shell"`)
- `preview` — File browser (with `file` for initial directory)
- `web` — Web view (with `url` for initial URL)
- `sysinfo` — System info panel

### How indexarr works

- `[0]` — First child of root (left/top)
- `[1]` — Second child of root (right/bottom)
- `[1, 1]` — Second child of second child (nested split)
- See `GetStarterLayout()` in `pkg/wcore/layout.go` for a 4-block example

## Changes

- `schema/settings.json` — Added JSON Schema definition for `tab:newtablayout`
- `pkg/wconfig/settingsconfig.go` — Added `TabNewTabLayout` field to `SettingsType`
- `pkg/wcore/workspace.go` — Added `getNewTabLayoutFromConfig()` and updated `CreateTab()` to use it

## Test plan

- [ ] Build and run Wave locally
- [ ] Verify: without `tab:newtablayout` set, new tabs open with single terminal (unchanged behavior)
- [ ] Verify: with `tab:newtablayout` set as shown above, new tabs open with file browser + terminal split
- [ ] Verify: invalid layout JSON falls back to default single terminal
- [ ] Verify: first-launch starter layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)