### PR TITLE
[codex] Fix terminal IME composition handling

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -199,6 +199,7 @@ tasks:
             - task: build:server:internal
               vars:
                   ARCHS: arm64,amd64
+                  GO_ENV_VARS: MACOSX_DEPLOYMENT_TARGET=12.0
 
     build:server:quickdev:
         desc: Build the wavesrv component for quickdev (arm64 macOS only, no generate).
@@ -207,6 +208,7 @@ tasks:
             - task: build:server:internal
               vars:
                   ARCHS: arm64
+                  GO_ENV_VARS: MACOSX_DEPLOYMENT_TARGET=12.0
         deps:
             - go:mod:tidy
         sources:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -124,12 +124,12 @@ tasks:
     package:
         desc: Package the application for the current platform.
         cmds:
+            - task: clean
+            - task: build:backend
+            - task: build:tsunamiscaffold
             - npm run build:prod && npm exec electron-builder -- -c electron-builder.config.cjs -p never {{.CLI_ARGS}}
         deps:
-            - clean
             - npm:install
-            - build:backend
-            - build:tsunamiscaffold
 
     build:frontend:dev:
         desc: Build the frontend in development mode.

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -4,6 +4,44 @@ const fs = require("fs");
 const path = require("path");
 
 const windowsShouldSign = !!process.env.SM_CODE_SIGNING_CERT_SHA1_HASH;
+const archNameByValue = {
+    [Arch.x64]: "x64",
+    [Arch.arm64]: "arm64",
+    [Arch.universal]: "universal",
+};
+
+function getPackageBinDir(context) {
+    if (context.electronPlatformName !== "darwin") {
+        return path.resolve(context.appOutDir, "resources/app.asar.unpacked/dist/bin");
+    }
+    return path.resolve(context.appOutDir, `${pkg.productName}.app/Contents/Resources/app.asar.unpacked/dist/bin`);
+}
+
+function getExpectedPackageBinaries(context) {
+    const platform = context.electronPlatformName;
+    const arch = archNameByValue[context.arch] ?? context.arch;
+    const exeExt = platform === "win32" ? ".exe" : "";
+
+    if (platform === "darwin" && arch === "universal") {
+        return ["wavesrv.arm64", "wavesrv.x64", `wsh-${pkg.version}-darwin.arm64`, `wsh-${pkg.version}-darwin.x64`];
+    }
+
+    return [
+        `wavesrv.${arch}${exeExt}`,
+        `wsh-${pkg.version}-${platform === "win32" ? "windows" : platform}.${arch}${exeExt}`,
+    ];
+}
+
+function validatePackagedBinaries(context) {
+    const packageBinDir = getPackageBinDir(context);
+    const missing = getExpectedPackageBinaries(context).filter(
+        (file) => !fs.existsSync(path.resolve(packageBinDir, file))
+    );
+    if (missing.length === 0) {
+        return;
+    }
+    throw new Error(`Missing packaged Wave binaries in ${packageBinDir}: ${missing.join(", ")}`);
+}
 
 /**
  * @type {import('electron-builder').Configuration}
@@ -61,6 +99,7 @@ const config = {
         singleArchFiles: "**/dist/bin/wavesrv.*",
         entitlements: "build/entitlements.mac.plist",
         entitlementsInherit: "build/entitlements.mac.plist",
