### PR TITLE
Fix Korean IME space handling on Windows

### DIFF
--- a/frontend/app/view/term/term-model.ts
+++ b/frontend/app/view/term/term-model.ts
@@ -697,6 +697,10 @@ export class TermViewModel implements ViewModel {
     }
 
     handleTerminalKeydown(event: KeyboardEvent): boolean {
+        if (this.shouldDeferImeSpaceToComposition(event)) {
+            return false;
+        }
+
         const waveEvent = keyutil.adaptFromReactOrNativeKeyEvent(event);
         if (waveEvent.type != "keydown") {
             return true;
@@ -777,6 +781,14 @@ export class TermViewModel implements ViewModel {
             return false;
         }
         return true;
+    }
+
+    shouldDeferImeSpaceToComposition(event: KeyboardEvent): boolean {
+        // On Windows Korean IME, xterm's keydown path can finalize composition before
+        // Chromium commits the last syllable, causing space to be sent before it.
+        return (
+            isWindows() && event.isComposing && event.key === " " && !event.ctrlKey && !event.altKey && !event.metaKey
+        );
     }
 
     setTerminalTheme(themeName: string) {


### PR DESCRIPTION

  ## Summary

  Fixes a Windows-specific Korean IME composition bug in the terminal input handler.

  When using the Korean IME on Windows, pressing Space while a syllable is still composing can be handled by Wave's terminal keydown path before Chromium finishes committing the composed text. In that case, the terminal can receive the Space before the final Korean
  syllable, producing the wrong commit order.

  This PR adds a narrow guard for that case and lets the native IME composition flow finish handling the plain Space key.

  Fixes #3335

  ## Problem

  Reproduction case:

  1. Run Wave on Windows with the Korean IME enabled.
  2. Focus a terminal block.
  3. Type Korean text where the final syllable is still under IME composition.
  4. Press Space to commit the syllable and insert a word separator.

  Before this change, the Space key could be processed by the terminal keydown handler before the IME composition committed the final syllable. This caused incorrect ordering in the terminal input.

  ## Approach

  The change adds an early check in `handleTerminalKeydown` for the specific IME case:

  - platform is Windows
  - the key event is currently composing
  - the key is plain Space
  - Ctrl/Alt/Meta are not pressed

  When all of those are true, the handler returns early so Chromium/native IME composition can commit the text in the correct order.

  The guard is intentionally narrow so normal terminal key handling, shortcuts, and non-IME Space input continue to use the existing path.

  ## Scope

  This PR changes only `frontend/app/view/term/term-model.ts`.

  It does not include unrelated cleanup, formatting churn, refactors, or broader terminal input behavior changes.

  ## Validation

  Tested locally on Windows 11 with the Korean IME enabled.

  Verified:

  - Wave builds and launches locally.
  - `task dev` builds the backend/frontend and starts Electron.
  - After clearing dev data, `task electron:winquickdev` launches correctly on Windows.
  - Korean IME composition commits the final syllable before inserting Space.
  - Plain Space still works normally outside active IME composition.
  - Ctrl/Alt/Meta + Space behavior is not affected by this guard.

  Also ran:

  - `npm exec eslint -- frontend/app/view/term/term-model.ts`
  - `npm exec prettier -- --check frontend/app/view/term/term-model.ts`
  - `npm exec tsc -- --noEmit`

  `tsc --noEmit` currently fails on existing preview mock type errors unrelated to this change.

## Issue

  When typing Korean text with the Windows Korean IME, punctuation can be inserted before the final composed syllable is committed.

  For example, when I type:

  ```text
  안녕하세요?

  Wave inputs it as:

  안녕하세?요
```
  The expected behavior is that the composed Korean text should be committed in the correct order before the punctuation is inserted.

  I attached a video below showing the issue.

https://github.com/user-attachments/assets/20b16958-9c90-4f43-a137-74db1df81794


