### PR TITLE
fix: support OAuth/SSO auth flows in webview blocks

### DIFF
--- a/emain/emain-tabview.ts
+++ b/emain/emain-tabview.ts
@@ -319,9 +319,24 @@ export async function getOrCreateWebViewForTab(waveWindowId: string, tabId: stri
             if (wc == null || wc.isDestroyed() || tabView.webContents == null || tabView.webContents.isDestroyed()) {
                 return { action: "deny" };
             }
+            // OAuth/SSO flows call window.open(url, name, "width=...,height=...") which Electron
+            // reports as disposition "new-window". They require a real popup that preserves the
+            // window.opener relationship (postMessage token return) and a valid Cross-Origin-
+            // Opener-Policy browsing context. Rerouting them into a new web block breaks both
+            // (results in ERR_BLOCKED_BY_RESPONSE). Allow a genuine popup window for these; it
+            // shares wc's session so any auth cookies/tokens remain visible to the webview.
+            if (details.disposition === "new-window") {
+                return {
+                    action: "allow",
+                    overrideBrowserWindowOptions: { width: 600, height: 700, autoHideMenuBar: true },
+                };
+            }
+            // Plain link clicks (target=_blank, foreground/background tab) keep existing behavior:
+            // open in a new Wave web block.
             tabView.webContents.send("webview-new-window", wc.id, details);
             return { action: "deny" };
         });
+        wc.on("did-create-window", (popup) => popup.setMenuBarVisibility(false));
     });
     tabView.webContents.on("before-input-event", (e, input) => {
         const waveEvent = adaptFromElectronKeyEvent(input);

--- a/emain/emain-tabview.ts
+++ b/emain/emain-tabview.ts
@@ -325,7 +325,9 @@ export async function getOrCreateWebViewForTab(waveWindowId: string, tabId: stri
             // Opener-Policy browsing context. Rerouting them into a new web block breaks both
             // (results in ERR_BLOCKED_BY_RESPONSE). Allow a genuine popup window for these; it
             // shares wc's session so any auth cookies/tokens remain visible to the webview.
-            if (details.disposition === "new-window") {
+            // Gate on a non-empty features string: a shift+click on a plain link also reports
+            // disposition "new-window" but carries no features, and must keep routing to a web block.
+            if (details.disposition === "new-window" && details.features !== "") {
                 return {
                     action: "allow",
                     overrideBrowserWindowOptions: { width: 600, height: 700, autoHideMenuBar: true },

--- a/frontend/app/view/webview/webview.tsx
+++ b/frontend/app/view/webview/webview.tsx
@@ -1044,6 +1044,14 @@ const WebView = memo(({ model, onFailLoad, blockRef, initialSrc }: WebViewProps)
         const failLoadHandler = (e: any) => {
             if (e.errorCode === -3) {
                 console.warn("Suppressed ERR_ABORTED error", e);
+            } else if (e.isMainFrame === false) {
+                // Sub-frame load failures are non-fatal. Web apps routinely load hidden iframes
+                // that are expected to fail — e.g. OAuth/OIDC silent-auth probes
+                // (response_mode=web_message, prompt=none), which get blocked by the embedder's
+                // Cross-Origin-Embedder-Policy and are then handled by the app's auth SDK (it
+                // falls back to interactive login). A normal browser surfaces these only to the
+                // SDK, not the user, so don't paint a fatal error over the whole block.
+                console.warn("Suppressed sub-frame load failure", e.validatedURL, e.errorDescription);
             } else {
                 const errorMessage = `Failed to load ${e.validatedURL}: ${e.errorDescription}`;
                 console.error(errorMessage);


### PR DESCRIPTION
Fixes #2764

Login flows that rely on OAuth/OIDC or popup-based SSO currently dead-end inside Wave web blocks with `ERR_BLOCKED_BY_RESPONSE` instead of completing. Two related changes fix this:

**1. Don't treat sub-frame load failures as fatal** (`webview.tsx`)

Web apps routinely load hidden iframes that are *expected* to fail — notably OAuth/OIDC silent-auth probes (`response_mode=web_message`, `prompt=none`), which the embedding page's Cross-Origin-Embedder-Policy blocks. A normal browser surfaces these only to the page's auth SDK, which then falls back to interactive login. Wave instead painted a fatal error overlay over the whole block on *any* `did-fail-load`, killing the flow before the fallback could run. Now the overlay is only shown for main-frame failures; sub-frame failures are logged and suppressed.

**2. Allow genuine popups for `window.open` with features** (`emain-tabview.ts`)

Popup-based SSO (e.g. GitHub/Microsoft) calls `window.open(url, name, "width=...")`, which Electron reports as disposition `new-window`. These need a real popup window that preserves `window.opener` and the COOP browsing context — rerouting them into a new web block severs both. This allows a real popup for the `new-window` disposition while keeping ordinary link clicks routed to web blocks.

## Verification

Reproduced the **DuckDB local UI → MotherDuck (Auth0) sign-in** inside a web block on two builds: this branch, and upstream `main` (baseline, neither fix). In both, the OIDC silent-auth probe (`response_mode=web_message&prompt=none`) is blocked by the embedder's COEP and fails with `ERR_BLOCKED_BY_RESPONSE` — the difference is how Wave reacts to that sub-frame failure.

**Before — upstream `main` (no fix).** The host renderer treats the sub-frame failure as fatal and paints an error overlay over the whole block, killing the flow:

```
webview.tsx:1049  Failed to load https://auth.motherduck.com/authorize?...&response_mode=web_message&prompt=none...: ERR_BLOCKED_BY_RESPONSE
```

**After — this branch.** The sub-frame failure is logged and suppressed; no overlay is shown, so the auth SDK's own fallback can run:

```
webview.tsx:1054  Suppressed sub-frame load failure https://auth.motherduck.com/authorize?...&response_mode=web_message&prompt=none... ERR_BLOCKED_BY_RESPONSE
```

With the block no longer killed, the page's Auth0 SDK handles the blocked probe and the DuckDB UI keeps loading instead of dead-ending (web-block page console, fixed build):

```
Completed Auth0SilentSignIn successfully {result: 'failed'}
DuckDB UI entering unauthenticated mode
... CreateDuckDBInstance -> SwitchToNotebook -> in-memory db attached successfully
```
