### PR TITLE
add Cmd+, shortcut to open Settings, Esc to close

### DIFF
--- a/docs/docs/keybindings.mdx
+++ b/docs/docs/keybindings.mdx
@@ -39,6 +39,7 @@ Chords are shown with a + between the keys. You have 2 seconds to hit the 2nd ch
 | <Kbd k="Cmd:Shift:w"/>                            | Close the current tab                                                                                                                                  |
 | <Kbd k="Cmd:m"/>                                  | Magnify / Un-Magnify the current block                                                                                                                 |
 | <Kbd k="Cmd:g"/>                                  | Open the "connection" switcher                                                                                                                         |
+| <Kbd k="Cmd:,"/>                                  | Open Settings                                                                                                                                          |
 | <Kbd k="Cmd:i"/>                                  | Refocus the current block (useful if the block has lost input focus)                                                                                   |
 | <Kbd k="Ctrl:Shift"/>                             | Show block numbers                                                                                                                                     |
 | <Kbd k="Ctrl:Shift:0"/>                           | Focus WaveAI input                                                                                                                                     |

--- a/frontend/app/element/quicktips.tsx
+++ b/frontend/app/element/quicktips.tsx
@@ -160,6 +160,14 @@ const QuickTips = () => {
                             <span className="text-[15px]">Open Wave AI Panel</span>
                             <KeyBinding keyDecl="Cmd:Shift:a" />
                         </div>
+                        <div className="flex flex-col gap-0.5 p-2 rounded-md hover:bg-white/5 transition-colors">
+                            <span className="text-[15px]">Open Settings</span>
+                            <KeyBinding keyDecl="Cmd:," />
+                        </div>
+                        <div className="flex flex-col gap-0.5 p-2 rounded-md hover:bg-white/5 transition-colors">
+                            <span className="text-[15px]">Close Settings / Close Search</span>
+                            <KeyBinding keyDecl="Escape" />
+                        </div>
                     </div>
 
                     <div className="flex flex-col gap-1.5">

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -655,6 +655,10 @@ function registerGlobalKeys() {
             return true;
         }
     });
+    globalKeyMap.set("Cmd:,", () => {
+        createBlock({ meta: { view: "waveconfig" } }, false, true);
+        return true;
+    });
     globalKeyMap.set("Ctrl:Shift:i", () => {
         const tabModel = getActiveTabModel();
         if (tabModel == null) {
@@ -737,6 +741,17 @@ function registerGlobalKeys() {
         }
         if (deactivateSearch()) {
             return true;
+        }
+        const layoutModel = getLayoutModelForStaticTab();
+        const focusedNode = globalStore.get(layoutModel.focusedNode);
+        const blockId = focusedNode?.data?.blockId;
+        if (blockId != null) {
+            const blockAtom = WOS.getWaveObjectAtom<Block>(WOS.makeORef("block", blockId));
+            const blockData = globalStore.get(blockAtom);
+            if (blockData?.meta?.view === "waveconfig" || blockData?.meta?.view === "tips") {
+                fireAndForget(layoutModel.closeFocusedNode.bind(layoutModel));
+                return true;
+            }
         }
         return false;
     });


### PR DESCRIPTION
Adds a `Cmd+,` keyboard shortcut to open the Settings panel as an ephemeral block (matching the gear icon behavior). Pressing `Escape` while focused on Settings or Tips closes the block.

### Changes

- **`frontend/app/store/keymodel.ts`**: Register `Cmd+,` global shortcut that calls `createBlock` with ephemeral flag; extend Escape handler to close `waveconfig` and `tips` blocks when focused
- **`frontend/app/element/quicktips.tsx`**: Add "Open Settings" (`Cmd+,`) and "Close Settings / Close Search" (Escape) entries to the Tips block's Main Keybindings section
- **`docs/docs/keybindings.mdx`**: Document `Cmd+,` in the Global Keybindings table

### Testing

Open Tips block to see the new shortcuts listed. Press `Cmd+,` to open Settings, press Escape to close it.