### PR TITLE
fix: prevent browser webview from stealing keyboard shortcuts

### DIFF
--- a/emain/emain-ipc.ts
+++ b/emain/emain-ipc.ts
@@ -10,7 +10,6 @@ import { PNG } from "pngjs";
 import { Readable } from "stream";
 import { RpcApi } from "../frontend/app/store/wshclientapi";
 import { getWebServerEndpoint } from "../frontend/util/endpoints";
-import * as keyutil from "../frontend/util/keyutil";
 import { fireAndForget, parseDataUrl } from "../frontend/util/util";
 import {
     incrementTermCommandsDurable,
@@ -22,15 +21,12 @@ import {
 import { createBuilderWindow, getAllBuilderWindows, getBuilderWindowByWebContentsId } from "./emain-builder";
 import { callWithOriginalXdgCurrentDesktopAsync, unamePlatform } from "./emain-platform";
 import { getWaveTabViewByWebContentsId } from "./emain-tabview";
-import { handleCtrlShiftState } from "./emain-util";
+import { setWebviewKeys } from "./emain-util";
 import { getWaveVersion } from "./emain-wavesrv";
 import { createNewWaveWindow, getWaveWindowByWebContentsId } from "./emain-window";
 import { ElectronWshClient } from "./emain-wsh";
 
 const electronApp = electron.app;
-
-let webviewFocusId: number = null;
-let webviewKeys: string[] = [];
 
 export function openBuilderWindow(appId?: string) {
     const normalizedAppId = appId || "";
@@ -280,48 +276,12 @@ export function initIpcHandlers() {
         event.returnValue = event.sender.getZoomFactor();
     });
 
-    const hasBeforeInputRegisteredMap = new Map<number, boolean>();
-
-    electron.ipcMain.on("webview-focus", (event: Electron.IpcMainEvent, focusedId: number) => {
-        webviewFocusId = focusedId;
+    electron.ipcMain.on("webview-focus", (_event: Electron.IpcMainEvent, focusedId: number) => {
         console.log("webview-focus", focusedId);
-        if (focusedId == null) {
-            return;
-        }
-        const parentWc = event.sender;
-        const webviewWc = electron.webContents.fromId(focusedId);
-        if (webviewWc == null) {
-            webviewFocusId = null;
-            return;
-        }
-        if (!hasBeforeInputRegisteredMap.get(focusedId)) {
-            hasBeforeInputRegisteredMap.set(focusedId, true);
-            webviewWc.on("before-input-event", (e, input) => {
-                let waveEvent = keyutil.adaptFromElectronKeyEvent(input);
-                handleCtrlShiftState(parentWc, waveEvent);
-                if (webviewFocusId != focusedId) {
-                    return;
-                }
-                if (input.type != "keyDown") {
-                    return;
-                }
-                for (let keyDesc of webviewKeys) {
-                    if (keyutil.checkKeyPressed(waveEvent, keyDesc)) {
-                        e.preventDefault();
-                        parentWc.send("reinject-key", waveEvent);
-                        console.log("webview reinject-key", keyDesc);
-                        return;
-                    }
-                }
-            });
-            webviewWc.on("destroyed", () => {
-                hasBeforeInputRegisteredMap.delete(focusedId);
-            });
-        }
     });
 
     electron.ipcMain.on("register-global-webview-keys", (event, keys: string[]) => {
-        webviewKeys = keys ?? [];
+        setWebviewKeys(keys);
     });
 
     electron.ipcMain.on("set-keyboard-chord-mode", (event) => {

--- a/emain/emain-tabview.ts
+++ b/emain/emain-tabview.ts
@@ -12,6 +12,7 @@ import { setWasActive } from "./emain-activity";
 import { getElectronAppBasePath, isDevVite, unamePlatform } from "./emain-platform";
 import {
     decreaseZoomLevel,
+    getWebviewKeys,
     handleCtrlShiftFocus,
     handleCtrlShiftState,
     increaseZoomLevel,
@@ -321,6 +322,20 @@ export async function getOrCreateWebViewForTab(waveWindowId: string, tabId: stri
             }
             tabView.webContents.send("webview-new-window", wc.id, details);
             return { action: "deny" };
+        });
+        wc.on("before-input-event", (e, input) => {
+            if (input.type != "keyDown") {
+                return;
+            }
+            const waveEvent = adaptFromElectronKeyEvent(input);
+            handleCtrlShiftState(tabView.webContents, waveEvent);
+            for (const keyDesc of getWebviewKeys()) {
+                if (checkKeyPressed(waveEvent, keyDesc)) {
+                    e.preventDefault();
+                    tabView.webContents.send("reinject-key", waveEvent);
+                    return;
+                }
+            }
         });
     });
     tabView.webContents.on("before-input-event", (e, input) => {

--- a/emain/emain-util.ts
+++ b/emain/emain-util.ts
@@ -8,6 +8,16 @@ export const WaveAppPathVarName = "WAVETERM_APP_PATH";
 export const WaveAppResourcesPathVarName = "WAVETERM_RESOURCES_PATH";
 export const WaveAppElectronExecPath = "WAVETERM_ELECTRONEXECPATH";
 
+let webviewKeys: string[] = [];
+
+export function getWebviewKeys(): string[] {
+    return webviewKeys;
+}
+
+export function setWebviewKeys(keys: string[]) {
+    webviewKeys = keys ?? [];
+}
+
 const MinZoomLevel = 0.4;
 const MaxZoomLevel = 2.6;
 const ZoomDelta = 0.2;


### PR DESCRIPTION
Move the before-input-event handler from webview-focus IPC (which registered on webview webContents) to the tab's setWebContents handler in emain-tabview.ts. This ensures keyboard shortcuts like Cmd+Number tab switching work even when a browser webview has focus.