### PR TITLE
feat(pi): integrate pi coding agent as a waveterm AI backend

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -130,12 +130,24 @@ tasks:
             - npm:install
             - build:backend
             - build:tsunamiscaffold
+            - build:pi
 
-    build:frontend:dev:
-        desc: Build the frontend in development mode.
-        cmd: npm run build:dev
+    electron:dev:
+        desc: Run the Electron application via the Vite dev server (enables hot reloading).
+        cmd: npm run dev
+        aliases:
+            - dev
         deps:
             - npm:install
+            - build:backend
+            - build:tsunamiscaffold
+            - build:pi
+        env:
+            WAVETERM_ENVFILE: "{{.ROOT_DIR}}/.env"
+            WCLOUD_PING_ENDPOINT: "https://ping-dev.waveterm.dev/central"
+            WCLOUD_ENDPOINT: "https://api-dev.waveterm.dev/central"
+            WCLOUD_WS_ENDPOINT: "wss://wsapi-dev.waveterm.dev"
+            WAVETERM_NOCONFIRMQUIT: "1"
 
     build:backend:
         desc: Build the wavesrv and wsh components.
@@ -341,6 +353,16 @@ tasks:
                 - VERSION
         cmd: (CGO_ENABLED=0 GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build -ldflags="-s -w -X main.BuildTime=$({{.DATE}} +'%Y%m%d%H%M') -X main.WaveVersion={{.VERSION}}" -o dist/bin/wsh-{{.VERSION}}-{{.GOOS}}.{{.NORMALIZEDARCH}}{{.EXT}} cmd/wsh/main-wsh.go)
         internal: true
