### PR TITLE
Add Tab Lock feature: prevent close, lock icon and tab color

### DIFF
--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -21,6 +21,7 @@ import {
     WOS,
 } from "@/app/store/global";
 import { getActiveTabModel } from "@/app/store/tab-model";
+import { isTabLocked } from "@/app/tab/tablock";
 import { WorkspaceLayoutModel } from "@/app/workspace/workspace-layout-model";
 import { deleteLayoutModelForTab, getLayoutModelForStaticTab, NavigateDirection } from "@/layout/index";
 import * as keyutil from "@/util/keyutil";
@@ -131,6 +132,9 @@ function getStaticTabBlockCount(): number {
 function simpleCloseStaticTab() {
     const workspaceId = globalStore.get(atoms.workspaceId);
     const tabId = globalStore.get(atoms.staticTabId);
+    if (isTabLocked(tabId)) {
+        return;
+    }
     const confirmClose = globalStore.get(getSettingsKeyAtom("tab:confirmclose")) ?? false;
     getApi()
         .closeTab(workspaceId, tabId, confirmClose)

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -129,6 +129,7 @@ function getStaticTabBlockCount(): number {
     return tabData?.blockids?.length ?? 0;
 }
 
+/** Closes the active static tab via the keyboard shortcut, unless the tab is locked. */
 function simpleCloseStaticTab() {
     const workspaceId = globalStore.get(atoms.workspaceId);
     const tabId = globalStore.get(atoms.staticTabId);

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -91,6 +91,27 @@
     .close {
         visibility: hidden;
     }
+
+    &.locked {
+        .tab-inner {
+            box-shadow: inset 0 0 0 1px rgb(255 180 0 / 0.45);
+            background: rgb(255 180 0 / 0.08);
+        }
+
+        .close {
+            display: none;
+        }
+
+        .lock-icon {
+            position: absolute;
+            top: 50%;
+            right: 6px;
+            transform: translate3d(0, -50%, 0);
+            z-index: var(--zindex-tab-name);
+            font-size: 11px;
+            pointer-events: none;
+        }
+    }
 }
 
 // Only apply hover effects when not in nohover mode. This prevents the previously-hovered tab from remaining hovered while a tab view is not mounted.

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -16,6 +16,7 @@ import { makeORef } from "../store/wos";
 import { TabBadges } from "./tabbadges";
 import "./tab.scss";
 import { buildTabContextMenu } from "./tabcontextmenu";
+import { TabLockedColor } from "./tablock";
 
 export type TabEnv = WaveEnvSubset<{
     rpc: {
@@ -42,6 +43,7 @@ interface TabVProps {
     isNew: boolean;
     badges?: Badge[] | null;
     flagColor?: string | null;
+    locked?: boolean;
     onClick: () => void;
     onClose: (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null) => void;
     onDragStart: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -62,6 +64,7 @@ const TabV = forwardRef<HTMLDivElement, TabVProps>((props, ref) => {
         isNew,
         badges,
         flagColor,
+        locked,
         onClick,
         onClose,
         onDragStart,
@@ -185,6 +188,7 @@ const TabV = forwardRef<HTMLDivElement, TabVProps>((props, ref) => {
                 active,
                 dragging: isDragging,
                 "new-tab": isNew,
+                locked,
             })}
             onMouseDown={onDragStart}
             onClick={onClick}
@@ -205,14 +209,22 @@ const TabV = forwardRef<HTMLDivElement, TabVProps>((props, ref) => {
                     {displayName}
                 </div>
                 <TabBadges badges={badges} flagColor={flagColor} />
-                <Button
-                    className="ghost grey close"
-                    onClick={onClose}
-                    onMouseDown={handleMouseDownOnClose}
-                    title="Close Tab"
-                >
-                    <i className="fa fa-solid fa-xmark" />
-                </Button>
+                {locked ? (
+                    <i
+                        className="lock-icon fa fa-solid fa-lock"
+                        style={{ color: TabLockedColor }}
+                        title="Tab is locked"
+                    />
+                ) : (
+                    <Button
+                        className="ghost grey close"
+                        onClick={onClose}
+                        onMouseDown={handleMouseDownOnClose}
+                        title="Close Tab"
+                    >
+                        <i className="fa fa-solid fa-xmark" />
+                    </Button>
+                )}
             </div>
         </div>
     );
@@ -249,6 +261,8 @@ const TabInner = forwardRef<HTMLDivElement, TabProps>((props, ref) => {
             flagColor = null;
         }
     }
+
+    const locked = !!tabData?.meta?.["tab:locked"];
 
     const loadedRef = useRef(false);
     const renameRef = useRef<(() => void) | null>(null);
@@ -304,6 +318,7 @@ const TabInner = forwardRef<HTMLDivElement, TabProps>((props, ref) => {
             isNew={isNew}
             badges={badges}
             flagColor={flagColor}
+            locked={locked}
             onClick={handleTabClick}
             onClose={onClose}
             onDragStart={onDragStart}

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -53,6 +53,7 @@ interface TabVProps {
     renameRef?: React.RefObject<(() => void) | null>;
 }
 
+/** Presentational top-bar tab: renders the name, badges, and either a close button or, when locked, a lock icon. */
 const TabV = forwardRef<HTMLDivElement, TabVProps>((props, ref) => {
     const {
         tabId,
@@ -245,6 +246,7 @@ interface TabProps {
     onLoaded: () => void;
 }
 
+/** Connects a top-bar tab to its wave object, deriving name, badges, flag color, and locked state from tab meta. */
 const TabInner = forwardRef<HTMLDivElement, TabProps>((props, ref) => {
     const { id, active, showDivider, isDragging, tabWidth, isNew, onLoaded, onSelect, onClose, onDragStart } = props;
     const env = useWaveEnv<TabEnv>();

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -13,6 +13,7 @@ import { OverlayScrollbars } from "overlayscrollbars";
 import { createRef, memo, useCallback, useEffect, useRef, useState } from "react";
 import { debounce } from "throttle-debounce";
 import { Tab } from "./tab";
+import { isTabLocked } from "./tablock";
 import "./tabbar.scss";
 import { TabBarEnv } from "./tabbarenv";
 import { UpdateStatusBanner } from "./updatebanner";
@@ -541,6 +542,9 @@ const TabBar = memo(({ workspace, noTabs }: TabBarProps) => {
 
     const handleCloseTab = (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null, tabId: string) => {
         event?.stopPropagation();
+        if (isTabLocked(tabId)) {
+            return;
+        }
         env.electron
             .closeTab(workspace.oid, tabId, confirmClose)
             .then((didClose) => {

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -540,6 +540,7 @@ const TabBar = memo(({ workspace, noTabs }: TabBarProps) => {
         setNewTabIdDebounced(null);
     };
 
+    /** Closes a tab from the top tab bar, ignoring the request when the tab is locked. */
     const handleCloseTab = (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null, tabId: string) => {
         event?.stopPropagation();
         if (isTabLocked(tabId)) {

--- a/frontend/app/tab/tabcontextmenu.ts
+++ b/frontend/app/tab/tabcontextmenu.ts
@@ -73,7 +73,20 @@ export function buildTabContextMenu(
                 ),
         })),
     ];
-    menu.push({ label: "Flag Tab", type: "submenu", submenu: flagSubmenu }, { type: "separator" });
+    menu.push({ label: "Flag Tab", type: "submenu", submenu: flagSubmenu });
+    const isLocked = !!globalStore.get(getOrefMetaKeyAtom(tabORef, "tab:locked"));
+    menu.push(
+        {
+            label: isLocked ? "Unlock Tab" : "Lock Tab",
+            type: "checkbox",
+            checked: isLocked,
+            click: () =>
+                fireAndForget(() =>
+                    env.rpc.SetMetaCommand(TabRpcClient, { oref: tabORef, meta: { "tab:locked": !isLocked } })
+                ),
+        },
+        { type: "separator" }
+    );
     const fullConfig = globalStore.get(env.atoms.fullConfigAtom);
     const backgrounds = fullConfig?.backgrounds ?? {};
     const bgKeys = Object.keys(backgrounds).filter((k) => backgrounds[k] != null);
@@ -115,6 +128,6 @@ export function buildTabContextMenu(
         menu.push({ label: "Backgrounds", type: "submenu", submenu }, { type: "separator" });
     }
     menu.push(...buildTabBarContextMenu(env), { type: "separator" });
-    menu.push({ label: "Close Tab", click: () => onClose(null) });
+    menu.push({ label: "Close Tab", enabled: !isLocked, click: () => onClose(null) });
     return menu;
 }

--- a/frontend/app/tab/tablock.ts
+++ b/frontend/app/tab/tablock.ts
@@ -6,6 +6,13 @@ import { getTabMetaKeyAtom, globalStore } from "@/app/store/global";
 // Amber padlock tint shown on locked tabs.
 export const TabLockedColor = "#FFB400";
 
+/**
+ * Returns whether a tab is currently locked (close-protected).
+ *
+ * Reads the `tab:locked` meta synchronously from the global store so it can be
+ * called from non-reactive close handlers (button, context menu, keybinding)
+ * to short-circuit a close before it reaches the backend.
+ */
 export function isTabLocked(tabId: string): boolean {
     if (!tabId) {
         return false;

--- a/frontend/app/tab/tablock.ts
+++ b/frontend/app/tab/tablock.ts
@@ -1,0 +1,14 @@
+// Copyright 2026, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getTabMetaKeyAtom, globalStore } from "@/app/store/global";
+
+// Amber padlock tint shown on locked tabs.
+export const TabLockedColor = "#FFB400";
+
+export function isTabLocked(tabId: string): boolean {
+    if (!tabId) {
+        return false;
+    }
+    return !!globalStore.get(getTabMetaKeyAtom(tabId, "tab:locked"));
+}

--- a/frontend/app/tab/vtab.test.tsx
+++ b/frontend/app/tab/vtab.test.tsx
@@ -4,11 +4,12 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { VTab, VTabItem } from "./vtab";
+import { TabLockedColor } from "./tablock";
 
 const OriginalCss = globalThis.CSS;
 const HexColorRegex = /^#([\da-f]{3}|[\da-f]{4}|[\da-f]{6}|[\da-f]{8})$/i;
 
-function renderVTab(tab: VTabItem): string {
+function renderVTab(tab: VTabItem, withClose = false): string {
     return renderToStaticMarkup(
         <VTab
             tab={tab}
@@ -16,6 +17,7 @@ function renderVTab(tab: VTabItem): string {
             isDragging={false}
             isReordering={false}
             onSelect={() => null}
+            onClose={withClose ? () => null : undefined}
             onDragStart={() => null}
             onDragOver={() => null}
             onDrop={() => null}
@@ -59,5 +61,22 @@ describe("VTab badges", () => {
         expect(markup).not.toContain("definitely-not-a-color");
         expect(markup).not.toContain("fa-flag");
         expect(markup).toContain("#4ade80");
+    });
+});
+
+describe("VTab lock", () => {
+    it("shows a lock icon and hides the close button when locked", () => {
+        const markup = renderVTab({ id: "tab-3", name: "Prod", locked: true }, true);
+
+        expect(markup).toContain("fa-lock");
+        expect(markup).toContain(TabLockedColor);
+        expect(markup).not.toContain("fa-xmark");
+    });
+
+    it("shows the close button and no lock icon when unlocked", () => {
+        const markup = renderVTab({ id: "tab-4", name: "Scratch" }, true);
+
+        expect(markup).toContain("fa-xmark");
+        expect(markup).not.toContain("fa-lock");
     });
 });

--- a/frontend/app/tab/vtab.test.tsx
+++ b/frontend/app/tab/vtab.test.tsx
@@ -9,6 +9,7 @@ import { TabLockedColor } from "./tablock";
 const OriginalCss = globalThis.CSS;
 const HexColorRegex = /^#([\da-f]{3}|[\da-f]{4}|[\da-f]{6}|[\da-f]{8})$/i;
 
+/** Renders a VTab to static markup for assertions; pass withClose to supply an onClose handler. */
 function renderVTab(tab: VTabItem, withClose = false): string {
     return renderToStaticMarkup(
         <VTab

--- a/frontend/app/tab/vtab.tsx
+++ b/frontend/app/tab/vtab.tsx
@@ -37,6 +37,7 @@ interface VTabProps {
     renameRef?: React.RefObject<(() => void) | null>;
 }
 
+/** Presentational left-bar tab: renders the name and badges, and either a close button or, when locked, a lock icon. */
 export function VTab({
     tab,
     active,

--- a/frontend/app/tab/vtab.tsx
+++ b/frontend/app/tab/vtab.tsx
@@ -6,6 +6,7 @@ import { validateCssColor } from "@/util/color-validator";
 import { cn } from "@/util/util";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { TabBadges } from "./tabbadges";
+import { TabLockedColor } from "./tablock";
 
 const RenameFocusDelayMs = 50;
 
@@ -15,6 +16,7 @@ export interface VTabItem {
     badge?: Badge | null;
     badges?: Badge[] | null;
     flagColor?: string | null;
+    locked?: boolean;
 }
 
 interface VTabProps {
@@ -57,6 +59,7 @@ export function VTab({
     const editableRef = useRef<HTMLDivElement>(null);
     const editableTimeoutRef = useRef<NodeJS.Timeout | null>(null);
     const badges = tab.badges ?? (tab.badge ? [tab.badge] : null);
+    const locked = !!tab.locked;
 
     const rawFlagColor = tab.flagColor;
     let flagColor: string | null = null;
@@ -174,6 +177,9 @@ export function VTab({
             {!active && !isReordering && (
                 <div className="pointer-events-none absolute inset-x-1 inset-y-[4px] rounded-sm bg-transparent transition-colors group-hover:bg-foreground/10" />
             )}
+            {locked && (
+                <div className="pointer-events-none absolute inset-x-1 inset-y-[4px] rounded-sm bg-[#FFB400]/10 ring-1 ring-inset ring-[#FFB400]/40" />
+            )}
             <div
                 className={cn(
                     "pointer-events-none absolute bottom-0 left-[5%] right-[5%] h-px bg-border/70",
@@ -189,7 +195,8 @@ export function VTab({
                 ref={editableRef}
                 className={cn(
                     "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap transition-[padding-right] pr-3",
-                    onClose && !isReordering && "group-hover:pr-6",
+                    locked && "pr-6",
+                    !locked && onClose && !isReordering && "group-hover:pr-6",
                     isEditable && "rounded-[2px] bg-white/15 outline-none"
                 )}
                 contentEditable={isEditable}
@@ -202,7 +209,15 @@ export function VTab({
             >
                 {tab.name}
             </div>
-            {onClose && (
+            {locked && (
+                <i
+                    className="fa fa-solid fa-lock absolute top-1/2 right-0 shrink-0 -translate-y-1/2 py-1 pl-1 pr-3 text-[10px]"
+                    style={{ color: TabLockedColor }}
+                    title="Tab is locked"
+                    aria-label="Tab is locked"
+                />
+            )}
+            {!locked && onClose && (
                 <button
                     type="button"
                     className={cn(

--- a/frontend/app/tab/vtabbar.tsx
+++ b/frontend/app/tab/vtabbar.tsx
@@ -13,6 +13,7 @@ import { cn, fireAndForget } from "@/util/util";
 import { useAtomValue } from "jotai";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { buildTabBarContextMenu, buildTabContextMenu } from "./tabcontextmenu";
+import { isTabLocked } from "./tablock";
 import { UpdateStatusBanner } from "./updatebanner";
 import { VTab, VTabItem } from "./vtab";
 import { VTabBarEnv } from "./vtabbarenv";
@@ -150,6 +151,7 @@ function VTabWrapper({
         name: tabData?.name ?? "",
         badges,
         flagColor,
+        locked: !!tabData?.meta?.["tab:locked"],
     };
 
     const handleContextMenu = useCallback(
@@ -374,7 +376,12 @@ export function VTabBar({ workspace, className }: VTabBarProps) {
                             hoverResetVersion={hoverResetVersion}
                             index={index}
                             onSelect={() => env.electron.setActiveTab(tabId)}
-                            onClose={() => fireAndForget(() => env.electron.closeTab(workspace.oid, tabId, false))}
+                            onClose={() => {
+                                if (isTabLocked(tabId)) {
+                                    return;
+                                }
+                                fireAndForget(() => env.electron.closeTab(workspace.oid, tabId, false));
+                            }}
                             onRename={(newName) =>
                                 fireAndForget(() => env.rpc.UpdateTabNameCommand(TabRpcClient, tabId, newName))
                             }

--- a/frontend/app/tab/vtabbar.tsx
+++ b/frontend/app/tab/vtabbar.tsx
@@ -103,6 +103,7 @@ interface VTabWrapperProps {
     onHoverChanged: (isHovered: boolean) => void;
 }
 
+/** Connects a left-bar tab to its wave object, deriving name, badges, flag color, and locked state from tab meta. */
 function VTabWrapper({
     tabId,
     active,
@@ -186,6 +187,7 @@ function VTabWrapper({
     );
 }
 
+/** The vertical (left) tab bar: renders the workspace's tabs as a reorderable list and routes close requests, honoring tab locks. */
 export function VTabBar({ workspace, className }: VTabBarProps) {
     const env = useWaveEnv<VTabBarEnv>();
     const activeTabId = useAtomValue(env.atoms.staticTabId);

--- a/frontend/preview/previews/tablock.preview.tsx
+++ b/frontend/preview/previews/tablock.preview.tsx
@@ -1,0 +1,114 @@
+// Copyright 2026, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { TabV } from "@/app/tab/tab";
+import { VTab, VTabItem } from "@/app/tab/vtab";
+import { useEffect, useRef } from "react";
+
+const TAB_WIDTH = 130;
+const TAB_HEIGHT = 26;
+
+interface TopTabEntry {
+    tabId: string;
+    tabName: string;
+    active: boolean;
+    locked?: boolean;
+}
+
+const topTabs: TopTabEntry[] = [
+    { tabId: "lock-top-1", tabName: "Terminal", active: false },
+    { tabId: "lock-top-2", tabName: "Production", active: true, locked: true },
+    { tabId: "lock-top-3", tabName: "Scratch", active: false },
+];
+
+const leftTabs: VTabItem[] = [
+    { id: "lock-left-1", name: "Terminal" },
+    { id: "lock-left-2", name: "Production", locked: true },
+    { id: "lock-left-3", name: "Deploy Logs" },
+];
+
+function noop() {}
+
+function TopBar() {
+    const tabRefs = useRef<Record<string, HTMLDivElement | null>>({});
+    useEffect(() => {
+        topTabs.forEach((tab, index) => {
+            const el = tabRefs.current[tab.tabId];
+            if (el) {
+                el.style.opacity = "1";
+                el.style.transform = `translate3d(${index * TAB_WIDTH}px, 0, 0)`;
+            }
+        });
+    }, []);
+    return (
+        <div style={{ position: "relative", width: TAB_WIDTH * topTabs.length, height: TAB_HEIGHT }}>
+            {topTabs.map((tab, index) => {
+                const activeIndex = topTabs.findIndex((t) => t.active);
+                const showDivider = index !== 0 && !tab.active && index !== activeIndex + 1;
+                return (
+                    <TabV
+                        key={tab.tabId}
+                        ref={(el) => {
+                            tabRefs.current[tab.tabId] = el;
+                        }}
+                        tabId={tab.tabId}
+                        tabName={tab.tabName}
+                        active={tab.active}
+                        showDivider={showDivider}
+                        isDragging={false}
+                        tabWidth={TAB_WIDTH}
+                        isNew={false}
+                        locked={tab.locked}
+                        onClick={noop}
+                        onClose={noop}
+                        onDragStart={noop}
+                        onContextMenu={noop}
+                        onRename={noop}
+                    />
+                );
+            })}
+        </div>
+    );
+}
+
+function LeftBar() {
+    return (
+        <div
+            className="flex w-[220px] flex-col rounded-md py-1"
+            style={{ backdropFilter: "blur(20px)", background: "rgba(0, 0, 0, 0.35)" }}
+        >
+            {leftTabs.map((tab) => (
+                <VTab
+                    key={tab.id}
+                    tab={tab}
+                    active={tab.id === "lock-left-2"}
+                    isDragging={false}
+                    isReordering={false}
+                    onSelect={noop}
+                    onClose={noop}
+                    onRename={noop}
+                    onContextMenu={noop}
+                    onDragStart={noop}
+                    onDragOver={noop}
+                    onDrop={noop}
+                    onDragEnd={noop}
+                />
+            ))}
+        </div>
+    );
+}
+
+export function TabLockPreview() {
+    return (
+        <div className="flex flex-col gap-8 p-10">
+            <div className="flex flex-col gap-2">
+                <div className="text-xs text-secondary">Top tab bar — &ldquo;Production&rdquo; locked</div>
+                <TopBar />
+            </div>
+            <div className="flex flex-col gap-2">
+                <div className="text-xs text-secondary">Left tab bar — &ldquo;Production&rdquo; locked</div>
+                <LeftBar />
+            </div>
+        </div>
+    );
+}

--- a/frontend/preview/previews/tablock.preview.tsx
+++ b/frontend/preview/previews/tablock.preview.tsx
@@ -27,8 +27,10 @@ const leftTabs: VTabItem[] = [
     { id: "lock-left-3", name: "Deploy Logs" },
 ];
 
+/** No-op handler used to satisfy the tab components' required event props in the preview. */
 function noop() {}
 
+/** Renders the horizontal (top) tab bar with one locked tab to preview the locked styling. */
 function TopBar() {
     const tabRefs = useRef<Record<string, HTMLDivElement | null>>({});
     useEffect(() => {
@@ -71,6 +73,7 @@ function TopBar() {
     );
 }
 
+/** Renders the vertical (left) tab bar with one locked tab to preview the locked styling. */
 function LeftBar() {
     return (
         <div
@@ -98,6 +101,7 @@ function LeftBar() {
     );
 }
 
+/** Preview entry that shows the locked-tab visuals in both the top and left tab bars. */
 export function TabLockPreview() {
     return (
         <div className="flex flex-col gap-8 p-10">

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1156,6 +1156,7 @@ declare global {
         "sysinfo:type"?: string;
         "tab:flagcolor"?: string;
         "tab:background"?: string;
+        "tab:locked"?: boolean;
         "bg:*"?: boolean;
         bg?: string;
         "bg:opacity"?: number;
@@ -1589,6 +1590,7 @@ declare global {
         "debug:panictype"?: string;
         "block:view"?: string;
         "block:controller"?: string;
+        "block:subblock"?: boolean;
         "ai:backendtype"?: string;
         "ai:local"?: boolean;
         "wsh:cmd"?: string;

--- a/pkg/service/workspaceservice/workspaceservice.go
+++ b/pkg/service/workspaceservice/workspaceservice.go
@@ -214,7 +214,9 @@ func (svc *WorkspaceService) CloseTab_Meta() tsgenmeta.MethodMeta {
 	}
 }
 
-// returns the new active tabid
+// CloseTab deletes the given tab and returns the new active tabid (empty when the
+// window should close). It refuses to close a tab whose "tab:locked" meta is set,
+// returning an error so the lock is enforced regardless of which client requested the close.
 func (svc *WorkspaceService) CloseTab(ctx context.Context, workspaceId string, tabId string, fromElectron bool) (*CloseTabRtnType, waveobj.UpdatesRtnType, error) {
 	ctx = waveobj.ContextWithUpdates(ctx)
 	tab, err := wstore.DBGet[*waveobj.Tab](ctx, tabId)

--- a/pkg/service/workspaceservice/workspaceservice.go
+++ b/pkg/service/workspaceservice/workspaceservice.go
@@ -218,6 +218,9 @@ func (svc *WorkspaceService) CloseTab_Meta() tsgenmeta.MethodMeta {
 func (svc *WorkspaceService) CloseTab(ctx context.Context, workspaceId string, tabId string, fromElectron bool) (*CloseTabRtnType, waveobj.UpdatesRtnType, error) {
 	ctx = waveobj.ContextWithUpdates(ctx)
 	tab, err := wstore.DBGet[*waveobj.Tab](ctx, tabId)
+	if err == nil && tab != nil && tab.Meta.GetBool(waveobj.MetaKey_TabLocked, false) {
+		return nil, nil, fmt.Errorf("tab is locked")
+	}
 	if err == nil && tab != nil {
 		go func() {
 			for _, blockId := range tab.BlockIds {

--- a/pkg/waveobj/metaconsts.go
+++ b/pkg/waveobj/metaconsts.go
@@ -91,6 +91,7 @@ const (
 
 	MetaKey_TabFlagColor                     = "tab:flagcolor"
 	MetaKey_TabBackground                    = "tab:background"
+	MetaKey_TabLocked                        = "tab:locked"
 
 	MetaKey_BgClear                          = "bg:*"
 	MetaKey_Bg                               = "bg"

--- a/pkg/waveobj/wtypemeta.go
+++ b/pkg/waveobj/wtypemeta.go
@@ -94,6 +94,7 @@ type MetaTSType struct {
 	// for tabs
 	TabFlagColor        string  `json:"tab:flagcolor,omitempty"`
 	TabBackground       string  `json:"tab:background,omitempty"`
+	TabLocked           bool    `json:"tab:locked,omitempty"`
 	BgClear             bool    `json:"bg:*,omitempty"`
 	Bg                  string  `json:"bg,omitempty"`
 	BgOpacity           float64 `json:"bg:opacity,omitempty"`


### PR DESCRIPTION
## Preview

Lock / unlock interaction (right-click → Lock Tab). A locked tab shows an amber padlock in place of the close button, gets an amber tint, and can no longer be closed:

![Tab Lock lock/unlock demo](https://raw.githubusercontent.com/norarat-devsmith/waveterm/pr-assets/tab-lock.gif)

In both the top and left tab bars:

![Tab Lock screenshot](https://raw.githubusercontent.com/norarat-devsmith/waveterm/pr-assets/tab-lock.png)

## Summary

Adds a per-tab **Tab Lock** toggle, accessible from the tab right-click menu. Locking a tab protects it from being closed accidentally and gives it a clear visual indicator.

When a tab is locked:
- It **cannot be closed** via the close button, the context-menu *Close Tab* item, or the `Cmd`/`Ctrl`+`W` shortcut. All three frontend entry points are guarded, plus a backend guard in `WorkspaceService.CloseTab` as defense in depth.
- The close "X" is replaced by an amber **lock icon**.
- The tab gets a subtle **amber tint** (ring + background).

Works in both the **top** (horizontal) and **left** (vertical) tab bars.

## Implementation

Lock state is stored in tab `meta` under a new `tab:locked` key, mirroring the existing `tab:flagcolor` pattern — so no new RPC is required (it uses the existing `SetMetaCommand`), and it persists/syncs like other tab meta.

**Backend (Go)**
- `pkg/waveobj/metaconsts.go` — `MetaKey_TabLocked = "tab:locked"`
- `pkg/waveobj/wtypemeta.go` — `TabLocked bool` meta field
- `pkg/service/workspaceservice/workspaceservice.go` — `CloseTab` refuses a locked tab
- `frontend/types/gotypes.d.ts` — regenerated via `task generate`

**Frontend (TS/React)**
- `frontend/app/tab/tablock.ts` *(new)* — `isTabLocked()` helper + `TabLockedColor`
- `frontend/app/tab/tabcontextmenu.ts` — Lock/Unlock toggle; disabled *Close Tab* when locked
- `frontend/app/tab/tab.tsx` + `tab.scss` — top tab bar visuals
- `frontend/app/tab/vtab.tsx` / `vtabbar.tsx` — left tab bar visuals
- `frontend/app/tab/tabbar.tsx`, `vtabbar.tsx`, `store/keymodel.ts` — guard close entry points

Note: window-close still closes locked tabs by design — locking only blocks per-tab close, not quitting.

## Testing
- `go vet ./pkg/service/workspaceservice/ ./pkg/waveobj/` — clean
- `tsc --noEmit` — no errors in changed files
- `vitest run frontend/app/tab/vtab.test.tsx` — 4/4 pass (added 2 tests covering locked rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

