### PR TITLE
Update Google Gemini model details in documentation

### DIFF
--- a/docs/docs/waveai-modes.mdx
+++ b/docs/docs/waveai-modes.mdx
@@ -326,9 +326,9 @@ For Groq, you must manually specify `ai:capabilities` based on your model's feat
 ```json
 {
   "google-gemini": {
-    "display:name": "Gemini 3 Pro",
+    "display:name": "Gemini 3.5 Flash",
     "ai:provider": "google",
-    "ai:model": "gemini-3-pro-preview"
+    "ai:model": "gemini-3.5-flash"
   }
 }
 ```


### PR DESCRIPTION
3.0 preview is no longer a valid option.   Google recommends 3.5 Flash for all agentic work