### PR TITLE
fix(UI)): ensure terminal theme application via xterm theme setter

### DIFF
--- a/frontend/app/view/term/termtheme.ts
+++ b/frontend/app/view/term/termtheme.ts
@@ -20,8 +20,8 @@ const TermThemeUpdater = ({ blockId, model, termRef }: TermThemeProps) => {
     const transparency = useAtomValue(model.termTransparencyAtom);
     const [theme, _] = computeTheme(fullConfig, blockTermTheme, transparency);
     useEffect(() => {
-        if (termRef.current?.terminal) {
-            termRef.current.terminal.options.theme = theme;
+        if (termRef.current != null) {
+            termRef.current.setTheme(theme);
         }
     }, [theme]);
     return null;

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -336,6 +336,14 @@ export class TermWrap {
         this.terminal.options.cursorBlink = cursorBlink ?? false;
     }
 
+    setTheme(theme: TermTypes.ITerminalOptions["theme"]) {
+        if (typeof (this.terminal as any).setOption === "function") {
+            (this.terminal as any).setOption("theme", theme);
+        } else {
+            this.terminal.options.theme = theme;
+        }
+    }
+
     setTermRenderer(renderer: "webgl" | "dom") {
         if (renderer === "webgl") {
             if (this.webglAddon != null) {


### PR DESCRIPTION
When you try to set a theme on a widget:
```json
"test": {
    "icon": "dharmachakra",
    "label": "test",
    "color": "#326ce5",
    "blockdef": {
      "meta": {
        "view": "term",
        "controller": "cmd",
        "cmd": "wsl.exe -d Debian --shell-type login bash -ic \"k9s\"",
        "cmd:interactive": true,
        "cmd:runonstart": true,
        "term:theme": "Dracula"
      }
    }
``` 

It's not take in account. You have to manually change the theme of the block.

Purpose of this PR is to fix this and having the widget taking into account the theme from start.