### PR TITLE
fix(term): provide OSC 8 linkHandler to fix hyperlinks not opening

### DIFF
--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -143,6 +143,36 @@ export class TermWrap {
         this.lastCommandAtom = jotai.atom(null) as jotai.PrimitiveAtom<string | null>;
         this.claudeCodeActiveAtom = jotai.atom(false);
         this.webglEnabledAtom = jotai.atom(false) as jotai.PrimitiveAtom<boolean>;
+        // Custom linkHandler for OSC 8 hyperlinks. Without this, xterm.js falls
+        // back to window.confirm() + window.open(), which Electron's renderer
+        // blocks — so the confirmation dialog appears but clicking OK silently
+        // fails. Route OSC 8 clicks through the same Cmd/Ctrl-click path that
+        // WebLinksAddon uses for regex-detected URLs.
+        options.linkHandler = {
+            activate: (event: MouseEvent, uri: string) => {
+                event.preventDefault();
+                switch (PLATFORM) {
+                    case PlatformMacOS:
+                        if (event.metaKey) {
+                            fireAndForget(() => openLink(uri));
+                        }
+                        break;
+                    default:
+                        if (event.ctrlKey) {
+                            fireAndForget(() => openLink(uri));
+                        }
+                        break;
+                }
+            },
+            hover: (event: MouseEvent, uri: string) => {
+                this.hoveredLinkUri = uri;
+                this.onLinkHover?.(uri, event.clientX, event.clientY);
+            },
+            leave: () => {
+                this.hoveredLinkUri = null;
+                this.onLinkHover?.(null, 0, 0);
+            },
+        };
         this.terminal = new Terminal(options);
         this.fitAddon = new FitAddon();
         this.serializeAddon = new SerializeAddon();


### PR DESCRIPTION
## Problem

OSC 8 hyperlinks (e.g. `printf '\e]8;;https://example.com\aClick me\e]8;;\a\n'`) render correctly in Wave, but clicking them shows xterm.js's default `window.confirm()` dialog, and clicking **OK** does nothing. Fixes #3165.

The root cause: when no `linkHandler` is set in `ITerminalOptions`, xterm.js falls back to `window.confirm()` + `window.open()`. In Electron's renderer, `window.open()` navigation is intercepted by `shNavHandler` / `shFrameNavHandler` — so the dialog appears but the browser never opens.

## Fix

Add a `linkHandler` to the terminal options in `TermWrap`'s constructor. The handler:

- Routes `activate` through `openLink()`, using the same **Cmd-click** (macOS) / **Ctrl-click** (other platforms) convention already used by `WebLinksAddon` for regex-detected URLs.
- Wires `hover`/`leave` to `hoveredLinkUri` and `onLinkHover`, so the existing `TermLinkTooltip` ("Cmd-click to open link") appears on OSC 8 links exactly like it does on plain URLs.

The change is a single block in `TermWrap`'s constructor, touching only `termwrap.ts`.

## Testing

```bash
# In a Wave terminal block:
printf '\e]8;;https://example.com\aClick me\e]8;;\a\n'
```

- Hover over "Click me" → tooltip shows "Cmd-click to open link"
- Cmd+click (macOS) / Ctrl+click (Linux/Windows) → opens in default browser or internal web widget (respecting `web:openlinksinternally` setting)
- Plain click → no dialog, no action (consistent with bare-URL behavior)