### PR TITLE
feat(preview): sort directories before files in directory preview

### DIFF
--- a/frontend/app/view/preview/preview-directory.tsx
+++ b/frontend/app/view/preview/preview-directory.tsx
@@ -431,7 +431,13 @@ function TableBody({
 
     const allRows = table.getRowModel().flatRows;
     const dotdotRow = allRows.find((row) => row.getValue("name") === "..");
-    const otherRows = allRows.filter((row) => row.getValue("name") !== "..");
+    const nonDotDotRows = allRows.filter((row) => row.getValue("name") !== "..");
+    // group directories ahead of files (Windows Explorer style) while keeping the
+    // active column sort within each group
+    const otherRows = [
+        ...nonDotDotRows.filter((row) => row.original.isdir),
+        ...nonDotDotRows.filter((row) => !row.original.isdir),
+    ];
 
     return (
         <div className="dir-table-body" ref={bodyRef}>


### PR DESCRIPTION
## Summary

Groups directories ahead of files in the directory preview table — the familiar Windows Explorer / VSCode ordering — while preserving the active column sort (Name or Last Modified, asc/desc) **within** each group. The `..` entry stays pinned at the top.

Closes #2541

## What changed

`frontend/app/view/preview/preview-directory.tsx` — after the sorted row model is computed, the non-`..` rows are partitioned into directories and files via the existing `row.original.isdir` field, then concatenated (dirs first). This keeps TanStack Table's column sort intact inside each group and is direction-independent (folders stay first whether sorting name asc/desc or by modtime), matching native file-manager behavior.

```ts
const otherRows = [
    ...nonDotDotRows.filter((row) => row.original.isdir),
    ...nonDotDotRows.filter((row) => !row.original.isdir),
];
```

## Notes

- Implemented as default behavior (per the request in #2541). Happy to gate it behind a new `preview:directoriesfirst` boolean setting alongside the existing `preview:defaultsort` if maintainers prefer opt-in/out — say the word and I'll add the Go const, schema entry, docs row, and context-menu toggle.
- Surgical change; `FileInfo.isdir` and `row.original` (typed `FileInfo`) are already used throughout this file, so it's type-safe. Did not run a full `task build` locally; CI will validate.

## Test plan

- Open a directory preview block; confirm folders are grouped above files.
- Toggle Name asc/desc and Last Modified — folders remain grouped first, sort applies within each group.
- Confirm `..` is still the first row.