### PR TITLE
fix: set XDG_CONFIG_DIRS and XDG_DATA_DIRS defaults in tryGetPamEnvVars

### DIFF
--- a/pkg/shellexec/shellexec.go
+++ b/pkg/shellexec/shellexec.go
@@ -760,5 +760,11 @@ func tryGetPamEnvVars() map[string]string {
 	if runtime_dir, ok := envVars["XDG_RUNTIME_DIR"]; !ok || runtime_dir == "" {
 		envVars["XDG_RUNTIME_DIR"] = "/run/user/" + fmt.Sprint(os.Getuid())
 	}
+	if configDirs, ok := envVars["XDG_CONFIG_DIRS"]; !ok || configDirs == "" {
+		envVars["XDG_CONFIG_DIRS"] = "/etc/xdg"
+	}
+	if dataDirs, ok := envVars["XDG_DATA_DIRS"]; !ok || dataDirs == "" {
+		envVars["XDG_DATA_DIRS"] = "/usr/local/share:/usr/share"
+	}
 	return envVars
 }


### PR DESCRIPTION
## Summary

- Fixes #2970: WaveTerm does not inherit `XDG_CONFIG_DIRS` (and `XDG_DATA_DIRS`) when snap or other environments strip these variables and PAM env files do not define them
- In `tryGetPamEnvVars()`, after the existing `XDG_RUNTIME_DIR` fallback, adds identical fallback logic for `XDG_CONFIG_DIRS` (default: `/etc/xdg`) and `XDG_DATA_DIRS` (default: `/usr/local/share:/usr/share`) per the XDG Base Directory Specification
- No behavior change when these vars are already set by PAM env files

## Root Cause

Snap confinement strips several XDG environment variables. `tryGetPamEnvVars()` already handles `XDG_RUNTIME_DIR` with a sensible default, but `XDG_CONFIG_DIRS` and `XDG_DATA_DIRS` were left unhandled, causing child shells to receive empty/unset values.

## Test plan

- [ ] `gofmt -l ./pkg/shellexec/` — no output (clean)
- [ ] `go build ./...` — succeeds
- [ ] On Linux with snap, verify that child shells receive `XDG_CONFIG_DIRS=/etc/xdg` and `XDG_DATA_DIRS=/usr/local/share:/usr/share` when the variables are not set by the desktop environment