+        notarize: !!process.env.APPLE_API_KEY || !!process.env.APPLE_ID,
         extendInfo: {
             NSContactsUsageDescription: "A CLI application running in Wave wants to use your contacts.",
             NSRemindersUsageDescription: "A CLI application running in Wave wants to use your reminders.",
@@ -122,12 +161,11 @@ const config = {
         url: "https://dl.waveterm.dev/releases-w2",
     },
     afterPack: (context) => {
+        validatePackagedBinaries(context);
+
         // This is a workaround to restore file permissions to the wavesrv binaries on macOS after packaging the universal binary.
         if (context.electronPlatformName === "darwin" && context.arch === Arch.universal) {
-            const packageBinDir = path.resolve(
-                context.appOutDir,
-                `${pkg.productName}.app/Contents/Resources/app.asar.unpacked/dist/bin`
-            );
+            const packageBinDir = getPackageBinDir(context);
 
             // Reapply file permissions to the wavesrv binaries in the final app package
             fs.readdirSync(packageBinDir, {

--- a/frontend/app/modals/closetabconfirmmodal.tsx
+++ b/frontend/app/modals/closetabconfirmmodal.tsx
@@ -1,0 +1,54 @@
+// Copyright 2026, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Modal } from "@/app/modals/modal";
+import { modalsModel } from "@/app/store/modalmodel";
+import { useState } from "react";
+
+type CloseTabConfirmModalProps = {
+    onCancel: () => void;
+    onConfirm: (dontAskAgain: boolean) => void | Promise<void>;
+};
+
+const CloseTabConfirmModal = ({ onCancel, onConfirm }: CloseTabConfirmModalProps) => {
+    const [dontAskAgain, setDontAskAgain] = useState(false);
+
+    const handleCancel = () => {
+        modalsModel.popModal();
+        onCancel();
+    };
+
+    const handleConfirm = () => {
+        modalsModel.popModal();
+        onConfirm(dontAskAgain);
+    };
+
+    return (
+        <Modal
+            className="pt-6 pb-4 px-5 w-[420px]"
+            onOk={handleConfirm}
+            onCancel={handleCancel}
+            onClose={handleCancel}
+            okLabel="Close Tab"
+            cancelLabel="Cancel"
+        >
+            <div className="mx-4 pb-2.5 font-bold text-primary">Close Tab?</div>
+            <div className="mx-4 mb-4 flex flex-col gap-4 text-primary">
+                <div className="text-sm text-secondary">Are you sure you want to close this tab?</div>
+                <label className="flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                        type="checkbox"
+                        className="accent-accent cursor-pointer"
+                        checked={dontAskAgain}
+                        onChange={(e) => setDontAskAgain(e.target.checked)}
+                    />
+                    <span>Do not ask me again</span>
+                </label>
+            </div>
+        </Modal>
+    );
+};
+
+CloseTabConfirmModal.displayName = "CloseTabConfirmModal";
+
+export { CloseTabConfirmModal };

--- a/frontend/app/modals/modalregistry.tsx
+++ b/frontend/app/modals/modalregistry.tsx
@@ -8,12 +8,14 @@ import { UpgradeOnboardingPatch } from "@/app/onboarding/onboarding-upgrade-patc
 import { DeleteFileModal, PublishAppModal, RenameFileModal } from "@/builder/builder-apppanel";
 import { SetSecretDialog } from "@/builder/tabs/builder-secrettab";
 import { AboutModal } from "./about";
+import { CloseTabConfirmModal } from "./closetabconfirmmodal";
 import { UserInputModal } from "./userinputmodal";
 
 const modalRegistry: { [key: string]: React.ComponentType<any> } = {
     [NewInstallOnboardingModal.displayName || "NewInstallOnboardingModal"]: NewInstallOnboardingModal,
     [UpgradeOnboardingModal.displayName || "UpgradeOnboardingModal"]: UpgradeOnboardingModal,
     [UpgradeOnboardingPatch.displayName || "UpgradeOnboardingPatch"]: UpgradeOnboardingPatch,
+    [CloseTabConfirmModal.displayName || "CloseTabConfirmModal"]: CloseTabConfirmModal,
     [UserInputModal.displayName || "UserInputModal"]: UserInputModal,
     [AboutModal.displayName || "AboutModal"]: AboutModal,
     [MessageModal.displayName || "MessageModal"]: MessageModal,

--- a/frontend/app/onboarding/onboarding-common.tsx
+++ b/frontend/app/onboarding/onboarding-common.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026, Command Line Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export const CurrentOnboardingVersion = "v0.14.5";
+export const CurrentOnboardingVersion = "v0.14.6";
 
 export function OnboardingGradientBg() {
     return (

--- a/frontend/app/onboarding/onboarding-upgrade-patch.tsx
+++ b/frontend/app/onboarding/onboarding-upgrade-patch.tsx
@@ -27,6 +27,7 @@ import { UpgradeOnboardingModal_v0_14_1_Content } from "./onboarding-upgrade-v01
 import { UpgradeOnboardingModal_v0_14_2_Content } from "./onboarding-upgrade-v0142";
 import { UpgradeOnboardingModal_v0_14_4_Content } from "./onboarding-upgrade-v0144";
 import { UpgradeOnboardingModal_v0_14_5_Content } from "./onboarding-upgrade-v0145";
+import { UpgradeOnboardingModal_v0_14_6_Content } from "./onboarding-upgrade-v0146";
 
 interface VersionConfig {
     version: string;
@@ -64,10 +65,7 @@ export function UpgradeOnboardingFooter({
                 <div className="flex-1 flex justify-start">
                     {hasPrev && (
                         <div className="text-sm text-secondary">
-                            <button
-                                onClick={onPrev}
-                                className="cursor-pointer hover:text-foreground transition-colors"
-                            >
+                            <button onClick={onPrev} className="cursor-pointer hover:text-foreground transition-colors">
                                 &lt; {prevText}
                             </button>
                         </div>
@@ -81,10 +79,7 @@ export function UpgradeOnboardingFooter({
                 <div className="flex-1 flex justify-end">
                     {hasNext && (
                         <div className="text-sm text-secondary">
-                            <button
-                                onClick={onNext}
-                                className="cursor-pointer hover:text-foreground transition-colors"
-                            >
+                            <button onClick={onNext} className="cursor-pointer hover:text-foreground transition-colors">
                                 {nextText} &gt;
                             </button>
                         </div>
@@ -153,6 +148,12 @@ export const UpgradeOnboardingVersions: VersionConfig[] = [
         version: "v0.14.5",
         content: () => <UpgradeOnboardingModal_v0_14_5_Content />,
         prevText: "Prev (v0.14.4)",
+        nextText: "Next (v0.14.6)",
+    },
+    {
+        version: "v0.14.6",
+        content: () => <UpgradeOnboardingModal_v0_14_6_Content />,
+        prevText: "Prev (v0.14.5)",
     },
 ];
 
@@ -242,10 +243,7 @@ const UpgradeOnboardingPatch = ({ isReleaseNotes = false }: UpgradeOnboardingPat
 
     if (showStarAsk) {
         return (
-            <FlexiModal
-                className="w-[500px] rounded-[10px] !p-[30px] relative overflow-hidden bg-panel"
-                ref={modalRef}
-            >
+            <FlexiModal className="w-[500px] rounded-[10px] !p-[30px] relative overflow-hidden bg-panel" ref={modalRef}>
                 <OnboardingGradientBg />
                 <div className="relative z-10 flex flex-col w-full h-full">
                     <StarAskPage onClose={doClose} page="upgrade" />

--- a/frontend/app/onboarding/onboarding-upgrade-v0146.tsx
+++ b/frontend/app/onboarding/onboarding-upgrade-v0146.tsx
@@ -1,0 +1,45 @@
+// Copyright 2026, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+const UpgradeOnboardingModal_v0_14_6_Content = () => {
+    return (
+        <div className="flex flex-col items-start gap-6 w-full mb-4 unselectable">
+            <div className="text-secondary leading-relaxed">
+                <p className="mb-0">
+                    Wave v0.14.6 is a patch release focused on terminal input reliability and packaging safeguards.
+                </p>
+            </div>
+
+            <div className="flex w-full items-start gap-4">
+                <div className="flex-shrink-0">
+                    <i className="text-[24px] text-accent fa-solid fa-keyboard"></i>
+                </div>
+                <div className="flex flex-col items-start gap-2 flex-1">
+                    <div className="text-foreground text-base font-semibold leading-[18px]">IME Input Fixes</div>
+                    <div className="text-secondary leading-5">
+                        Korean IME composition now preserves the correct ordering when pressing Enter before a final
+                        consonant is committed. This also avoids intermittent duplicated input when switching between
+                        English and Korean input modes.
+                    </div>
+                </div>
+            </div>
+
+            <div className="flex w-full items-start gap-4">
+                <div className="flex-shrink-0">
+                    <i className="text-[24px] text-accent fa-sharp fa-solid fa-box"></i>
+                </div>
+                <div className="flex flex-col items-start gap-2 flex-1">
+                    <div className="text-foreground text-base font-semibold leading-[18px]">Packaging Validation</div>
+                    <div className="text-secondary leading-5">
+                        Release packaging now fails early if required Wave backend binaries are missing from the
+                        packaged app, preventing broken installers from being published.
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+UpgradeOnboardingModal_v0_14_6_Content.displayName = "UpgradeOnboardingModal_v0_14_6_Content";
+
+export { UpgradeOnboardingModal_v0_14_6_Content };

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -21,6 +21,7 @@ import {
     WOS,
 } from "@/app/store/global";
 import { getActiveTabModel } from "@/app/store/tab-model";
+import { closeTabWithConfirmation } from "@/app/tab/closetab";
 import { WorkspaceLayoutModel } from "@/app/workspace/workspace-layout-model";
 import { deleteLayoutModelForTab, getLayoutModelForStaticTab, NavigateDirection } from "@/layout/index";
 import * as keyutil from "@/util/keyutil";
@@ -132,16 +133,13 @@ function simpleCloseStaticTab() {
     const workspaceId = globalStore.get(atoms.workspaceId);
     const tabId = globalStore.get(atoms.staticTabId);
     const confirmClose = globalStore.get(getSettingsKeyAtom("tab:confirmclose")) ?? false;
-    getApi()
-        .closeTab(workspaceId, tabId, confirmClose)
-        .then((didClose) => {
-            if (didClose) {
-                deleteLayoutModelForTab(tabId);
-            }
-        })
-        .catch((e) => {
-            console.log("error closing tab", e);
-        });
+    closeTabWithConfirmation({
+        confirmClose,
+        closeTab: () => getApi().closeTab(workspaceId, tabId, false),
+        onDidClose: () => deleteLayoutModelForTab(tabId),
+    }).catch((e) => {
+        console.log("error closing tab", e);
+    });
 }
 
 function uxCloseBlock(blockId: string) {

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -417,7 +417,7 @@ function appHandleKeyDown(waveEvent: WaveKeyboardEvent): boolean {
     if (globalKeybindingsDisabled) {
         return false;
     }
-    if ((waveEvent as any).isComposing) {
+    if (waveEvent.isComposing) {
         return false;
     }
     const nativeEvent = (waveEvent as any).nativeEvent;

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -417,6 +417,9 @@ function appHandleKeyDown(waveEvent: WaveKeyboardEvent): boolean {
     if (globalKeybindingsDisabled) {
         return false;
     }
+    if ((waveEvent as any).isComposing) {
+        return false;
+    }
     const nativeEvent = (waveEvent as any).nativeEvent;
     if (lastHandledEvent != null && nativeEvent != null && lastHandledEvent === nativeEvent) {
         return false;

--- a/frontend/app/tab/closetab.ts
+++ b/frontend/app/tab/closetab.ts
@@ -1,0 +1,48 @@
+// Copyright 2026, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { modalsModel } from "@/app/store/modalmodel";
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
+
+type CloseTabFn = () => Promise<boolean>;
+
+type CloseTabWithConfirmationOpts = {
+    confirmClose: boolean;
+    closeTab: CloseTabFn;
+    onDidClose?: () => void;
+};
+
+export async function closeTabWithConfirmation({
+    confirmClose,
+    closeTab,
+    onDidClose,
+}: CloseTabWithConfirmationOpts): Promise<boolean> {
+    if (!confirmClose) {
+        return await runClose(closeTab, onDidClose);
+    }
+    return await new Promise<boolean>((resolve, reject) => {
+        modalsModel.pushModal("CloseTabConfirmModal", {
+            onCancel: () => resolve(false),
+            onConfirm: async (dontAskAgain: boolean) => {
+                try {
+                    if (dontAskAgain) {
+                        await RpcApi.SetConfigCommand(TabRpcClient, { "tab:confirmclose": false });
+                    }
+                    const didClose = await runClose(closeTab, onDidClose);
+                    resolve(didClose);
+                } catch (e) {
+                    reject(e);
+                }
+            },
+        });
+    });
+}
+
+async function runClose(closeTab: CloseTabFn, onDidClose?: () => void): Promise<boolean> {
+    const didClose = await closeTab();
+    if (didClose) {
+        onDidClose?.();
+    }
+    return didClose;
+}

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -12,6 +12,7 @@ import { useAtomValue } from "jotai";
 import { OverlayScrollbars } from "overlayscrollbars";
 import { createRef, memo, useCallback, useEffect, useRef, useState } from "react";
 import { debounce } from "throttle-debounce";
+import { closeTabWithConfirmation } from "./closetab";
 import { Tab } from "./tab";
 import "./tabbar.scss";
 import { TabBarEnv } from "./tabbarenv";
@@ -283,16 +284,7 @@ const TabBar = memo(({ workspace, noTabs }: TabBarProps) => {
                 prevAllLoadedRef.current = true;
             }
         }
-    }, [
-        tabIds,
-        tabsLoaded,
-        newTabId,
-        saveTabsPosition,
-        hideAiButton,
-        appUpdateStatus,
-        zoomFactor,
-        showMenuBar,
-    ]);
+    }, [tabIds, tabsLoaded, newTabId, saveTabsPosition, hideAiButton, appUpdateStatus, zoomFactor, showMenuBar]);
 
     const getDragDirection = (currentX: number) => {
         let dragDirection: string;
@@ -541,17 +533,18 @@ const TabBar = memo(({ workspace, noTabs }: TabBarProps) => {
 
     const handleCloseTab = (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null, tabId: string) => {
         event?.stopPropagation();
-        env.electron
-            .closeTab(workspace.oid, tabId, confirmClose)
-            .then((didClose) => {
-                if (didClose) {
+        closeTabWithConfirmation({
+            confirmClose,
+            closeTab: () => env.electron.closeTab(workspace.oid, tabId, false),
+            onDidClose: () => {
+                if (tabsWrapperRef.current) {
                     tabsWrapperRef.current?.style.setProperty("--tabs-wrapper-transition", "width 0.3s ease");
-                    deleteLayoutModelForTab(tabId);
                 }
-            })
-            .catch((e) => {
-                console.log("error closing tab", e);
-            });
+                deleteLayoutModelForTab(tabId);
+            },
+        }).catch((e) => {
+            console.log("error closing tab", e);
+        });
     };
 
     const handleTabLoaded = useCallback((tabId: string) => {
@@ -576,9 +569,7 @@ const TabBar = memo(({ workspace, noTabs }: TabBarProps) => {
     // Calculate window drag left width based on platform and state
     let windowDragLeftWidth = 10;
     if (env.isMacOS() && !isFullScreen) {
-        const trafficLightsWidth = isMacOSTahoeOrLater()
-            ? MacOSTahoeTrafficLightsWidth
-            : MacOSTrafficLightsWidth;
+        const trafficLightsWidth = isMacOSTahoeOrLater() ? MacOSTahoeTrafficLightsWidth : MacOSTrafficLightsWidth;
         if (zoomFactor > 0) {
             windowDragLeftWidth = trafficLightsWidth / zoomFactor;
         } else {

--- a/frontend/app/tab/vtabbar.tsx
+++ b/frontend/app/tab/vtabbar.tsx
@@ -12,6 +12,7 @@ import { validateCssColor } from "@/util/color-validator";
 import { cn, fireAndForget } from "@/util/util";
 import { useAtomValue } from "jotai";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { closeTabWithConfirmation } from "./closetab";
 import { buildTabBarContextMenu, buildTabContextMenu } from "./tabcontextmenu";
 import { UpdateStatusBanner } from "./updatebanner";
 import { VTab, VTabItem } from "./vtab";
@@ -189,6 +190,7 @@ export function VTabBar({ workspace, className }: VTabBarProps) {
     const activeTabId = useAtomValue(env.atoms.staticTabId);
     const reinitVersion = useAtomValue(env.atoms.reinitVersion);
     const documentHasFocus = useAtomValue(env.atoms.documentHasFocus);
+    const confirmClose = useAtomValue(env.getSettingsKeyAtom("tab:confirmclose")) ?? false;
     const tabIds = workspace?.tabids ?? [];
 
     const [orderedTabIds, setOrderedTabIds] = useState<string[]>(tabIds);
@@ -374,7 +376,14 @@ export function VTabBar({ workspace, className }: VTabBarProps) {
                             hoverResetVersion={hoverResetVersion}
                             index={index}
                             onSelect={() => env.electron.setActiveTab(tabId)}
-                            onClose={() => fireAndForget(() => env.electron.closeTab(workspace.oid, tabId, false))}
+                            onClose={() =>
+                                fireAndForget(() =>
+                                    closeTabWithConfirmation({
+                                        confirmClose,
+                                        closeTab: () => env.electron.closeTab(workspace.oid, tabId, false),
+                                    })
+                                )
+                            }
                             onRename={(newName) =>
                                 fireAndForget(() => env.rpc.UpdateTabNameCommand(TabRpcClient, tabId, newName))
                             }

--- a/frontend/app/view/term/ijson.tsx
+++ b/frontend/app/view/term/ijson.tsx
@@ -104,7 +104,7 @@ body {
 }
 
 .fixed-font {
-	normal 12px / normal "Hack", monospace;
+	font: normal 12px / normal "Hack", "Noto Sans Mono CJK KR", "Noto Sans Mono CJK JP", "Noto Sans Mono CJK SC", "Noto Sans Mono CJK TC", "Noto Sans CJK KR", "Noto Sans CJK JP", "Noto Sans CJK SC", "Noto Sans CJK TC", "Apple SD Gothic Neo", "Hiragino Sans", "PingFang SC", "PingFang TC", "Microsoft YaHei", "Malgun Gothic", monospace;
 }
 					`}
                 </style>

--- a/frontend/app/view/term/term-model.ts
+++ b/frontend/app/view/term/term-model.ts
@@ -697,6 +697,9 @@ export class TermViewModel implements ViewModel {
     }
 
     handleTerminalKeydown(event: KeyboardEvent): boolean {
+        if (event.isComposing || event.keyCode == 229) {
+            return true;
+        }
         const waveEvent = keyutil.adaptFromReactOrNativeKeyEvent(event);
         if (waveEvent.type != "keydown") {
             return true;

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -29,6 +29,10 @@ import { TermWrap } from "./termwrap";
 import "./xterm.css";
 
 const dlog = debug("wave:term");
+const DefaultTermFontFamily =
+    "Hack, 'Noto Sans Mono CJK KR', 'Noto Sans Mono CJK JP', 'Noto Sans Mono CJK SC', 'Noto Sans Mono CJK TC', " +
+    "'Noto Sans CJK KR', 'Noto Sans CJK JP', 'Noto Sans CJK SC', 'Noto Sans CJK TC', " +
+    "'Apple SD Gothic Neo', 'Hiragino Sans', 'PingFang SC', 'PingFang TC', 'Microsoft YaHei', 'Malgun Gothic', monospace";
 
 interface TerminalViewProps {
     blockId: string;
@@ -300,7 +304,7 @@ const TerminalView = ({ blockId, model }: ViewComponentProps<TermViewModel>) => 
             {
                 theme: termTheme,
                 fontSize: termFontSize,
-                fontFamily: termSettings?.["term:fontfamily"] ?? connFontFamily ?? "Hack",
+                fontFamily: termSettings?.["term:fontfamily"] ?? connFontFamily ?? DefaultTermFontFamily,
                 drawBoldTextInBrightColors: false,
                 fontWeight: "normal",
                 fontWeightBold: "bold",

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -296,6 +296,7 @@ const TerminalView = ({ blockId, model }: ViewComponentProps<TermViewModel>) => 
         const termMacOptionIsMeta = globalStore.get(termMacOptionIsMetaAtom) ?? false;
         const termCursorStyle = normalizeCursorStyle(globalStore.get(getOverrideConfigAtom(blockId, "term:cursor")));
         const termCursorBlink = globalStore.get(getOverrideConfigAtom(blockId, "term:cursorblink")) ?? false;
+        const termDisableWebGl = termSettings?.["term:disablewebgl"] ?? true;
         const wasFocused = model.termRef.current != null && globalStore.get(model.nodeModel.isFocused);
         const termWrap = new TermWrap(
             tabModel.tabId,
@@ -319,7 +320,7 @@ const TerminalView = ({ blockId, model }: ViewComponentProps<TermViewModel>) => 
             },
             {
                 keydownHandler: model.handleTerminalKeydown.bind(model),
-                useWebGl: !termSettings?.["term:disablewebgl"],
+                useWebGl: !termDisableWebGl,
                 sendDataHandler: model.sendDataToController.bind(model),
                 nodeModel: model.nodeModel,
             }

--- a/frontend/app/view/term/termwrap.test.ts
+++ b/frontend/app/view/term/termwrap.test.ts
@@ -1,0 +1,88 @@
+// Copyright 2026, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("TermWrap IME data ordering", () => {
+    let originalDocument: Document;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        originalDocument = globalThis.document;
+        vi.stubGlobal("document", {
+            createElement: () => ({
+                getContext: () => null,
+            }),
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+        if (originalDocument != null) {
+            vi.stubGlobal("document", originalDocument);
+        }
+        vi.resetModules();
+    });
+
+    async function makeTermWrapHarness() {
+        const { TermWrap } = await import("./termwrap");
+        const sent: string[] = [];
+        const termWrap = Object.create(TermWrap.prototype) as InstanceType<typeof TermWrap>;
+
+        termWrap.loaded = true;
+        termWrap.disposed = false;
+        termWrap.compositionActive = false;
+        termWrap.compositionRecentlyEndedUntil = 0;
+        termWrap.pendingCompositionSuffix = null;
+        termWrap.sendDataHandler = (data: string) => sent.push(data);
+        termWrap.multiInputCallback = null;
+
+        return { sent, termWrap };
+    }
+
+    it("sends Enter after committed IME text when Enter arrives during composition", async () => {
+        const { sent, termWrap } = await makeTermWrapHarness();
+
+        termWrap.compositionActive = true;
+        termWrap.handleTermData("\r");
+        expect(sent).toEqual([]);
+
+        termWrap.compositionActive = false;
+        termWrap.compositionRecentlyEndedUntil = Date.now() + 75;
+        termWrap.handleTermData("가");
+
+        expect(sent).toEqual(["가", "\r"]);
+    });
+
+    it("flushes a deferred Enter if composition ends without committed text", async () => {
+        const { sent, termWrap } = await makeTermWrapHarness();
+
+        termWrap.compositionActive = true;
+        termWrap.handleTermData("\r");
+        termWrap.compositionActive = false;
+        termWrap.schedulePendingCompositionSuffixFlush();
+
+        vi.advanceTimersByTime(30);
+
+        expect(sent).toEqual(["\r"]);
+    });
+
+    it("does not defer ordinary ASCII data while composition is active", async () => {
+        const { sent, termWrap } = await makeTermWrapHarness();
+
+        termWrap.compositionActive = true;
+        termWrap.handleTermData("hello");
+
+        expect(sent).toEqual(["hello"]);
+    });
+
+    it("does not treat a full ASCII line as a composition suffix", async () => {
+        const { sent, termWrap } = await makeTermWrapHarness();
+
+        termWrap.compositionRecentlyEndedUntil = Date.now() + 75;
+        termWrap.handleTermData("previous sentence");
+
+        expect(sent).toEqual(["previous sentence"]);
+    });
+});

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -52,6 +52,7 @@ const TermCacheFileName = "cache:term:full";
 const MinDataProcessedForCache = 100 * 1024;
 export const SupportsImageInput = true;
 const MaxRepaintTransactionMs = 2000;
+const MaxCompositionSuffixLength = 4;
 
 // detect webgl support
 function detectWebGLSupport(): boolean {
@@ -114,7 +115,7 @@ export class TermWrap {
     // IME composition ordering
     compositionActive: boolean = false;
     compositionRecentlyEndedUntil: number = 0;
-    pendingCompositionSuffix: { data: string; timeout: ReturnType<typeof setTimeout> } | null = null;
+    pendingCompositionSuffix: { data: string; timeout: ReturnType<typeof setTimeout> | null } | null = null;
     disposed: boolean = false;
 
     // dev only (for debugging)
@@ -491,6 +492,7 @@ export class TermWrap {
         const compositionEndHandler = () => {
             this.compositionActive = false;
             this.compositionRecentlyEndedUntil = Date.now() + 75;
+            this.schedulePendingCompositionSuffixFlush();
         };
         textarea.addEventListener("compositionstart", compositionStartHandler);
         textarea.addEventListener("compositionend", compositionEndHandler);
@@ -523,7 +525,9 @@ export class TermWrap {
             return;
         }
         const pendingData = this.pendingCompositionSuffix.data;
-        clearTimeout(this.pendingCompositionSuffix.timeout);
+        if (this.pendingCompositionSuffix.timeout != null) {
+            clearTimeout(this.pendingCompositionSuffix.timeout);
+        }
         this.pendingCompositionSuffix = null;
         if (!this.loaded || this.disposed) {
             return;
@@ -535,8 +539,26 @@ export class TermWrap {
         if (this.pendingCompositionSuffix == null) {
             return;
         }
-        clearTimeout(this.pendingCompositionSuffix.timeout);
+        if (this.pendingCompositionSuffix.timeout != null) {
+            clearTimeout(this.pendingCompositionSuffix.timeout);
+        }
         this.pendingCompositionSuffix = null;
+    }
+
+    schedulePendingCompositionSuffixFlush() {
+        if (this.pendingCompositionSuffix == null) {
+            return;
+        }
+        if (this.pendingCompositionSuffix.timeout != null) {
+            clearTimeout(this.pendingCompositionSuffix.timeout);
+            this.pendingCompositionSuffix.timeout = null;
+        }
+        if (this.compositionActive) {
+            return;
+        }
+        this.pendingCompositionSuffix.timeout = setTimeout(() => {
+            this.flushPendingCompositionSuffix();
+        }, 30);
     }
 
     isLikelyCompositionText(data: string): boolean {
@@ -557,7 +579,7 @@ export class TermWrap {
     }
 
     isCompositionSuffixData(data: string): boolean {
-        if (data.length === 0) {
+        if (data.length === 0 || data.length > MaxCompositionSuffixLength) {
             return false;
         }
         for (const ch of data) {
@@ -569,6 +591,16 @@ export class TermWrap {
         return true;
     }
 
+    shouldDeferCompositionData(data: string): boolean {
+        if (this.compositionActive) {
+            return data === "\r";
+        }
+        if (Date.now() > this.compositionRecentlyEndedUntil) {
+            return false;
+        }
+        return data === "\r" || this.isCompositionSuffixData(data);
+    }
+
     handleTermData(data: string) {
         if (!this.loaded) {
             return;
@@ -577,34 +609,32 @@ export class TermWrap {
         if (this.pendingCompositionSuffix != null) {
             if (this.isLikelyCompositionText(data)) {
                 const pendingData = this.pendingCompositionSuffix.data;
-                clearTimeout(this.pendingCompositionSuffix.timeout);
+                if (this.pendingCompositionSuffix.timeout != null) {
+                    clearTimeout(this.pendingCompositionSuffix.timeout);
+                }
                 this.pendingCompositionSuffix = null;
                 this.sendTermData(data);
                 this.sendTermData(pendingData);
                 return;
             }
-            if (this.isCompositionSuffixData(data) && Date.now() <= this.compositionRecentlyEndedUntil) {
-                clearTimeout(this.pendingCompositionSuffix.timeout);
+            if (this.shouldDeferCompositionData(data)) {
+                if (this.pendingCompositionSuffix.timeout != null) {
+                    clearTimeout(this.pendingCompositionSuffix.timeout);
+                    this.pendingCompositionSuffix.timeout = null;
+                }
                 this.pendingCompositionSuffix.data += data;
-                this.pendingCompositionSuffix.timeout = setTimeout(() => {
-                    this.flushPendingCompositionSuffix();
-                }, 30);
+                this.schedulePendingCompositionSuffixFlush();
                 return;
             }
             this.flushPendingCompositionSuffix();
         }
 
-        if (
-            this.isCompositionSuffixData(data) &&
-            !this.compositionActive &&
-            Date.now() <= this.compositionRecentlyEndedUntil
-        ) {
+        if (this.shouldDeferCompositionData(data)) {
             this.pendingCompositionSuffix = {
                 data,
-                timeout: setTimeout(() => {
-                    this.flushPendingCompositionSuffix();
-                }, 30),
+                timeout: null,
             };
+            this.schedulePendingCompositionSuffixFlush();
             return;
         }
 

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -114,7 +114,7 @@ export class TermWrap {
     // IME composition ordering
     compositionActive: boolean = false;
     compositionRecentlyEndedUntil: number = 0;
-    pendingCompositionSpace: { timeout: ReturnType<typeof setTimeout> } | null = null;
+    pendingCompositionSuffix: { data: string; timeout: ReturnType<typeof setTimeout> } | null = null;
     disposed: boolean = false;
 
     // dev only (for debugging)
@@ -464,7 +464,7 @@ export class TermWrap {
             }
         });
         this.promptMarkers = [];
-        this.cancelPendingCompositionSpace();
+        this.cancelPendingCompositionSuffix();
         this.webglContextLossDisposable?.dispose();
         this.webglContextLossDisposable = null;
         this.terminal.dispose();
@@ -486,7 +486,7 @@ export class TermWrap {
         const compositionStartHandler = () => {
             this.compositionActive = true;
             this.compositionRecentlyEndedUntil = 0;
-            this.flushPendingCompositionSpace();
+            this.flushPendingCompositionSuffix();
         };
         const compositionEndHandler = () => {
             this.compositionActive = false;
@@ -498,7 +498,7 @@ export class TermWrap {
             dispose: () => {
                 textarea.removeEventListener("compositionstart", compositionStartHandler);
                 textarea.removeEventListener("compositionend", compositionEndHandler);
-                this.cancelPendingCompositionSpace();
+                this.cancelPendingCompositionSuffix();
             },
         });
     }
@@ -510,7 +510,7 @@ export class TermWrap {
         if (Date.now() > this.compositionRecentlyEndedUntil) {
             return false;
         }
-        return event.key === " ";
+        return !event.ctrlKey && !event.metaKey && !event.altKey && this.isCompositionSuffixData(event.key);
     }
 
     sendTermData(data: string) {
@@ -518,24 +518,25 @@ export class TermWrap {
         this.multiInputCallback?.(data);
     }
 
-    flushPendingCompositionSpace() {
-        if (this.pendingCompositionSpace == null) {
+    flushPendingCompositionSuffix() {
+        if (this.pendingCompositionSuffix == null) {
             return;
         }
-        clearTimeout(this.pendingCompositionSpace.timeout);
-        this.pendingCompositionSpace = null;
+        const pendingData = this.pendingCompositionSuffix.data;
+        clearTimeout(this.pendingCompositionSuffix.timeout);
+        this.pendingCompositionSuffix = null;
         if (!this.loaded || this.disposed) {
             return;
         }
-        this.sendTermData(" ");
+        this.sendTermData(pendingData);
     }
 
-    cancelPendingCompositionSpace() {
-        if (this.pendingCompositionSpace == null) {
+    cancelPendingCompositionSuffix() {
+        if (this.pendingCompositionSuffix == null) {
             return;
         }
-        clearTimeout(this.pendingCompositionSpace.timeout);
-        this.pendingCompositionSpace = null;
+        clearTimeout(this.pendingCompositionSuffix.timeout);
+        this.pendingCompositionSuffix = null;
     }
 
     isLikelyCompositionText(data: string): boolean {
@@ -548,26 +549,50 @@ export class TermWrap {
         return /[^\x00-\x7F]/.test(data);
     }
 
+    isCompositionSuffixData(data: string): boolean {
+        if (data.length === 0) {
+            return false;
+        }
+        if (/[\x00-\x1F\x7F]/.test(data)) {
+            return false;
+        }
+        return /^[\x20-\x7E]+$/.test(data);
+    }
+
     handleTermData(data: string) {
         if (!this.loaded) {
             return;
         }
 
-        if (this.pendingCompositionSpace != null) {
+        if (this.pendingCompositionSuffix != null) {
             if (this.isLikelyCompositionText(data)) {
-                clearTimeout(this.pendingCompositionSpace.timeout);
-                this.pendingCompositionSpace = null;
+                const pendingData = this.pendingCompositionSuffix.data;
+                clearTimeout(this.pendingCompositionSuffix.timeout);
+                this.pendingCompositionSuffix = null;
                 this.sendTermData(data);
-                this.sendTermData(" ");
+                this.sendTermData(pendingData);
                 return;
             }
-            this.flushPendingCompositionSpace();
+            if (this.isCompositionSuffixData(data) && Date.now() <= this.compositionRecentlyEndedUntil) {
+                clearTimeout(this.pendingCompositionSuffix.timeout);
+                this.pendingCompositionSuffix.data += data;
+                this.pendingCompositionSuffix.timeout = setTimeout(() => {
+                    this.flushPendingCompositionSuffix();
+                }, 30);
+                return;
+            }
+            this.flushPendingCompositionSuffix();
         }
 
-        if (data === " " && !this.compositionActive && Date.now() <= this.compositionRecentlyEndedUntil) {
-            this.pendingCompositionSpace = {
+        if (
+            this.isCompositionSuffixData(data) &&
+            !this.compositionActive &&
+            Date.now() <= this.compositionRecentlyEndedUntil
+        ) {
+            this.pendingCompositionSuffix = {
+                data,
                 timeout: setTimeout(() => {
-                    this.flushPendingCompositionSpace();
+                    this.flushPendingCompositionSuffix();
                 }, 30),
             };
             return;

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -111,6 +111,12 @@ export class TermWrap {
     lastPasteData: string = "";
     lastPasteTime: number = 0;
 
+    // IME composition ordering
+    compositionActive: boolean = false;
+    compositionRecentlyEndedUntil: number = 0;
+    pendingCompositionSpace: { timeout: ReturnType<typeof setTimeout> } | null = null;
+    disposed: boolean = false;
+
     // dev only (for debugging)
     recentWrites: { idx: number; data: string; ts: number }[] = [];
     recentWritesCounter: number = 0;
@@ -275,6 +281,9 @@ export class TermWrap {
             if (e.isComposing || e.keyCode == 229) {
                 return true;
             }
+            if (this.shouldBypassWaveKeydownForComposition(e)) {
+                return true;
+            }
             if (!waveOptions.keydownHandler) {
                 return true;
             }
@@ -285,6 +294,7 @@ export class TermWrap {
         this.heldData = [];
         this.handleResize_debounced = debounce(50, this.handleResize.bind(this));
         this.terminal.open(this.connectElem);
+        this.registerCompositionEventHandlers();
 
         const dragoverHandler = (e: DragEvent) => {
             e.preventDefault();
@@ -445,6 +455,7 @@ export class TermWrap {
     }
 
     dispose() {
+        this.disposed = true;
         this.promptMarkers.forEach((marker) => {
             try {
                 marker.dispose();
@@ -453,6 +464,7 @@ export class TermWrap {
             }
         });
         this.promptMarkers = [];
+        this.cancelPendingCompositionSpace();
         this.webglContextLossDisposable?.dispose();
         this.webglContextLossDisposable = null;
         this.terminal.dispose();
@@ -466,13 +478,102 @@ export class TermWrap {
         this.mainFileSubject.release();
     }
 
+    registerCompositionEventHandlers() {
+        const textarea = this.terminal.textarea;
+        if (textarea == null) {
+            return;
+        }
+        const compositionStartHandler = () => {
+            this.compositionActive = true;
+            this.compositionRecentlyEndedUntil = 0;
+            this.flushPendingCompositionSpace();
+        };
+        const compositionEndHandler = () => {
+            this.compositionActive = false;
+            this.compositionRecentlyEndedUntil = Date.now() + 75;
+        };
+        textarea.addEventListener("compositionstart", compositionStartHandler);
+        textarea.addEventListener("compositionend", compositionEndHandler);
+        this.toDispose.push({
+            dispose: () => {
+                textarea.removeEventListener("compositionstart", compositionStartHandler);
+                textarea.removeEventListener("compositionend", compositionEndHandler);
+                this.cancelPendingCompositionSpace();
+            },
+        });
+    }
+
+    shouldBypassWaveKeydownForComposition(event: KeyboardEvent): boolean {
+        if (this.compositionActive) {
+            return true;
+        }
+        if (Date.now() > this.compositionRecentlyEndedUntil) {
+            return false;
+        }
+        return event.key === " ";
+    }
+
+    sendTermData(data: string) {
+        this.sendDataHandler?.(data);
+        this.multiInputCallback?.(data);
+    }
+
+    flushPendingCompositionSpace() {
+        if (this.pendingCompositionSpace == null) {
+            return;
+        }
+        clearTimeout(this.pendingCompositionSpace.timeout);
+        this.pendingCompositionSpace = null;
+        if (!this.loaded || this.disposed) {
+            return;
+        }
+        this.sendTermData(" ");
+    }
+
+    cancelPendingCompositionSpace() {
+        if (this.pendingCompositionSpace == null) {
+            return;
+        }
+        clearTimeout(this.pendingCompositionSpace.timeout);
+        this.pendingCompositionSpace = null;
+    }
+
+    isLikelyCompositionText(data: string): boolean {
+        if (data.length === 0) {
+            return false;
+        }
+        if (/[\x00-\x1F\x7F]/.test(data)) {
+            return false;
+        }
+        return /[^\x00-\x7F]/.test(data);
+    }
+
     handleTermData(data: string) {
         if (!this.loaded) {
             return;
         }
 
-        this.sendDataHandler?.(data);
-        this.multiInputCallback?.(data);
+        if (this.pendingCompositionSpace != null) {
+            if (this.isLikelyCompositionText(data)) {
+                clearTimeout(this.pendingCompositionSpace.timeout);
+                this.pendingCompositionSpace = null;
+                this.sendTermData(data);
+                this.sendTermData(" ");
+                return;
+            }
+            this.flushPendingCompositionSpace();
+        }
+
+        if (data === " " && !this.compositionActive && Date.now() <= this.compositionRecentlyEndedUntil) {
+            this.pendingCompositionSpace = {
+                timeout: setTimeout(() => {
+                    this.flushPendingCompositionSpace();
+                }, 30),
+            };
+            return;
+        }
+
+        this.sendTermData(data);
     }
 
     addFocusListener(focusFn: () => void) {

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -272,6 +272,9 @@ export class TermWrap {
             })
         );
         this.terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+            if (e.isComposing || e.keyCode == 229) {
+                return true;
+            }
             if (!waveOptions.keydownHandler) {
                 return true;
             }

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -543,20 +543,30 @@ export class TermWrap {
         if (data.length === 0) {
             return false;
         }
-        if (/[\x00-\x1F\x7F]/.test(data)) {
-            return false;
+        let hasNonAscii = false;
+        for (const ch of data) {
+            const codePoint = ch.codePointAt(0);
+            if (codePoint == null || codePoint <= 0x1f || codePoint === 0x7f) {
+                return false;
+            }
+            if (codePoint > 0x7f) {
+                hasNonAscii = true;
+            }
         }
-        return /[^\x00-\x7F]/.test(data);
+        return hasNonAscii;
     }
 
     isCompositionSuffixData(data: string): boolean {
         if (data.length === 0) {
             return false;
         }
-        if (/[\x00-\x1F\x7F]/.test(data)) {
-            return false;
+        for (const ch of data) {
+            const codePoint = ch.codePointAt(0);
+            if (codePoint == null || codePoint < 0x20 || codePoint > 0x7e) {
+                return false;
+            }
         }
-        return /^[\x20-\x7E]+$/.test(data);
+        return true;
     }
 
     handleTermData(data: string) {

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -2052,6 +2052,7 @@ declare global {
         code: string;
         repeat?: boolean;
         location?: number;
+        isComposing?: boolean;
         shift?: boolean;
         control?: boolean;
         alt?: boolean;

--- a/frontend/util/keyutil.ts
+++ b/frontend/util/keyutil.ts
@@ -240,6 +240,7 @@ function adaptFromReactOrNativeKeyEvent(event: React.KeyboardEvent | KeyboardEve
     rtn.key = event.key;
     rtn.location = event.location;
     (rtn as any).nativeEvent = event;
+    (rtn as any).isComposing = event.isComposing || (event as any).keyCode == 229;
     if (event.type == "keydown" || event.type == "keyup" || event.type == "keypress") {
         rtn.type = event.type;
     } else {
@@ -268,6 +269,7 @@ function adaptFromElectronKeyEvent(event: any): WaveKeyboardEvent {
     rtn.location = event.location;
     rtn.code = event.code;
     rtn.key = event.key;
+    (rtn as any).isComposing = event.isComposing || event.keyCode == 229;
     return rtn;
 }
 

--- a/frontend/util/keyutil.ts
+++ b/frontend/util/keyutil.ts
@@ -240,7 +240,7 @@ function adaptFromReactOrNativeKeyEvent(event: React.KeyboardEvent | KeyboardEve
     rtn.key = event.key;
     rtn.location = event.location;
     (rtn as any).nativeEvent = event;
-    (rtn as any).isComposing = event.isComposing || (event as any).keyCode == 229;
+    rtn.isComposing = event.isComposing || (event as any).keyCode == 229;
     if (event.type == "keydown" || event.type == "keyup" || event.type == "keypress") {
         rtn.type = event.type;
     } else {
@@ -269,7 +269,7 @@ function adaptFromElectronKeyEvent(event: any): WaveKeyboardEvent {
     rtn.location = event.location;
     rtn.code = event.code;
     rtn.key = event.key;
-    (rtn as any).isComposing = event.isComposing || event.keyCode == 229;
+    rtn.isComposing = event.isComposing || event.keyCode == 229;
     return rtn;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "waveterm",
-    "version": "0.14.5",
+    "version": "0.14.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "waveterm",
-            "version": "0.14.5",
+            "version": "0.14.6",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "workspaces": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "waveterm",
-    "version": "0.14.6",
+    "version": "0.14.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "waveterm",
-            "version": "0.14.6",
+            "version": "0.14.7",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "workspaces": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "productName": "Wave",
     "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
     "license": "Apache-2.0",
-    "version": "0.14.6",
+    "version": "0.14.7",
     "homepage": "https://waveterm.dev",
     "build": {
         "appId": "dev.commandline.waveterm"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "productName": "Wave",
     "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
     "license": "Apache-2.0",
-    "version": "0.14.5",
+    "version": "0.14.6",
     "homepage": "https://waveterm.dev",
     "build": {
         "appId": "dev.commandline.waveterm"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "productName": "Wave",
     "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
     "license": "Apache-2.0",
-    "version": "0.14.7",
+    "version": "0.14.8",
     "homepage": "https://waveterm.dev",
     "build": {
         "appId": "dev.commandline.waveterm"

--- a/pkg/vdom/vdom_types.go
+++ b/pkg/vdom/vdom_types.go
@@ -236,6 +236,8 @@ type WaveKeyboardEvent struct {
 	Code     string `json:"code"` // KeyboardEvent.code
 	Repeat   bool   `json:"repeat,omitempty"`
 	Location int    `json:"location,omitempty"` // KeyboardEvent.location
+	// True while an IME composition is active. These key events should not trigger app shortcuts.
+	IsComposing bool `json:"isComposing,omitempty"`
 
 	// modifiers
 	Shift   bool `json:"shift,omitempty"`

--- a/pkg/wconfig/defaultconfig/defaultconfig.go
+++ b/pkg/wconfig/defaultconfig/defaultconfig.go
@@ -5,5 +5,5 @@ package defaultconfig
 
 import "embed"
 
-//go:embed *.json all:*/*.json
+//go:embed *.json */*.json
 var ConfigFS embed.FS

--- a/pkg/wconfig/defaultconfig/settings.json
+++ b/pkg/wconfig/defaultconfig/settings.json
@@ -32,6 +32,7 @@
     "telemetry:enabled": true,
     "term:bellsound": false,
     "term:bellindicator": true,
+    "term:fontfamily": "Hack, 'Noto Sans Mono CJK KR', 'Noto Sans Mono CJK JP', 'Noto Sans Mono CJK SC', 'Noto Sans Mono CJK TC', 'Noto Sans CJK KR', 'Noto Sans CJK JP', 'Noto Sans CJK SC', 'Noto Sans CJK TC', 'Apple SD Gothic Neo', 'Hiragino Sans', 'PingFang SC', 'PingFang TC', 'Microsoft YaHei', 'Malgun Gothic', monospace",
     "term:osc52": "always",
     "term:cursor": "block",
     "term:cursorblink": false,

--- a/pkg/wconfig/defaultconfig/settings.json
+++ b/pkg/wconfig/defaultconfig/settings.json
@@ -32,6 +32,7 @@
     "telemetry:enabled": true,
     "term:bellsound": false,
     "term:bellindicator": true,
+    "term:disablewebgl": true,
     "term:fontfamily": "Hack, 'Noto Sans Mono CJK KR', 'Noto Sans Mono CJK JP', 'Noto Sans Mono CJK SC', 'Noto Sans Mono CJK TC', 'Noto Sans CJK KR', 'Noto Sans CJK JP', 'Noto Sans CJK SC', 'Noto Sans CJK TC', 'Apple SD Gothic Neo', 'Hiragino Sans', 'PingFang SC', 'PingFang TC', 'Microsoft YaHei', 'Malgun Gothic', monospace",
     "term:osc52": "always",
     "term:cursor": "block",

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -618,6 +618,10 @@ func selectDirEntsBySuffix(dirEnts []fs.DirEntry, fileNameSuffix string) []fs.Di
 		if ent.IsDir() {
 			continue
 		}
+		// skip hidden files, notably macOS AppleDouble sidecars ("._ai.json") which are binary and fail JSON parsing
+		if strings.HasPrefix(ent.Name(), ".") {
+			continue
+		}
 		if !strings.HasSuffix(ent.Name(), fileNameSuffix) {
 			continue
 		}


### PR DESCRIPTION
## Summary

- Preserve IME composition state when adapting keyboard events.
- Avoid Wave global/custom terminal key handling while IME composition is active.
- Add broader CJK font fallback while keeping Hack as the primary terminal font.
- Fix the `.fixed-font` CSS declaration to use a valid `font:` property.

## Why

IME composition key events can flow through Wave keyboard handling and terminal custom key handling. In interactive terminal prompts, this can cause unexpected input while composing text with Korean, Japanese, Chinese, or other composition-based input methods.

The terminal font fallback also previously relied only on Hack/monospace. Keeping Hack first preserves the existing monospace behavior, while adding Noto CJK and common platform CJK fallbacks improves glyph coverage for multilingual terminal output.

## Verification

- `npm run build:dev` in a clean worktree from this commit
- Build completed with exit code 0
- Existing Vite warnings observed: browser externalization for `fs`/`path`, circular chunk warning for cytoscape/mermaid
- Image optimizer reported missing optional `sharp` package, but the build command still completed successfully
