### PR TITLE
fix: rewrite electron imports in bundle to bypass `Node.js` v24 CJS static analysis

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -8,9 +8,73 @@ import { ViteImageOptimizer } from "vite-plugin-image-optimizer";
 import svgr from "vite-plugin-svgr";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-// from our electron build
 const CHROME = "chrome140";
 const NODE = "node22";
+
+/**
+ * Rewrites all ESM import forms from "electron" so that every access goes
+ * through the CJS default export (module.exports) at runtime. This works
+ * around Node.js v24's stricter CJS-to-ESM static analysis which cannot
+ * detect lazy-getter exports (BaseWindow, BrowserWindow, etc.) from
+ * Electron's CJS module.
+ *
+ * Three patterns are handled:
+ *
+ *   import * as electron from "electron"
+ *     → import electron from "electron"
+ *       (namespace → default; electron.X now hits module.exports.X directly)
+ *
+ *   import electron__default, { app, net as net$1 } from "electron"
+ *     → import electron__default from "electron"
+ *       const { app, net: net$1 } = electron__default
+ *
+ *   import { app, BaseWindow } from "electron"
+ *     → import __electron__ from "electron"
+ *       const { app, BaseWindow } = __electron__
+ */
+function electronEsmInteropPlugin() {
+    const importAsToDestructure = (namedImports: string): string =>
+        namedImports
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .map((s) => s.replace(/^([\w$]+)\s+as\s+([\w$]+)$/, "$1: $2"))
+            .join(", ");
+
+    return {
+        name: "electron-esm-interop",
+        renderChunk(code: string) {
+            let result = code;
+            let transformed = false;
+
+            result = result.replace(
+                /import\s+([\w$]+)\s*,\s*\{([^}]+)\}\s*from\s*["']electron["']\s*;?/g,
+                (_match: string, defaultName: string, named: string) => {
+                    transformed = true;
+                    return `import ${defaultName} from "electron";\nconst { ${importAsToDestructure(named)} } = ${defaultName};`;
+                }
+            );
+
+            result = result.replace(
+                /import\s*\{([^}]+)\}\s*from\s*["']electron["']\s*;?/g,
+                (_match: string, named: string) => {
+                    transformed = true;
+                    return `import __electron__ from "electron";\nconst { ${importAsToDestructure(named)} } = __electron__;`;
+                }
+            );
+
+            result = result.replace(
+                /import\s*\*\s*as\s+([\w$]+)\s+from\s*["']electron["']\s*;?/g,
+                (_match: string, nsName: string) => {
+                    transformed = true;
+                    return `import ${nsName} from "electron";`;
+                }
+            );
+
+            return transformed ? { code: result, map: null } : null;
+        },
+    };
+}
 
 // for debugging
 // target is like -- path.resolve(__dirname, "frontend/app/workspace/workspace-layout-model.ts");
@@ -85,7 +149,7 @@ export default defineConfig({
             outDir: "dist/main",
             externalizeDeps: false,
         },
-        plugins: [tsconfigPaths()],
+        plugins: [tsconfigPaths(), electronEsmInteropPlugin()],
         resolve: {
             alias: {
                 "@": "frontend",


### PR DESCRIPTION
## Summary
Fixes https://github.com/wavetermdev/waveterm/issues/3213

Electron 41 ships Node.js v24, whose stricter `cjs-module-lexer` cannot detect lazy-getter exports (`BaseWindow`, `BrowserWindow`) from Electron's CJS module. This causes a `SyntaxError` at parse time before any code executes, making `task electron:quickdev` and `npm run dev` crash immediately on a clean clone of `main`.

This PR adds a Rollup `renderChunk` plugin to `electron.vite.config.ts` that rewrites all named and namespace imports from `"electron"` into default-import + runtime destructuring in the final bundle output, bypassing Node.js v24's static analysis entirely.

## Changes Made

- Added `electronEsmInteropPlugin()` to `electron.vite.config.ts` — a Rollup `renderChunk` plugin that transforms three import patterns in the bundled output:
  - `import * as electron from "electron"` → `import electron from "electron"`
  - `import default, { named } from "electron"` → `import default from "electron"; const { named } = default;`
  - `import { named } from "electron"` → `import __electron__ from "electron"; const { named } = __electron__;`
- Registered the plugin in the `main` build config's `plugins` array

## Test Plan

- [x] `npx electron-vite build --mode development` succeeds without errors
- [x] `npx electron-vite preview` launches Electron — no `SyntaxError`
- [x] Verified `dist/main/index.js` contains only default imports from `"electron"` (no named or namespace imports)