+
+    build:pi:
+        desc: Download and extract the pi CLI binary to dist/bin.
+        cmds:
+            - cmd: "mkdir -p dist/bin"
+            - cmd: "npm install @mariozechner/pi-coding-agent --prefix /tmp/pi-install --no-save 2>/dev/null"
+            - cmd: "cp /tmp/pi-install/node_modules/@mariozechner/pi-coding-agent/dist/cli.js dist/bin/pi"
+            - cmd: "sed -i '1s/^/#!/' dist/bin/pi && chmod +x dist/bin/pi"
+        generates:
+            - "dist/bin/pi"
 
     build:tsunamiscaffold:
         desc: Build and copy tsunami scaffold to dist directory.

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -22,7 +22,7 @@ const config = {
         {
             from: "./dist",
             to: "./dist",
-            filter: ["**/*", "!bin/*", "bin/wavesrv.${arch}*", "bin/wsh*", "!tsunamiscaffold/**/*"],
+            filter: ["**/*", "!bin/*", "bin/wavesrv.${arch}*", "bin/wsh*", "bin/pi*", "!tsunamiscaffold/**/*"],
         },
         {
             from: ".",
@@ -41,7 +41,7 @@ const config = {
         output: "make",
     },
     asarUnpack: [
-        "dist/bin/**/*", // wavesrv and wsh binaries
+        "dist/bin/**/*", // wavesrv, wsh, and pi binaries
         "dist/schema/**/*", // schema files for Monaco editor
     ],
     mac: {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "dependencies": {
         "@ai-sdk/react": "^2.0.104",
         "@floating-ui/react": "^0.27.16",
+        "@mariozechner/pi-coding-agent": "^0.67.1",
         "@observablehq/plot": "^0.6.17",
         "@react-hook/resize-observer": "^2.0.2",
         "@table-nav/core": "^0.0.7",

--- a/pkg/aiusechat/pi/backend.go
+++ b/pkg/aiusechat/pi/backend.go
@@ -1,0 +1,804 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/wavetermdev/waveterm/pkg/aiusechat/aiutil"
+	"github.com/wavetermdev/waveterm/pkg/aiusechat/chatstore"
+	"github.com/wavetermdev/waveterm/pkg/aiusechat/uctypes"
+	"github.com/wavetermdev/waveterm/pkg/web/sse"
+)
+
+// Backend implements aiusechat.UseChatBackend for the pi coding agent.
+// It spawns pi as a subprocess and communicates via JSONL RPC mode,
+// translating pi's events into waveterm SSE events.
+type Backend struct {
+	mgr *Manager
+
+	mu sync.RWMutex
+	// Per-RunChatStep state (protected by mu)
+	currentTools    []piToolCall
+	currentToolIdx map[string]int // toolCallID -> index
+	accumulatedText    string
+	accumulatedThinking string
+	textID      string
+	thinkingID  string
+	toolResults []uctypes.AIToolResult
+	stopReason  *uctypes.WaveStopReason
+	streamErr   error
+
+	// Persisted messages across the chat
+	chatMessages []uctypes.GenAIMessage
+}
+
+// NewBackend creates a new pi Backend.
+func NewBackend(mgr *Manager) *Backend {
+	return &Backend{
+		mgr:            mgr,
+		currentToolIdx: make(map[string]int),
+	}
+}
+
+// compile-time interface assertion
+var _ interface{ UseChatBackendSelf() } = (*Backend)(nil)
+
+func (b *Backend) UseChatBackendSelf() {}
+
+// RunChatStep executes a single chat step. It sends a prompt to pi and
+// streams back events as SSE data until a terminal stop reason is reached.
+func (b *Backend) RunChatStep(
+	ctx context.Context,
+	sseHandler *sse.SSEHandlerCh,
+	chatOpts uctypes.WaveChatOpts,
+	cont *uctypes.WaveContinueResponse,
+) (*uctypes.WaveStopReason, []uctypes.GenAIMessage, *uctypes.RateLimitInfo, error) {
+	b.resetTurnState()
+
+	// Ensure the chat exists in the store
+	aiChat := chatstore.DefaultChatStore.Get(chatOpts.ChatId)
+	if aiChat == nil {
+		return nil, nil, nil, fmt.Errorf("chat not found: %s", chatOpts.ChatId)
+	}
+
+	// cont signals whether this is a fresh prompt or a continuation after tool use
+	if cont != nil && cont.ContinueFromKind == uctypes.StopKindToolUse {
+		// Send tool results as a follow_up
+		b.mu.Lock()
+		toolResults := make([]uctypes.AIToolResult, len(b.toolResults))
+		copy(toolResults, b.toolResults)
+		b.mu.Unlock()
+		followUpText := b.buildToolResultsFollowUp(toolResults)
+		if err := b.sendFollowUp(ctx, followUpText); err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to send tool results: %w", err)
+		}
+	} else {
+		// Get the next pending user message from the chat
+		userMsg := b.getNextPendingUserMessage(aiChat)
+		if userMsg == nil {
+			return nil, nil, nil, fmt.Errorf("no pending user messages")
+		}
+		if err := b.sendPromptFromAIMessage(ctx, userMsg); err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to send prompt: %w", err)
+		}
+	}
+
+	// Register for events from pi
+	events := b.mgr.RegisterEventListener()
+	defer b.mgr.UnregisterEventListener(events)
+
+	// Reset SSE state IDs
+	b.mu.Lock()
+	b.textID = uuid.New().String()
+	b.thinkingID = uuid.New().String()
+	b.mu.Unlock()
+
+	// Process event stream
+	for {
+		select {
+		case <-ctx.Done():
+			b.abort()
+			return nil, nil, nil, ctx.Err()
+		case ev, ok := <-events:
+			if !ok {
+				// pi process ended
+				return b.stopReason, b.chatMessages, nil, b.streamErr
+			}
+			stopReason, err := b.handleEvent(ctx, ev, sseHandler, chatOpts)
+			if stopReason != nil {
+				b.stopReason = stopReason
+			}
+			if err != nil {
+				b.streamErr = err
+			}
+			if stopReason != nil && stopReason.Kind != "" {
+				return b.stopReason, b.chatMessages, nil, nil
+			}
+		}
+	}
+}
+
+// getNextPendingUserMessage finds the last user message in the chat.
+// pi will then be asked to respond to it.
+func (b *Backend) getNextPendingUserMessage(aiChat *uctypes.AIChat) *uctypes.AIMessage {
+	var lastUser *uctypes.AIMessage
+	for _, msg := range aiChat.NativeMessages {
+		if msg.GetRole() == "user" {
+			if genMsg, ok := msg.(*genAIMessage); ok {
+				lastUser = genMsg.toAIMessage()
+			}
+		}
+	}
+	return lastUser
+}
+
+// sendPrompt sends a plain text prompt to pi.
+func (b *Backend) sendPrompt(ctx context.Context, message string) error {
+	cmd := RPCCommand{
+		Type:    RPCmdPrompt,
+		Message: message,
+	}
+	_, err := b.mgr.SendCommandAsync(cmd)
+	return err
+}
+
+// sendFollowUp sends a follow_up message to pi (used for tool results).
+func (b *Backend) sendFollowUp(ctx context.Context, text string) error {
+	cmd := RPCCommand{
+		Type:    RPCmdFollowUp,
+		Message: text,
+	}
+	_, err := b.mgr.SendCommandAsync(cmd)
+	return err
+}
+
+// sendPromptFromAIMessage converts a waveterm AIMessage to a pi prompt and sends it.
+func (b *Backend) sendPromptFromAIMessage(ctx context.Context, msg *uctypes.AIMessage) error {
+	var textParts []string
+	var images []RPCImage
+
+	for _, part := range msg.Parts {
+		switch part.Type {
+		case uctypes.AIMessagePartTypeText:
+			textParts = append(textParts, part.Text)
+		case uctypes.AIMessagePartTypeFile:
+			if part.MimeType != "" && len(part.Data) > 0 {
+				images = append(images, RPCImage{
+					Type:     "image",
+					Data:     string(part.Data),
+					MimeType: part.MimeType,
+				})
+			}
+		}
+	}
+
+	cmd := RPCCommand{
+		Type:    RPCmdPrompt,
+		Message: strings.Join(textParts, ""),
+		Images:  images,
+	}
+	_, err := b.mgr.SendCommandAsync(cmd)
+	return err
+}
+
+// buildToolResultsFollowUp builds a text summary of tool results for pi.
+func (b *Backend) buildToolResultsFollowUp(results []uctypes.AIToolResult) string {
+	if len(results) == 0 {
+		return ""
+	}
+	var lines []string
+	for _, r := range results {
+		if r.ErrorText != "" {
+			lines = append(lines, fmt.Sprintf("Tool %s error: %s", r.ToolName, r.ErrorText))
+		} else {
+			text := r.Text
+			if len(text) > 500 {
+				text = text[:500] + "..."
+			}
+			lines = append(lines, fmt.Sprintf("Tool %s result: %s", r.ToolName, text))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// resetTurnState resets per-turn state for a new LLM call.
+func (b *Backend) resetTurnState() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.currentTools = nil
+	b.currentToolIdx = make(map[string]int)
+	b.stopReason = nil
+	b.accumulatedText = ""
+	b.accumulatedThinking = ""
+	b.toolResults = nil
+	b.streamErr = nil
+}
+
+// handleEvent processes a single pi RPC event and emits SSE events.
+func (b *Backend) handleEvent(
+	ctx context.Context,
+	ev RPCEvent,
+	sseHandler *sse.SSEHandlerCh,
+	chatOpts uctypes.WaveChatOpts,
+) (*uctypes.WaveStopReason, error) {
+	evType := ev.EventType()
+
+	switch evType {
+	case RPCEventAgentStart:
+		return nil, nil
+
+	case RPCEventAgentEnd:
+		b.mu.Lock()
+		if b.stopReason == nil {
+			b.stopReason = &uctypes.WaveStopReason{Kind: piStopReasonDone}
+		}
+		b.finalizeCurrentMessage(sseHandler)
+		b.mu.Unlock()
+		return b.stopReason, nil
+
+	case RPCEventMessageStart:
+		b.mu.Lock()
+		b.accumulatedText = ""
+		b.accumulatedThinking = ""
+		b.currentTools = nil
+		b.currentToolIdx = make(map[string]int)
+		b.mu.Unlock()
+		_ = sseHandler.AiMsgStart(uuid.New().String())
+		return nil, nil
+
+	case RPCEventMessageUpdate:
+		b.handleMessageUpdate(ev, sseHandler)
+		return nil, nil
+
+	case RPCEventMessageEnd:
+		b.mu.Lock()
+		b.finalizeCurrentMessage(sseHandler)
+		b.mu.Unlock()
+		return nil, nil
+
+	case RPCEventTurnStart:
+		b.mu.Lock()
+		b.accumulatedText = ""
+		b.accumulatedThinking = ""
+		b.currentTools = nil
+		b.currentToolIdx = make(map[string]int)
+		b.mu.Unlock()
+		_ = sseHandler.AiMsgStartStep()
+		return nil, nil
+
+	case RPCEventTurnEnd:
+		b.mu.Lock()
+		data := ev.GetMap("data")
+		if data == nil {
+			data = ev
+		}
+		toolResults := b.decodeTurnEndToolResults(data)
+		b.toolResults = append(b.toolResults, toolResults...)
+		b.mu.Unlock()
+
+		for _, tr := range toolResults {
+			toolUseData := aiutil.CreateToolUseData(tr.ToolUseID, tr.ToolName, "", chatOpts)
+			if tr.ErrorText != "" {
+				toolUseData.Status = uctypes.ToolUseStatusError
+				toolUseData.ErrorMessage = tr.ErrorText
+			} else {
+				toolUseData.Status = uctypes.ToolUseStatusCompleted
+			}
+			_ = sseHandler.AiMsgData("data-tooluse", tr.ToolUseID, toolUseData)
+		}
+		_ = sseHandler.AiMsgFinishStep()
+		return nil, nil
+
+	case RPCEventToolExecutionStart:
+		toolCallID := ev.GetString("toolCallId")
+		toolName := ev.GetString("toolName")
+		argsMap := ev.GetAny("args")
+		argsJSON, _ := json.Marshal(argsMap)
+
+		b.mu.Lock()
+		idx := len(b.currentTools)
+		b.currentTools = append(b.currentTools, piToolCall{ID: toolCallID, Name: toolName, Input: argsMap})
+		b.currentToolIdx[toolCallID] = idx
+		b.mu.Unlock()
+
+		toolUseData := aiutil.CreateToolUseData(toolCallID, toolName, string(argsJSON), chatOpts)
+		toolUseData.Status = uctypes.ToolUseStatusPending
+		if !b.shouldAutoApprove(toolName) {
+			toolUseData.Approval = uctypes.ApprovalNeedsApproval
+		}
+		_ = sseHandler.AiMsgData("data-tooluse", toolCallID, toolUseData)
+		return nil, nil
+
+	case RPCEventToolExecutionUpdate:
+		toolCallID := ev.GetString("toolCallId")
+		partialMap := ev.GetMap("partialResult")
+		if partialMap == nil {
+			return nil, nil
+		}
+		contentList := b.decodeToolContent(partialMap)
+		statusLines := make([]string, 0, len(contentList))
+		for _, c := range contentList {
+			statusLines = append(statusLines, c.Text)
+		}
+		_ = sseHandler.AiMsgData("data-toolprogress", toolCallID, map[string]any{
+			"toolcallid":  toolCallID,
+			"toolname":    ev.GetString("toolName"),
+			"statuslines": statusLines,
+		})
+		return nil, nil
+
+	case RPCEventToolExecutionEnd:
+		toolCallID := ev.GetString("toolCallId")
+		toolName := ev.GetString("toolName")
+		isError := ev.GetBool("isError")
+		resultMap := ev.GetAny("result")
+
+		var resultText string
+		if resultMap != nil {
+			contentList := b.decodeToolContent(resultMap)
+			for _, c := range contentList {
+				resultText += c.Text
+			}
+		}
+
+		toolUseData := aiutil.CreateToolUseData(toolCallID, toolName, "", chatOpts)
+		if isError {
+			toolUseData.Status = uctypes.ToolUseStatusError
+			toolUseData.ErrorMessage = resultText
+		} else {
+			toolUseData.Status = uctypes.ToolUseStatusCompleted
+			toolUseData.ToolDesc = toolName + " completed"
+		}
+		_ = sseHandler.AiMsgData("data-tooluse", toolCallID, toolUseData)
+
+		aiResult := uctypes.AIToolResult{
+			ToolName:  toolName,
+			ToolUseID: toolCallID,
+			Text:      resultText,
+		}
+		if isError {
+			aiResult.ErrorText = resultText
+		}
+		b.mu.Lock()
+		b.toolResults = append(b.toolResults, aiResult)
+		b.mu.Unlock()
+		return nil, nil
+
+	case RPCEventQueueUpdate,
+		RPCEventCompactionStart,
+		RPCEventCompactionEnd:
+		return nil, nil
+
+	case RPCEventAutoRetryStart:
+		delayMs := ev.GetInt("delayMs")
+		msg := fmt.Sprintf("Retrying after %dms (attempt %d)...", delayMs, ev.GetInt("attempt"))
+		_ = sseHandler.WriteData(msg)
+		return nil, nil
+
+	case RPCEventAutoRetryEnd:
+		if ev.GetBool("success") {
+			return nil, nil
+		}
+		finalErr := ev.GetString("finalError")
+		b.mu.Lock()
+		b.stopReason = &uctypes.WaveStopReason{Kind: piStopReasonError, ErrorText: finalErr}
+		b.mu.Unlock()
+		_ = sseHandler.AiMsgError(finalErr)
+		return b.stopReason, nil
+
+	case RPCEventExtensionError:
+		extPath := ev.GetString("extensionPath")
+		errMsg := ev.GetString("error")
+		_ = sseHandler.AiMsgError(fmt.Sprintf("Extension error in %s: %s", extPath, errMsg))
+		return nil, nil
+
+	case RPCEventExtensionUIRequest:
+		// pi is requesting UI interaction (select, confirm, etc.)
+		reqID, _ := ev["id"].(string)
+		method, _ := ev["method"].(string)
+		title, _ := ev["title"].(string)
+		_ = sseHandler.AiMsgData("data-extui", reqID, map[string]any{
+			"method": method,
+			"title":  title,
+			"id":     reqID,
+		})
+		return nil, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+// handleMessageUpdate processes message_update events which contain streaming deltas.
+func (b *Backend) handleMessageUpdate(ev RPCEvent, sseHandler *sse.SSEHandlerCh) {
+	evtData := ev.GetAny("assistantMessageEvent")
+	if evtData == nil {
+		return
+	}
+	evtMap, ok := evtData.(map[string]any)
+	if !ok {
+		return
+	}
+	evtType, _ := evtMap["type"].(string)
+
+	switch evtType {
+	case "text_start":
+		b.mu.Lock()
+		b.textID = uuid.New().String()
+		textID := b.textID
+		b.mu.Unlock()
+		_ = sseHandler.AiMsgTextStart(textID)
+
+	case "text_delta":
+		delta, _ := evtMap["delta"].(string)
+		if delta == "" {
+			delta, _ = evtMap["textDelta"].(string)
+		}
+		if delta != "" {
+			b.mu.Lock()
+			b.accumulatedText += delta
+			textID := b.textID
+			b.mu.Unlock()
+			_ = sseHandler.AiMsgTextDelta(textID, delta)
+		}
+
+	case "text_end":
+		b.mu.Lock()
+		textID := b.textID
+		b.mu.Unlock()
+		_ = sseHandler.AiMsgTextEnd(textID)
+
+	case "thinking_start":
+		b.mu.Lock()
+		b.thinkingID = uuid.New().String()
+		thinkingID := b.thinkingID
+		b.mu.Unlock()
+		_ = sseHandler.AiMsgReasoningStart(thinkingID)
+
+	case "thinking_delta":
+		delta, _ := evtMap["delta"].(string)
+		if delta == "" {
+			delta, _ = evtMap["thinkingDelta"].(string)
+		}
+		if delta != "" {
+			b.mu.Lock()
+			b.accumulatedThinking += delta
+			thinkingID := b.thinkingID
+			b.mu.Unlock()
+			_ = sseHandler.AiMsgReasoningDelta(thinkingID, delta)
+		}
+
+	case "thinking_end":
+		b.mu.Lock()
+		thinkingID := b.thinkingID
+		b.mu.Unlock()
+		_ = sseHandler.AiMsgReasoningEnd(thinkingID)
+
+	case "toolcall_delta":
+		// Partial tool call — emit delta through the text channel
+		delta, _ := evtMap["delta"].(string)
+		if delta != "" {
+			b.mu.Lock()
+			textID := b.textID
+			b.mu.Unlock()
+			_ = sseHandler.AiMsgTextDelta(textID, delta)
+		}
+
+	case "toolcall_end":
+		partialMap := evtMap["partial"]
+		if pm, ok := partialMap.(map[string]any); ok {
+			contentList, _ := pm["content"].([]any)
+			if contentList != nil {
+				for _, cb := range contentList {
+					if cbMap, ok := cb.(map[string]any); ok {
+						if tc, ok := cbMap["toolCall"].(map[string]any); ok {
+							toolCallID, _ := tc["id"].(string)
+							toolName, _ := tc["name"].(string)
+							toolInput := tc["input"]
+							inputJSON, _ := json.Marshal(toolInput)
+
+							b.mu.Lock()
+							idx := len(b.currentTools)
+							b.currentTools = append(b.currentTools, piToolCall{
+								ID:    toolCallID,
+								Name:  toolName,
+								Input: toolInput,
+							})
+							b.currentToolIdx[toolCallID] = idx
+							b.mu.Unlock()
+
+							toolUseData := aiutil.CreateToolUseData(toolCallID, toolName, string(inputJSON), uctypes.WaveChatOpts{})
+							toolUseData.Status = uctypes.ToolUseStatusPending
+							_ = sseHandler.AiMsgData("data-tooluse", toolCallID, toolUseData)
+						}
+					}
+				}
+			}
+		}
+
+	case "done":
+		reason, _ := evtMap["reason"].(string)
+		b.mu.Lock()
+		if b.stopReason == nil {
+			b.stopReason = b.makeStopReason(reason)
+		}
+		b.mu.Unlock()
+		// Signal end of message
+		b.mu.Lock()
+		textID := b.textID
+		thinkingID := b.thinkingID
+		b.mu.Unlock()
+		if textID != "" {
+			_ = sseHandler.AiMsgTextEnd(textID)
+		}
+		if thinkingID != "" {
+			_ = sseHandler.AiMsgReasoningEnd(thinkingID)
+		}
+	}
+}
+
+// shouldAutoApprove returns true for read-only tools that should auto-approve.
+func (b *Backend) shouldAutoApprove(toolName string) bool {
+	readonlyTools := map[string]bool{
+		"read":             true,
+		"read_file":        true,
+		"read_dir":         true,
+		"read_dir_tree":    true,
+		"grep":             true,
+		"find":             true,
+		"ls":               true,
+		"screenshot":       true,
+		"web_search":       true,
+		"web_fetch":        true,
+		"get_session_stats": true,
+		"get_state":        true,
+		"get_messages":     true,
+	}
+	return readonlyTools[toolName]
+}
+
+// makeStopReason converts a pi done reason to a WaveStopReason.
+func (b *Backend) makeStopReason(reason string) *uctypes.WaveStopReason {
+	var kind uctypes.StopReasonKind
+	switch reason {
+	case "stop":
+		kind = piStopReasonDone
+	case "toolUse":
+		kind = piStopReasonToolUse
+	case "length":
+		kind = piStopReasonMaxTokens
+	case "error":
+		kind = piStopReasonError
+	case "aborted":
+		kind = piStopReasonAborted
+	default:
+		kind = piStopReasonDone
+	}
+
+	sr := &uctypes.WaveStopReason{Kind: kind}
+
+	if kind == piStopReasonToolUse {
+		b.mu.RLock()
+		var toolCalls []uctypes.WaveToolCall
+		for _, tc := range b.currentTools {
+			toolCalls = append(toolCalls, uctypes.WaveToolCall{
+				ID:    tc.ID,
+				Name:  tc.Name,
+				Input: tc.Input,
+			})
+		}
+		b.mu.RUnlock()
+		sr.ToolCalls = toolCalls
+	}
+
+	return sr
+}
+
+// finalizeCurrentMessage builds the current assistant message and appends it to chatMessages.
+func (b *Backend) finalizeCurrentMessage(sseHandler *sse.SSEHandlerCh) {
+	if b.accumulatedText == "" && b.accumulatedThinking == "" && len(b.currentTools) == 0 {
+		return
+	}
+
+	msg := &genAIMessage{
+		id:         uuid.New().String(),
+		role:       "assistant",
+		text:       b.accumulatedText,
+		thinking:   b.accumulatedThinking,
+		stopReason: b.stopReasonKindToString(),
+	}
+	// Attach tool calls
+	for _, tc := range b.currentTools {
+		msg.toolCalls = append(msg.toolCalls, uctypes.WaveToolCall{
+			ID:    tc.ID,
+			Name:  tc.Name,
+			Input: tc.Input,
+		})
+	}
+
+	b.chatMessages = append(b.chatMessages, msg)
+
+	// Emit finish
+	_ = sseHandler.AiMsgFinish(msg.stopReason, nil)
+}
+
+func (b *Backend) stopReasonKindToString() string {
+	if b.stopReason == nil {
+		return "stop"
+	}
+	switch b.stopReason.Kind {
+	case piStopReasonToolUse:
+		return "toolUse"
+	case piStopReasonMaxTokens:
+		return "length"
+	case piStopReasonError:
+		return "error"
+	case piStopReasonAborted:
+		return "aborted"
+	default:
+		return "stop"
+	}
+}
+
+// decodeTurnEndToolResults decodes tool results from a turn_end event.
+func (b *Backend) decodeTurnEndToolResults(data map[string]any) []uctypes.AIToolResult {
+	var results []uctypes.AIToolResult
+	toolResultsList, ok := data["toolResults"].([]any)
+	if !ok {
+		return results
+	}
+	for _, tr := range toolResultsList {
+		if trMap, ok := tr.(map[string]any); ok {
+			toolCallID, _ := trMap["toolCallId"].(string)
+			toolName, _ := trMap["toolName"].(string)
+			isError, _ := trMap["isError"].(bool)
+			var text string
+			if contentList, ok := trMap["content"].([]any); ok {
+				for _, c := range contentList {
+					if cMap, ok := c.(map[string]any); ok {
+						if t, ok := cMap["text"].(string); ok {
+							text += t
+						}
+					}
+				}
+			}
+			result := uctypes.AIToolResult{
+				ToolName:  toolName,
+				ToolUseID: toolCallID,
+				Text:      text,
+			}
+			if isError {
+				result.ErrorText = text
+			}
+			results = append(results, result)
+		}
+	}
+	return results
+}
+
+// decodeToolContent decodes the content list from a tool result.
+func (b *Backend) decodeToolContent(v any) []piToolContent {
+	if v == nil {
+		return nil
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	contentList, ok := m["content"].([]any)
+	if !ok {
+		return nil
+	}
+	var results []piToolContent
+	for _, c := range contentList {
+		if cMap, ok := c.(map[string]any); ok {
+			content := piToolContent{Type: "text"}
+			if t, ok := cMap["text"].(string); ok {
+				content.Text = t
+			}
+			results = append(results, content)
+		}
+	}
+	return results
+}
+
+// abort sends an abort command to pi.
+func (b *Backend) abort() {
+	b.mgr.SendCommand(context.Background(), RPCCommand{Type: RPCmdAbort})
+}
+
+// UpdateToolUseData is a no-op for pi — pi manages its own session state.
+func (b *Backend) UpdateToolUseData(chatId string, toolCallId string, toolUseData uctypes.UIMessageDataToolUse) error {
+	return nil
+}
+
+// RemoveToolUseCall is a no-op for pi.
+func (b *Backend) RemoveToolUseCall(chatId string, toolCallId string) error {
+	return nil
+}
+
+// ConvertToolResultsToNativeChatMessage converts waveterm tool results to native messages.
+// For pi, tool results are sent as follow_up messages via the RPC protocol,
+// not as native chat messages. This returns nil.
+func (b *Backend) ConvertToolResultsToNativeChatMessage(toolResults []uctypes.AIToolResult) ([]uctypes.GenAIMessage, error) {
+	return nil, nil
+}
+
+// ConvertAIMessageToNativeChatMessage converts a waveterm AIMessage to a native message.
+func (b *Backend) ConvertAIMessageToNativeChatMessage(message uctypes.AIMessage) (uctypes.GenAIMessage, error) {
+	var textParts []string
+	for _, part := range message.Parts {
+		if part.Type == uctypes.AIMessagePartTypeText {
+			textParts = append(textParts, part.Text)
+		}
+	}
+	return &genAIMessage{
+		id:     message.MessageId,
+		role:   "user",
+		text:   strings.Join(textParts, ""),
+	}, nil
+}
+
+// GetFunctionCallInputByToolCallId retrieves a function call from the chat history.
+func (b *Backend) GetFunctionCallInputByToolCallId(aiChat uctypes.AIChat, toolCallId string) *uctypes.AIFunctionCallInput {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for _, msg := range b.chatMessages {
+		if asstMsg, ok := msg.(*genAIMessage); ok {
+			for _, tc := range asstMsg.toolCalls {
+				if tc.ID == toolCallId {
+					inputJSON, _ := json.Marshal(tc.Input)
+					return &uctypes.AIFunctionCallInput{
+						CallId:    tc.ID,
+						Name:      tc.Name,
+						Arguments: string(inputJSON),
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// ConvertAIChatToUIChat is not yet implemented.
+func (b *Backend) ConvertAIChatToUIChat(aiChat uctypes.AIChat) (*uctypes.UIChat, error) {
+	return nil, fmt.Errorf("ConvertAIChatToUIChat not yet implemented for pi backend")
+}
+
+// --- genAIMessage: pi-native message type that implements GenAIMessage ---
+
+type genAIMessage struct {
+	id         string
+	role       string
+	text       string
+	thinking   string
+	toolCalls  []uctypes.WaveToolCall
+	stopReason string
+}
+
+func (m *genAIMessage) GetMessageId() string { return m.id }
+func (m *genAIMessage) GetRole() string     { return m.role }
+func (m *genAIMessage) GetUsage() *uctypes.AIUsage {
+	return nil // pi doesn't expose usage to the host app in this integration pattern
+}
+
+func (m *genAIMessage) toAIMessage() *uctypes.AIMessage {
+	parts := []uctypes.AIMessagePart{}
+	if m.text != "" {
+		parts = append(parts, uctypes.AIMessagePart{
+			Type: uctypes.AIMessagePartTypeText,
+			Text: m.text,
+		})
+	}
+	return &uctypes.AIMessage{
+		MessageId: m.id,
+		Parts:     parts,
+	}
+}

--- a/pkg/aiusechat/pi/factory.go
+++ b/pkg/aiusechat/pi/factory.go
@@ -1,0 +1,79 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pi
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/wavetermdev/waveterm/pkg/aiusechat/uctypes"
+	"github.com/wavetermdev/waveterm/pkg/wavebase"
+)
+
+// Factory creates and manages pi backend instances keyed by chat ID.
+// Each chat gets its own pi subprocess.
+type Factory struct {
+	backends map[string]*Backend
+}
+
+// NewFactory creates a new pi backend factory.
+func NewFactory() *Factory {
+	return &Factory{
+		backends: make(map[string]*Backend),
+	}
+}
+
+// NewBackendForChat creates a new pi backend for the given chat and config.
+// If a backend already exists for this chatId, it returns the existing one.
+func (f *Factory) NewBackendForChat(chatId string, chatOpts uctypes.WaveChatOpts) (*Backend, error) {
+	if existing, ok := f.backends[chatId]; ok {
+		return existing, nil
+	}
+
+	// Build pi manager config from chatOpts
+	cfg := ManagerConfig{
+		BinPath:   filepath.Join(wavebase.GetWaveAppBinPath(), "pi"),
+		Provider:  chatOpts.Config.Provider,
+		ModelID:   chatOpts.Config.Model,
+		SessionDir:  "", // TODO: derive from waveterm config
+		NoSession:   false,
+	}
+
+	// Provider must be set — pi needs to know which LLM to use
+	if cfg.Provider == "" {
+		cfg.Provider = "anthropic" // sensible default
+		cfg.ModelID = "claude-sonnet-4-20250514"
+	}
+
+	// TODO: pass the parent context from chatOpts
+	mgr, err := NewManager(context.Background(), cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start pi subprocess: %w", err)
+	}
+
+	backend := NewBackend(mgr)
+	f.backends[chatId] = backend
+	return backend, nil
+}
+
+// GetBackend returns an existing backend for the given chatId, or nil if none exists.
+func (f *Factory) GetBackend(chatId string) *Backend {
+	return f.backends[chatId]
+}
+
+// CloseBackend closes and removes the backend for the given chatId.
+func (f *Factory) CloseBackend(chatId string) {
+	if backend, ok := f.backends[chatId]; ok {
+		backend.mgr.Kill()
+		delete(f.backends, chatId)
+	}
+}
+
+// CloseAll closes all backends.
+func (f *Factory) CloseAll() {
+	for chatId := range f.backends {
+		f.CloseBackend(chatId)
+	}
+}

--- a/pkg/aiusechat/pi/manager.go
+++ b/pkg/aiusechat/pi/manager.go
@@ -1,0 +1,471 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DefaultBinPath is the default pi binary path. Override via WithBinPath.
+const DefaultBinPath = "pi"
+
+// DefaultStartupTimeout is how long we wait for pi to initialize and emit the first prompt.
+const DefaultStartupTimeout = 30 * time.Second
+
+// Manager manages a pi subprocess for a single chat session.
+// It handles spawning the process, serializing stdin/stdout JSONL framing,
+// and dispatching events to registered listeners.
+type Manager struct {
+	binPath string
+	args   []string
+	env    []string
+
+	cmd   *exec.Cmd
+	stdin io.Writer
+	scanner *JSONLScanner
+
+	mu         sync.RWMutex
+	state      managerState
+	reqIDGen   int64
+	cmdCond    sync.Cond
+	pendingReqs map[string]chan *RPCResponse
+	pendingErr  error
+
+	eventListeners []chan<- RPCEvent
+
+	// tool approval: toolCallID -> approval result channel
+	toolApprovals map[string]chan string
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+type managerState int
+
+const (
+	stateNew managerState = iota
+	stateStarting
+	stateRunning
+	stateDone
+)
+
+func (s managerState) String() string {
+	switch s {
+	case stateNew: return "new"
+	case stateStarting: return "starting"
+	case stateRunning: return "running"
+	case stateDone: return "done"
+	default: return fmt.Sprintf("unknown(%d)", int(s))
+	}
+}
+
+// ManagerConfig configures a new Manager.
+type ManagerConfig struct {
+	BinPath  string
+	Args     []string
+	Env      []string
+	Provider string
+	ModelID  string
+	// SessionDir sets --session-dir. If empty, pi uses its default.
+	SessionDir string
+	// NoSession disables session persistence (--no-session).
+	NoSession bool
+}
+
+// NewManager creates a new pi subprocess manager.
+func NewManager(ctx context.Context, cfg ManagerConfig) (*Manager, error) {
+	if cfg.BinPath == "" {
+		cfg.BinPath = DefaultBinPath
+	}
+
+	args := []string{"--mode", "rpc"}
+	if cfg.Provider != "" {
+		args = append(args, "--provider", cfg.Provider)
+	}
+	if cfg.ModelID != "" {
+		args = append(args, "--model", cfg.ModelID)
+	}
+	if cfg.SessionDir != "" {
+		args = append(args, "--session-dir", cfg.SessionDir)
+	}
+	if cfg.NoSession {
+		args = append(args, "--no-session")
+	}
+	args = append(args, cfg.Args...)
+
+	cmd := exec.Command(cfg.BinPath, args...)
+	if cfg.Env != nil {
+		cmd.Env = cfg.Env
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stdin pipe: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stdout pipe: %w", err)
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stderr pipe: %w", err)
+	}
+
+	// Read stderr in a goroutine so it doesn't fill the buffer
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		buf := make([]byte, 4096)
+		for {
+			n, err := stderr.Read(buf)
+			if n > 0 {
+				// Could log this to a buffer or discard; for now just eat it
+				_ = n
+			}
+			if err != nil {
+				break
+			}
+		}
+	}()
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start pi: %w", err)
+	}
+
+	mgrCtx, cancel := context.WithCancel(ctx)
+	m := &Manager{
+		binPath:       cfg.BinPath,
+		args:          args,
+		env:           cfg.Env,
+		cmd:           cmd,
+		stdin:         stdin,
+		scanner:       NewJSONLScanner(stdout),
+		pendingReqs:   make(map[string]chan *RPCResponse),
+		toolApprovals: make(map[string]chan string),
+		ctx:           mgrCtx,
+		cancel:        cancel,
+	}
+	m.cmdCond.L = &m.mu
+
+	// Start event reader loop
+	go m.readLoop(stderrDone)
+
+	// Wait for pi to initialize (it emits events once ready)
+	if err := m.waitForReady(DefaultStartupTimeout); err != nil {
+		m.Kill()
+		return nil, fmt.Errorf("pi startup failed: %w", err)
+	}
+
+	return m, nil
+}
+
+// waitForReady waits until pi has started and is ready to receive commands.
+// pi signals readiness by emitting the first event on stdout after startup.
+func (m *Manager) waitForReady(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		m.mu.Lock()
+		state := m.state
+		readyErr := m.pendingErr
+		m.mu.Unlock()
+		if state == stateRunning {
+			return nil
+		}
+		if readyErr != nil {
+			return readyErr
+		}
+		if state == stateDone {
+			return fmt.Errorf("pi process exited during startup")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("pi startup timed out after %v", timeout)
+}
+
+func (m *Manager) readLoop(stderrDone <-chan struct{}) {
+	defer func() {
+		m.mu.Lock()
+		m.state = stateDone
+		m.mu.Unlock()
+
+		// Wait for stderr to drain (avoid broken pipe on cmd.Wait)
+		<-stderrDone
+		m.cmd.Wait()
+
+		// Resolve all pending requests with an error
+		m.mu.Lock()
+		for id, ch := range m.pendingReqs {
+			ch <- &RPCResponse{
+				Type:    "response",
+				Command: "internal",
+				Success: false,
+				Error:   "pi process exited",
+			}
+			delete(m.pendingReqs, id)
+		}
+		m.mu.Unlock()
+	}()
+
+	for {
+		rec, err := m.scanner.Next()
+		if err != nil {
+			m.mu.Lock()
+			if m.state != stateDone {
+				m.pendingErr = fmt.Errorf("JSONL read error: %w", err)
+			}
+			m.mu.Unlock()
+			return
+		}
+		if rec == nil {
+			// EOF
+			return
+		}
+
+		var base struct {
+			ID     string `json:"id,omitempty"`
+			Type   string `json:"type"`
+		}
+		if err := json.Unmarshal(rec, &base); err != nil {
+			// Non-JSON output (shouldn't happen in normal mode)
+			continue
+		}
+
+		if base.Type == "response" {
+			// Synchronous command response
+			var resp RPCResponse
+			if err := json.Unmarshal(rec, &resp); err != nil {
+				continue
+			}
+			if base.ID != "" {
+				m.mu.Lock()
+				ch, ok := m.pendingReqs[base.ID]
+				if ok {
+					ch <- &resp
+					delete(m.pendingReqs, base.ID)
+				}
+				m.mu.Unlock()
+			}
+		} else {
+			// Event — dispatch to all listeners
+			ev, err := RPCEventDecoder{}.Decode(rec)
+			if err != nil {
+				continue
+			}
+			m.dispatchEvent(ev)
+		}
+	}
+}
+
+// dispatchEvent sends an event to all registered listeners.
+func (m *Manager) dispatchEvent(ev RPCEvent) {
+	m.mu.RLock()
+	listeners := m.eventListeners
+	m.mu.RUnlock()
+
+	for _, ch := range listeners {
+		select {
+		case ch <- ev:
+		default:
+			// Non-blocking: don't block event dispatch
+		}
+	}
+}
+
+// SendCommand sends a command to pi and waits for the response.
+// It handles JSONL framing: writes a single LF-terminated JSON record.
+func (m *Manager) SendCommand(ctx context.Context, cmd RPCCommand) (*RPCResponse, error) {
+	// Generate request ID
+	reqID := fmt.Sprintf("%s-%d", uuid.New().String()[:8], atomic.AddInt64(&m.reqIDGen, 1))
+	cmd.ID = reqID
+
+	// Serialize command as a single JSON line
+	frame, err := json.Marshal(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal command: %w", err)
+	}
+	frame = append(frame, '\n')
+
+	// Enqueue response channel BEFORE writing to avoid race
+	respCh := make(chan *RPCResponse, 1)
+	m.mu.Lock()
+	m.pendingReqs[reqID] = respCh
+	m.mu.Unlock()
+
+	// Write to stdin
+	if _, err := m.stdin.Write(frame); err != nil {
+		m.mu.Lock()
+		delete(m.pendingReqs, reqID)
+		m.mu.Unlock()
+		return nil, fmt.Errorf("failed to write to pi stdin: %w", err)
+	}
+
+	// Wait for response or context cancellation
+	select {
+	case <-ctx.Done():
+		// Remove from pending and send abort
+		m.mu.Lock()
+		delete(m.pendingReqs, reqID)
+		m.mu.Unlock()
+		return nil, ctx.Err()
+	case resp := <-respCh:
+		return resp, nil
+	}
+}
+
+// SendCommandAsync sends a command without waiting for the response.
+// Use this for streaming commands like "prompt" which return immediately.
+// The command ID is returned so the caller can correlate responses.
+func (m *Manager) SendCommandAsync(cmd RPCCommand) (string, error) {
+	reqID := fmt.Sprintf("%s-%d", uuid.New().String()[:8], atomic.AddInt64(&m.reqIDGen, 1))
+	cmd.ID = reqID
+
+	frame, err := json.Marshal(cmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal command: %w", err)
+	}
+	frame = append(frame, '\n')
+
+	if _, err := m.stdin.Write(frame); err != nil {
+		return "", fmt.Errorf("failed to write to pi stdin: %w", err)
+	}
+	return reqID, nil
+}
+
+// RegisterEventListener registers a channel to receive all pi RPC events.
+// The caller must drain the channel to avoid blocking event dispatch.
+// The returned unsubscribe function removes the listener.
+func (m *Manager) RegisterEventListener() chan RPCEvent {
+	ch := make(chan RPCEvent, 50)
+	m.mu.Lock()
+	m.eventListeners = append(m.eventListeners, ch)
+	m.mu.Unlock()
+	return ch
+}
+
+func (m *Manager) UnregisterEventListener(ch chan RPCEvent) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, l := range m.eventListeners {
+		if l == ch {
+			m.eventListeners = append(m.eventListeners[:i], m.eventListeners[i+1:]...)
+			close(ch)
+			return
+		}
+	}
+}
+
+// ApproveTool registers approval for a tool call. result is one of:
+// uctypes.ApprovalApproved, uctypes.ApprovalUserDenied, uctypes.ApprovalTimeout.
+// This unblocks the corresponding WaitForToolApproval call.
+func (m *Manager) ApproveTool(toolCallID string, result string) {
+	m.mu.Lock()
+	ch, ok := m.toolApprovals[toolCallID]
+	if ok {
+		ch <- result
+		delete(m.toolApprovals, toolCallID)
+	}
+	m.mu.Unlock()
+}
+
+// WaitForToolApproval blocks until a tool requires approval.
+// It returns the approval result once the frontend resolves it.
+func (m *Manager) WaitForToolApproval(toolCallID string) string {
+	ch := make(chan string, 1)
+	m.mu.Lock()
+	m.toolApprovals[toolCallID] = ch
+	m.mu.Unlock()
+
+	select {
+	case result := <-ch:
+		return result
+	case <-m.ctx.Done():
+		return "timeout"
+	}
+}
+
+// State returns the current manager state.
+func (m *Manager) State() managerState {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.state
+}
+
+// PID returns the process ID of the pi subprocess.
+func (m *Manager) PID() int {
+	return m.cmd.Process.Pid
+}
+
+// Kill terminates the pi subprocess immediately.
+func (m *Manager) Kill() {
+	m.cancel()
+	m.mu.Lock()
+	if m.state != stateDone {
+		m.state = stateDone
+		m.cmd.Process.Kill()
+	}
+	m.mu.Unlock()
+}
+
+// BuildCommand builds a pi invocation command slice.
+// Use this to present the user with a displayable command (e.g., for settings UI).
+func BuildCommand(provider, modelID, sessionDir string, noSession bool) []string {
+	var cmd []string
+	if provider != "" {
+		cmd = append(cmd, "--provider", provider)
+	}
+	if modelID != "" {
+		cmd = append(cmd, "--model", modelID)
+	}
+	if sessionDir != "" {
+		cmd = append(cmd, "--session-dir", sessionDir)
+	}
+	if noSession {
+		cmd = append(cmd, "--no-session")
+	}
+	return cmd
+}
+
+// WaveTabContext holds the context from a waveterm tab that we inject into pi.
+type WaveTabContext struct {
+	TabID         string
+	WorkingDir    string
+	ShellType     string
+	ShellVersion  string
+	Connection    string
+	BlockIDs      []string // visible block IDs in current view
+	UserEnv       map[string]string
+}
+
+// AsSystemPrompt returns a pi-compatible system prompt string describing the tab context.
+func (c *WaveTabContext) AsSystemPrompt() string {
+	var parts []string
+	parts = append(parts, "## Wave Terminal Context")
+	if c.Connection != "" {
+		parts = append(parts, fmt.Sprintf("Connected to: %s", c.Connection))
+	}
+	if c.ShellType != "" {
+		shell := c.ShellType
+		if c.ShellVersion != "" {
+			shell += " " + c.ShellVersion
+		}
+		parts = append(parts, fmt.Sprintf("Shell: %s", shell))
+	}
+	if c.WorkingDir != "" {
+		parts = append(parts, fmt.Sprintf("Working directory: %s", c.WorkingDir))
+	}
+	parts = append(parts, "This is a pi coding agent session running inside waveterm.")
+	return strings.Join(parts, "\n")
+}

--- a/pkg/aiusechat/pi/rpc.go
+++ b/pkg/aiusechat/pi/rpc.go
@@ -1,0 +1,240 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package pi implements a UseChatBackend that spawns the pi coding agent
+// as a subprocess and communicates with it via JSONL RPC mode.
+// The pi agent handles LLM interaction and tool execution internally;
+// this backend translates pi's RPC protocol events into waveterm SSE events.
+package pi
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// RPC event types emitted by pi on stdout during agent operation.
+// These are documented in packages/coding-agent/docs/rpc.md.
+type RPCEventType string
+
+const (
+	RPCEventAgentStart              RPCEventType = "agent_start"
+	RPCEventAgentEnd                RPCEventType = "agent_end"
+	RPCEventTurnStart              RPCEventType = "turn_start"
+	RPCEventTurnEnd                RPCEventType = "turn_end"
+	RPCEventMessageStart           RPCEventType = "message_start"
+	RPCEventMessageEnd             RPCEventType = "message_end"
+	RPCEventMessageUpdate          RPCEventType = "message_update"
+	RPCEventToolExecutionStart     RPCEventType = "tool_execution_start"
+	RPCEventToolExecutionUpdate    RPCEventType = "tool_execution_update"
+	RPCEventToolExecutionEnd       RPCEventType = "tool_execution_end"
+	RPCEventQueueUpdate            RPCEventType = "queue_update"
+	RPCEventCompactionStart        RPCEventType = "compaction_start"
+	RPCEventCompactionEnd          RPCEventType = "compaction_end"
+	RPCEventAutoRetryStart         RPCEventType = "auto_retry_start"
+	RPCEventAutoRetryEnd           RPCEventType = "auto_retry_end"
+	RPCEventExtensionError         RPCEventType = "extension_error"
+	RPCEventExtensionUIRequest    RPCEventType = "extension_ui_request"
+)
+
+// RPC command types sent to pi on stdin.
+type RPCCommandType string
+
+const (
+	RPCmdPrompt       RPCCommandType = "prompt"
+	RPCmdSteer        RPCCommandType = "steer"
+	RPCmdFollowUp     RPCCommandType = "follow_up"
+	RPCmdAbort        RPCCommandType = "abort"
+	RPCmdNewSession   RPCCommandType = "new_session"
+	RPCmdGetState     RPCCommandType = "get_state"
+	RPCmdGetMessages  RPCCommandType = "get_messages"
+	RPCmdSetModel     RPCCommandType = "set_model"
+	RPCmdCycleModel   RPCCommandType = "cycle_model"
+	RPCmdSetThinking  RPCCommandType = "set_thinking_level"
+	RPCmdCompact      RPCCommandType = "compact"
+	RPCmdGetStats     RPCCommandType = "get_session_stats"
+	RPCmdSetSessionName RPCCommandType = "set_session_name"
+	RPCmdFork         RPCCommandType = "fork"
+	RPCmdExtUIRsp     RPCCommandType = "extension_ui_response"
+)
+
+// RPCCommand is a command sent to pi over stdin.
+type RPCCommand struct {
+	ID               string            `json:"id,omitempty"`
+	Type             RPCCommandType    `json:"type"`
+	Message          string            `json:"message,omitempty"`
+	Images           []RPCImage       `json:"images,omitempty"`
+	StreamingBehavior string           `json:"streamingBehavior,omitempty"` // "steer" | "followUp"
+	Provider         string            `json:"provider,omitempty"`
+	ModelID          string            `json:"modelId,omitempty"`
+	Level            string            `json:"level,omitempty"`
+	CustomInstr      string            `json:"customInstructions,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	SessionPath      string            `json:"sessionPath,omitempty"`
+	ParentSession    string            `json:"parentSession,omitempty"`
+	OutputPath       string            `json:"outputPath,omitempty"`
+	EntryID          string            `json:"entryId,omitempty"`
+	Enabled          *bool             `json:"enabled,omitempty"`
+	Command          string            `json:"command,omitempty"`
+	// extension_ui_response fields
+	ExtUIValue         string `json:"value,omitempty"`
+	ExtUIConfirmed     *bool  `json:"confirmed,omitempty"`
+	ExtUICancelled     bool   `json:"cancelled,omitempty"`
+}
+
+// RPCImage is an image attachment in a prompt command.
+type RPCImage struct {
+	Type    string `json:"type"` // always "image"
+	Data    string `json:"data"` // base64-encoded
+	MimeType string `json:"mimeType"`
+}
+
+// RPCResponse is a response received from pi for a command.
+type RPCResponse struct {
+	ID       string          `json:"id,omitempty"`
+	Type     string          `json:"type"` // always "response"
+	Command  string          `json:"command"`
+	Success  bool            `json:"success"`
+	Data     json.RawMessage `json:"data,omitempty"`
+	Error    string          `json:"error,omitempty"`
+}
+
+// RPCEvent is an event streamed by pi on stdout.
+// It is tagged with "type" so we decode it generically first,
+// then dispatch based on the type field.
+type RPCEvent map[string]any
+
+func (e RPCEvent) EventType() RPCEventType {
+	if t, ok := e["type"].(string); ok {
+		return RPCEventType(t)
+	}
+	return ""
+}
+
+func (e RPCEvent) GetString(field string) string {
+	if v, ok := e[field].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func (e RPCEvent) GetFloat(field string) float64 {
+	if v, ok := e[field].(float64); ok {
+		return v
+	}
+	return 0
+}
+
+func (e RPCEvent) GetInt(field string) int {
+	if v, ok := e[field].(float64); ok {
+		return int(v)
+	}
+	return 0
+}
+
+func (e RPCEvent) GetBool(field string) bool {
+	if v, ok := e[field].(bool); ok {
+		return v
+	}
+	return false
+}
+
+func (e RPCEvent) GetMap(field string) map[string]any {
+	if v, ok := e[field].(map[string]any); ok {
+		return v
+	}
+	return nil
+}
+
+func (e RPCEvent) GetSlice(field string) []any {
+	if v, ok := e[field].([]any); ok {
+		return v
+	}
+	return nil
+}
+
+func (e RPCEvent) GetAny(field string) any {
+	return e[field]
+}
+
+// JSONLScanner reads LF-delimited JSON records from an io.Reader.
+// It correctly handles JSONL framing: only splits on '\n', not on
+// Unicode separators that might appear inside JSON strings.
+// This is critical: Node's readline is NOT protocol-compliant because
+// it splits on U+2028 and U+2029 which are valid inside JSON strings.
+type JSONLScanner struct {
+	reader *io.LimitedReader
+	buf    bytes.Buffer
+	scanR  *bufio.Reader
+	once   sync.Once
+}
+
+func NewJSONLScanner(r io.Reader) *JSONLScanner {
+	// Use a large limit; we reset it via SetLimit after each record
+	lr := io.LimitedReader{R: r, N: 1 << 20} // 1MB per record max
+	return &JSONLScanner{
+		scanR: bufio.NewReader(&lr),
+	}
+}
+
+// Next reads the next JSONL record and returns it as json.RawMessage.
+// Returns nil, nil when EOF is reached.
+// Returns an error on parse failure.
+func (s *JSONLScanner) Next() (json.RawMessage, error) {
+	s.once.Do(func() {}) // no-op to satisfy linter
+
+	for {
+		l, prefix, err := s.scanR.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				// Return buffered content if any (final record without trailing newline)
+				if s.buf.Len() > 0 {
+					rec := make([]byte, s.buf.Len())
+					copy(rec, s.buf.Bytes())
+					s.buf.Reset()
+					return rec, nil
+				}
+				return nil, nil
+			}
+			return nil, fmt.Errorf("JSONL read error: %w", err)
+		}
+
+		// Strip optional trailing CR (for \r\n line endings)
+		if len(l) > 0 && l[len(l)-1] == '\r' {
+			l = l[:len(l)-1]
+		}
+
+		if prefix {
+			// Line was too long; accumulate
+			s.buf.Write(l)
+			s.buf.WriteByte('\n')
+		} else {
+			s.buf.Write(l)
+			break
+		}
+	}
+
+	if s.buf.Len() == 0 {
+		// Empty line (blank newline) — skip
+		return s.Next()
+	}
+
+	rec := make([]byte, s.buf.Len())
+	copy(rec, s.buf.Bytes())
+	s.buf.Reset()
+	return rec, nil
+}
+
+// RPCEventDecoder decodes pi RPC events from json.RawMessage.
+type RPCEventDecoder struct{}
+
+func (RPCEventDecoder) Decode(raw json.RawMessage) (RPCEvent, error) {
+	var ev RPCEvent
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal RPC event: %w", err)
+	}
+	return ev, nil
+}

--- a/pkg/aiusechat/pi/types.go
+++ b/pkg/aiusechat/pi/types.go
@@ -1,0 +1,154 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pi
+
+import (
+	"github.com/wavetermdev/waveterm/pkg/aiusechat/uctypes"
+)
+
+// APIType is the waveterm API type identifier for the pi backend.
+// This is registered in uctypes so GetBackendByAPIType can dispatch to it.
+const APIType = "pi-rpc"
+
+// StopReasonKind constants for pi stop reasons.
+const (
+	piStopReasonDone      uctypes.StopReasonKind = "done"
+	piStopReasonToolUse   uctypes.StopReasonKind = "tool_use"
+	piStopReasonMaxTokens uctypes.StopReasonKind = "max_tokens"
+	piStopReasonError     uctypes.StopReasonKind = "error"
+	piStopReasonAborted   uctypes.StopReasonKind = "aborted"
+	piStopReasonCanceled  uctypes.StopReasonKind = "canceled"
+)
+
+// piToolCall maps a pi tool_execution_start event to a WaveToolCall.
+type piToolCall struct {
+	ID     string
+	Name   string
+	Input  any
+	Result *piToolResult // filled in on tool_execution_end
+}
+
+type piToolResult struct {
+	Content []piToolContent `json:"content,omitempty"`
+	IsError bool            `json:"isError,omitempty"`
+}
+
+type piToolContent struct {
+	Type string `json:"type"` // "text"
+	Text string `json:"text,omitempty"`
+}
+
+// piAssistantMessage mirrors the pi AgentMessage structure for assistant roles.
+type piAssistantMessage struct {
+	ID        string                  `json:"id,omitempty"`
+	Role      string                  `json:"role"`
+	Content   []piContentBlock        `json:"content"`
+	StopReason string                 `json:"stopReason,omitempty"`
+	Usage     *piUsage               `json:"usage,omitempty"`
+}
+
+type piContentBlock struct {
+	Type       string         `json:"type"` // "text" | "thinking" | "toolCall"
+	Text       string         `json:"text,omitempty"`
+	Thinking   string         `json:"thinking,omitempty"`
+	ToolCall   *piTCBlock     `json:"toolCall,omitempty"`
+	ToolResult *piToolResultBlock `json:"toolResult,omitempty"`
+}
+
+type piTCBlock struct {
+	ID   string         `json:"id"`
+	Name string         `json:"name"`
+	Input any            `json:"input,omitempty"`
+}
+
+type piToolResultBlock struct {
+	ToolCallID string         `json:"toolCallId"`
+	Content    []piToolContent `json:"content,omitempty"`
+	IsError    bool           `json:"isError,omitempty"`
+}
+
+type piUsage struct {
+	InputTokens  int `json:"inputTokens,omitempty"`
+	OutputTokens int `json:"outputTokens,omitempty"`
+	CacheRead   int `json:"cacheRead,omitempty"`
+	CacheWrite  int `json:"cacheWrite,omitempty"`
+}
+
+// piEventMessageUpdate is the nested assistantMessageEvent inside a message_update event.
+type piEventMessageUpdate struct {
+	Type        string        `json:"type"` // text_delta, toolcall_delta, etc.
+	ContentIndex int          `json:"contentIndex,omitempty"`
+	Delta       string        `json:"delta,omitempty"`
+	Partial     *piAssistantMessage `json:"partial,omitempty"`
+	TextDelta   string        `json:"textDelta,omitempty"`
+	ThinkingDelta string      `json:"thinkingDelta,omitempty"`
+}
+
+// piStateData is returned from a get_state response.
+type piStateData struct {
+	Model             *piModel  `json:"model,omitempty"`
+	ThinkingLevel     string    `json:"thinkingLevel,omitempty"`
+	IsStreaming       bool      `json:"isStreaming,omitempty"`
+	IsCompacting      bool      `json:"isCompacting,omitempty"`
+	SteeringMode      string    `json:"steeringMode,omitempty"`
+	FollowUpMode      string    `json:"followUpMode,omitempty"`
+	SessionFile       string    `json:"sessionFile,omitempty"`
+	SessionID         string    `json:"sessionId,omitempty"`
+	SessionName       string    `json:"sessionName,omitempty"`
+	MessageCount      int       `json:"messageCount,omitempty"`
+	PendingMsgCount   int       `json:"pendingMessageCount,omitempty"`
+}
+
+type piModel struct {
+	ID              string  `json:"id"`
+	Name            string  `json:"name"`
+	API             string  `json:"api"`
+	Provider        string  `json:"provider"`
+	BaseURL         string  `json:"baseUrl,omitempty"`
+	Reasoning       bool    `json:"reasoning,omitempty"`
+	Input           []string `json:"input,omitempty"`
+	ContextWindow   int     `json:"contextWindow,omitempty"`
+	MaxTokens       int     `json:"maxTokens,omitempty"`
+}
+
+// piSessionStats is returned from a get_session_stats response.
+type piSessionStats struct {
+	SessionFile  string      `json:"sessionFile,omitempty"`
+	SessionID    string      `json:"sessionId,omitempty"`
+	UserMsgs     int         `json:"userMessages,omitempty"`
+	AsstMsgs     int         `json:"assistantMessages,omitempty"`
+	ToolCalls    int         `json:"toolCalls,omitempty"`
+	ToolResults  int         `json:"toolResults,omitempty"`
+	TotalMsgs   int         `json:"totalMessages,omitempty"`
+	Tokens       piTokenStats `json:"tokens,omitempty"`
+	Cost         float64     `json:"cost,omitempty"`
+	ContextUsage *piCtxUsage `json:"contextUsage,omitempty"`
+}
+
+type piTokenStats struct {
+	Input  int `json:"input,omitempty"`
+	Output int `json:"output,omitempty"`
+	CacheRead int `json:"cacheRead,omitempty"`
+	CacheWrite int `json:"cacheWrite,omitempty"`
+	Total int `json:"total,omitempty"`
+}
+
+type piCtxUsage struct {
+	Tokens        int     `json:"tokens,omitempty"`
+	ContextWindow int     `json:"contextWindow,omitempty"`
+	Percent       float64 `json:"percent,omitempty"`
+}
+
+// piTurnEnd is the data payload of a turn_end event.
+type piTurnEnd struct {
+	Message    *piAssistantMessage   `json:"message,omitempty"`
+	ToolResults []piToolResultPayload `json:"toolResults,omitempty"`
+}
+
+type piToolResultPayload struct {
+	ToolCallID string         `json:"toolCallId,omitempty"`
+	ToolName   string         `json:"toolName,omitempty"`
+	Content    []piToolContent `json:"content,omitempty"`
+	IsError    bool           `json:"isError,omitempty"`
+}

--- a/pkg/aiusechat/uctypes/uctypes.go
+++ b/pkg/aiusechat/uctypes/uctypes.go
@@ -20,7 +20,8 @@ const (
 	APIType_AnthropicMessages = "anthropic-messages"
 	APIType_OpenAIResponses   = "openai-responses"
 	APIType_OpenAIChat        = "openai-chat"
-	APIType_GoogleGemini      = "google-gemini"
+	APIType_GoogleGemini       = "google-gemini"
+	APIType_PiRPC             = "pi-rpc"
 )
 
 const (

--- a/pkg/aiusechat/usechat-backend.go
+++ b/pkg/aiusechat/usechat-backend.go
@@ -11,6 +11,7 @@ import (
 	"github.com/wavetermdev/waveterm/pkg/aiusechat/gemini"
 	"github.com/wavetermdev/waveterm/pkg/aiusechat/openai"
 	"github.com/wavetermdev/waveterm/pkg/aiusechat/openaichat"
+	"github.com/wavetermdev/waveterm/pkg/aiusechat/pi"
 	"github.com/wavetermdev/waveterm/pkg/aiusechat/uctypes"
 	"github.com/wavetermdev/waveterm/pkg/web/sse"
 )
@@ -61,8 +62,17 @@ var _ UseChatBackend = (*openaiCompletionsBackend)(nil)
 var _ UseChatBackend = (*anthropicBackend)(nil)
 var _ UseChatBackend = (*geminiBackend)(nil)
 
-// GetBackendByAPIType returns the appropriate UseChatBackend implementation for the given API type
-func GetBackendByAPIType(apiType string) (UseChatBackend, error) {
+// piBackendFactory manages stateful pi backend instances per chat.
+var piBackendFactory = pi.NewFactory()
+
+// GetOrCreatePiBackend returns a pi backend for the given chat, creating one if needed.
+func GetOrCreatePiBackend(chatId string, chatOpts uctypes.WaveChatOpts) (UseChatBackend, error) {
+	return piBackendFactory.NewBackendForChat(chatId, chatOpts)
+}
+
+// GetBackendByAPIType returns the appropriate UseChatBackend implementation for the given API type.
+// For stateful backends (pi), pass chatId and chatOpts to get a per-chat instance.
+func GetBackendByAPIType(apiType string, chatId string, chatOpts uctypes.WaveChatOpts) (UseChatBackend, error) {
 	switch apiType {
 	case uctypes.APIType_OpenAIResponses:
 		return &openaiResponsesBackend{}, nil
@@ -72,6 +82,8 @@ func GetBackendByAPIType(apiType string) (UseChatBackend, error) {
 		return &anthropicBackend{}, nil
 	case uctypes.APIType_GoogleGemini:
 		return &geminiBackend{}, nil
+	case uctypes.APIType_PiRPC:
+		return GetOrCreatePiBackend(chatId, chatOpts)
 	default:
 		return nil, fmt.Errorf("unsupported API type: %s", apiType)
 	}

--- a/pkg/aiusechat/usechat-utils.go
+++ b/pkg/aiusechat/usechat-utils.go
@@ -71,7 +71,7 @@ func ConvertAIChatToUIChat(aiChat *uctypes.AIChat) (*uctypes.UIChat, error) {
 		return nil, nil
 	}
 
-	backend, err := GetBackendByAPIType(aiChat.APIType)
+	backend, err := GetBackendByAPIType(aiChat.APIType, aiChat.ChatId, uctypes.WaveChatOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/aiusechat/usechat.go
+++ b/pkg/aiusechat/usechat.go
@@ -550,7 +550,7 @@ func WaveAIPostMessageWrap(ctx context.Context, sseHandler *sse.SSEHandlerCh, me
 	startTime := time.Now()
 
 	// Convert AIMessage to native chat message using backend
-	backend, err := GetBackendByAPIType(chatOpts.Config.APIType)
+	backend, err := GetBackendByAPIType(chatOpts.Config.APIType, chatOpts.ChatId, chatOpts)
 	if err != nil {
 		return err
 	}
@@ -777,7 +777,7 @@ func CreateWriteTextFileDiff(ctx context.Context, chatId string, toolCallId stri
 		return nil, nil, fmt.Errorf("chat not found: %s", chatId)
 	}
 
-	backend, err := GetBackendByAPIType(aiChat.APIType)
+	backend, err := GetBackendByAPIType(aiChat.APIType, chatId, uctypes.WaveChatOpts{})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Adds pi as a new AI backend (api type: pi-rpc) via subprocess. pi runs as a standalone CLI with JSONL/RPC protocol over stdin/stdout. Each chat gets its own pi subprocess managed by a factory.

Changes:
- pkg/aiusechat/pi/: new backend package (rpc, manager, backend, factory, types)
- pkg/aiusechat/uctypes/: add APIType_PiRPC constant
- pkg/aiusechat/usechat-backend.go: add piBackendFactory and GetOrCreatePiBackend
- pkg/aiusechat/usechat.go: update GetBackendByAPIType call sites to 3-arg form
- pkg/aiusechat/usechat-utils.go: update GetBackendByAPIType call site to 3-arg form
- Taskfile.yml: add build:pi task, wire into electron:dev and package
- electron-builder.config.cjs: include pi binary in dist/bin and asar unpack
- package.json: add @mariozechner/pi-coding-agent dependency