### PR TITLE
feat: support Windows right-click context menu to open directory

### DIFF
--- a/emain/emain-window.ts
+++ b/emain/emain-window.ts
@@ -29,6 +29,7 @@ export type WindowOpts = {
     unamePlatform: NodeJS.Platform;
     isPrimaryStartupWindow?: boolean;
     foregroundWindow?: boolean;
+    cwd?: string;
 };
 
 export const MinWindowWidth = 800;
@@ -724,6 +725,9 @@ export async function createBrowserWindow(
     if (!waveWindow) {
         console.log("createBrowserWindow: no waveWindow");
         waveWindow = await WindowService.CreateWindow(null, "");
+        if (opts.cwd && waveWindow?.workspaceid) {
+            await ObjectService.UpdateObjectMeta(`workspace:${waveWindow.workspaceid}`, { "cmd:cwd": opts.cwd } as MetaType);
+        }
     }
     let workspace = await WorkspaceService.GetWorkspace(waveWindow.workspaceid);
     if (!workspace) {
@@ -847,8 +851,8 @@ ipcMain.on("delete-workspace", (event, workspaceId) => {
     });
 });
 
-export async function createNewWaveWindow() {
-    log("createNewWaveWindow");
+export async function createNewWaveWindow(cwd?: string) {
+    log("createNewWaveWindow" + (cwd ? ` cwd=${cwd}` : ""));
     const clientData = await ClientService.GetClientData();
     const fullConfig = await RpcApi.GetFullConfigCommand(ElectronWshClient);
     let recreatedWindow = false;
@@ -862,6 +866,7 @@ export async function createNewWaveWindow() {
             const win = await createBrowserWindow(existingWindowData, fullConfig, {
                 unamePlatform,
                 isPrimaryStartupWindow: false,
+                cwd,
             });
             if (quakeWindow == null) {
                 quakeWindow = win;
@@ -878,6 +883,7 @@ export async function createNewWaveWindow() {
     const newBrowserWindow = await createBrowserWindow(null, fullConfig, {
         unamePlatform,
         isPrimaryStartupWindow: false,
+        cwd,
     });
     if (quakeWindow == null) {
         quakeWindow = newBrowserWindow;

--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -388,7 +388,8 @@ async function appMain() {
     }
     electronApp.on("second-instance", (_event, argv, workingDirectory) => {
         console.log("second-instance event, argv:", argv, "workingDirectory:", workingDirectory);
-        fireAndForget(createNewWaveWindow);
+        const cwd = workingDirectory || undefined;
+        fireAndForget(() => createNewWaveWindow(cwd));
     });
     try {
         await runWaveSrv(handleWSEvent);

--- a/wave-context-menu-remove.reg
+++ b/wave-context-menu-remove.reg
@@ -1,0 +1,9 @@
+Windows Registry Editor Version 5.00
+
+; ============================================================
+; Remove Wave Terminal Context Menu
+; ============================================================
+
+[-HKEY_CLASSES_ROOT\Directory\Background\shell\WaveTerminal]
+[-HKEY_CLASSES_ROOT\Directory\shell\WaveTerminal]
+[-HKEY_CLASSES_ROOT\Drive\shell\WaveTerminal]

--- a/wave-context-menu.reg
+++ b/wave-context-menu.reg
@@ -1,0 +1,33 @@
+Windows Registry Editor Version 5.00
+
+; ============================================================
+; Wave Terminal - Windows Right-Click Context Menu
+; ============================================================
+; Adds "Open in Wave Terminal" to:
+;   1. Right-click on empty space in a folder (Directory\Background)
+;   2. Right-click on a folder itself (Directory)
+; ============================================================
+
+; --- Folder background (right-click empty space) ---
+[HKEY_CLASSES_ROOT\Directory\Background\shell\WaveTerminal]
+@="Open in Wave Terminal"
+"Icon"="C:\\Users\\azurr\\AppData\\Local\\Programs\\waveterm\\Wave.exe"
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\WaveTerminal\command]
+@="\"C:\\Users\\azurr\\AppData\\Local\\Programs\\waveterm\\Wave.exe\" \"%V\""
+
+; --- Folder itself (right-click on folder) ---
+[HKEY_CLASSES_ROOT\Directory\shell\WaveTerminal]
+@="Open in Wave Terminal"
+"Icon"="C:\\Users\\azurr\\AppData\\Local\\Programs\\waveterm\\Wave.exe"
+
+[HKEY_CLASSES_ROOT\Directory\shell\WaveTerminal\command]
+@="\"C:\\Users\\azurr\\AppData\\Local\\Programs\\waveterm\\Wave.exe\" \"%1\""
+
+; --- Drive root (right-click on drive in This PC) ---
+[HKEY_CLASSES_ROOT\Drive\shell\WaveTerminal]
+@="Open in Wave Terminal"
+"Icon"="C:\\Users\\azurr\\AppData\\Local\\Programs\\waveterm\\Wave.exe"
+
+[HKEY_CLASSES_ROOT\Drive\shell\WaveTerminal\command]
+@="\"C:\\Users\\azurr\\AppData\\Local\\Programs\\waveterm\\Wave.exe\" \"%1\""


### PR DESCRIPTION
## Summary
- Passes `workingDirectory` from Electron's `second-instance` event to `createNewWaveWindow` and ultimately sets `"cmd:cwd"` metadata on the new workspace, so shells spawn in the right-clicked directory.
- Adds `.reg` files for installing/removing the Windows context menu entry.

## Problem
Currently, right-clicking a folder in Windows Explorer and selecting "Open in Wave Terminal" opens Wave, but always starts in the home directory — the path from the context menu is silently ignored.

The root cause: `emain.ts` `second-instance` handler receives `workingDirectory` but throws it away:
```ts
electronApp.on("second-instance", (_event, argv, workingDirectory) => {
    fireAndForget(createNewWaveWindow); // ← workingDirectory ignored
});
```

## Solution
Three small changes in the Electron main process:

1. **`emain.ts`** — pass `workingDirectory` to `createNewWaveWindow`
2. **`emain-window.ts`** — `createNewWaveWindow(cwd?)` → `createBrowserWindow` → after workspace creation, call `ObjectService.UpdateObjectMeta` with `{"cmd:cwd": cwd}` before the default tab initializes its shell
3. **`emain-window.ts`** — add `cwd?: string` to `WindowOpts`

The Go backend already reads `"cmd:cwd"` from workspace metadata in `shellexec.go`:
```go
if cmdOpts.Cwd != "" {
    ecmd.Dir = cmdOpts.Cwd
}
```

## Testing
- TypeScript: `tsc --noEmit` — zero new errors in `emain/`
- Build: `electron-vite build` — passes (SSR + preload + frontend)

## Registry files included
- `wave-context-menu.reg` — installs "Open in Wave Terminal" in `Directory\Background`, `Directory`, and `Drive` shell keys
- `wave-context-menu-remove.reg` — removes the entries

## Related
- Discussion #2349 (users requesting this feature)
- The `second-instance` handler was already receiving the data — this PR just stops ignoring it.
