### PR TITLE
fix: use fspath.Base to strip Windows paths on SSH remote drag-drop

### DIFF
--- a/pkg/remote/fileshare/fspath/fspath_test.go
+++ b/pkg/remote/fileshare/fspath/fspath_test.go
@@ -1,0 +1,21 @@
+package fspath
+
+import "testing"
+
+func TestBase(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{`D:\package\AA.tar`, "AA.tar"},
+		{`D:/package/AA.tar`, "AA.tar"},
+		{"/home/user/file.txt", "file.txt"},
+		{"file.txt", "file.txt"},
+	}
+	for _, tt := range tests {
+		got := Base(tt.path)
+		if got != tt.want {
+			t.Errorf("Base(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}

--- a/pkg/wshrpc/wshremote/wshremote_file.go
+++ b/pkg/wshrpc/wshremote/wshremote_file.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/wavetermdev/waveterm/pkg/panichandler"
 	"github.com/wavetermdev/waveterm/pkg/remote/connparse"
+	"github.com/wavetermdev/waveterm/pkg/remote/fileshare/fspath"
 	"github.com/wavetermdev/waveterm/pkg/remote/fileshare/wshfs"
 	"github.com/wavetermdev/waveterm/pkg/util/fileutil"
 	"github.com/wavetermdev/waveterm/pkg/util/utilfn"
@@ -156,7 +157,7 @@ func (impl *ServerImpl) RemoteFileCopyCommand(ctx context.Context, data wshrpc.C
 		return false, fmt.Errorf("file %q size %d exceeds transfer limit of %d bytes", data.SrcUri, srcFileInfo.Size, RemoteFileTransferSizeLimit)
 	}
 
-	destFilePath, err := prepareDestForCopy(destPathCleaned, filepath.Base(srcConn.Path), destHasSlash, opts.Overwrite)
+	destFilePath, err := prepareDestForCopy(destPathCleaned, fspath.Base(srcConn.Path), destHasSlash, opts.Overwrite)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Fixes #3079

## Summary

When dragging a local file from Windows to an SSH remote connection, the full Windows path (e.g. `D:\package\AA.tar`) was being passed to `filepath.Base` on the remote (Linux) side. Since `filepath.Base` on Linux does not recognize backslashes as separators, the full path was used as the destination filename.

- In `RemoteFileCopyCommand` (`wshremote_file.go:159`), replace `filepath.Base(srcConn.Path)` with `fspath.Base(srcConn.Path)`
- `fspath.Base` calls `ToSlash` before `path.Base`, converting backslashes to forward slashes first, so `D:\package\AA.tar` correctly yields `AA.tar` on any OS
- Same-host copies at line 86 use `filepath.Base(srcPathCleaned)` and are unaffected — those run on the same OS where `filepath.Base` is correct

## Test Plan

- Added `pkg/remote/fileshare/fspath/fspath_test.go` with table-driven tests for `fspath.Base`:
  - Windows path with backslashes: `D:\package\AA.tar` → `AA.tar`
  - Windows path with forward slashes: `D:/package/AA.tar` → `AA.tar`
  - Unix path: `/home/user/file.txt` → `file.txt`
  - Filename only: `file.txt` → `file.txt`
- `go test ./pkg/remote/fileshare/fspath/...` passes