### PR TITLE
fix(ssh): wrap agent signers to continue to next identity on signing failure

### DIFF
--- a/pkg/remote/sshclient.go
+++ b/pkg/remote/sshclient.go
@@ -310,6 +310,8 @@ func createPublicKeyCallback(connCtx context.Context, sshKeywords *wconfig.ConnK
 		if len(*authSockSignersPtr) != 0 {
 			authSockSigner := (*authSockSignersPtr)[0]
 			*authSockSignersPtr = (*authSockSignersPtr)[1:]
+			blocklogger.Infof(connCtx, "[conndebug] trying agent identity %s %s...\n",
+				authSockSigner.PublicKey().Type(), ssh.FingerprintSHA256(authSockSigner.PublicKey()))
 			return []ssh.Signer{authSockSigner}, nil
 		}
 
@@ -772,10 +774,19 @@ func createClientConfig(connCtx context.Context, sshKeywords *wconfig.ConnKeywor
 	if !utilfn.SafeDeref(sshKeywords.SshIdentitiesOnly) && agentPath != "" {
 		conn, err := dialIdentityAgent(agentPath)
 		if err != nil {
+			blocklogger.Infof(connCtx, "[conndebug] failed to open identity agent socket %q: %v\n", agentPath, err)
 			log.Printf("Failed to open Identity Agent Socket %q: %v", agentPath, err)
 		} else {
 			agentClient = agent.NewClient(conn)
-			authSockSigners, _ = agentClient.Signers()
+			agentSigners, err := agentClient.Signers()
+			if err != nil {
+				blocklogger.Infof(connCtx, "[conndebug] failed to list identity agent keys: %v\n", err)
+				log.Printf("Failed to list identity agent keys: %v", err)
+			}
+			blocklogger.Infof(connCtx, "[conndebug] identity agent provided %d identities\n", len(agentSigners))
+			for _, agentSigner := range agentSigners {
+				authSockSigners = append(authSockSigners, failoverSigner{signer: agentSigner, connCtx: connCtx})
+			}
 		}
 	}
 

--- a/pkg/remote/sshsigners.go
+++ b/pkg/remote/sshsigners.go
@@ -1,0 +1,51 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package remote
+
+import (
+	"context"
+	"io"
+
+	"github.com/wavetermdev/waveterm/pkg/blocklogger"
+	"golang.org/x/crypto/ssh"
+)
+
+type failoverSigner struct {
+	signer  ssh.Signer
+	connCtx context.Context
+}
+
+func (f failoverSigner) PublicKey() ssh.PublicKey {
+	return f.signer.PublicKey()
+}
+
+func (f failoverSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	sig, err := f.signer.Sign(rand, data)
+	if err == nil {
+		return sig, nil
+	}
+	blocklogger.Infof(f.connCtx, "[conndebug] agent signing failed for key %s %s (%v); continuing with next identity\n",
+		f.signer.PublicKey().Type(), ssh.FingerprintSHA256(f.signer.PublicKey()), err)
+	return f.invalidSignature(), nil
+}
+
+func (f failoverSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*ssh.Signature, error) {
+	if as, ok := f.signer.(ssh.AlgorithmSigner); ok {
+		sig, err := as.SignWithAlgorithm(rand, data, algorithm)
+		if err == nil {
+			return sig, nil
+		}
+		blocklogger.Infof(f.connCtx, "[conndebug] agent signing failed for key %s %s (%v); continuing with next identity\n",
+			f.signer.PublicKey().Type(), ssh.FingerprintSHA256(f.signer.PublicKey()), err)
+		return f.invalidSignature(), nil
+	}
+	return f.Sign(rand, data)
+}
+
+func (f failoverSigner) invalidSignature() *ssh.Signature {
+	return &ssh.Signature{
+		Format: f.signer.PublicKey().Type(),
+		Blob:   []byte("invalid-signature-identity-skipped"),
+	}
+}

--- a/pkg/remote/sshsigners.go
+++ b/pkg/remote/sshsigners.go
@@ -11,15 +11,23 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// failoverSigner wraps an ssh.Signer so that a signing failure from one
+// agent identity does not abort authentication; instead it returns a
+// synthesized invalid signature, allowing the SSH client to try the next
+// identity (matching OpenSSH's failover behavior).
 type failoverSigner struct {
 	signer  ssh.Signer
 	connCtx context.Context
 }
 
+// PublicKey returns the public key of the wrapped signer.
 func (f failoverSigner) PublicKey() ssh.PublicKey {
 	return f.signer.PublicKey()
 }
 
+// Sign signs the data with the wrapped signer. On failure it logs the error
+// and returns an invalid placeholder signature so the client can continue to
+// the next identity.
 func (f failoverSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
 	sig, err := f.signer.Sign(rand, data)
 	if err == nil {
@@ -27,9 +35,13 @@ func (f failoverSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error
 	}
 	blocklogger.Infof(f.connCtx, "[conndebug] agent signing failed for key %s %s (%v); continuing with next identity\n",
 		f.signer.PublicKey().Type(), ssh.FingerprintSHA256(f.signer.PublicKey()), err)
-	return f.invalidSignature(), nil
+	return f.invalidSignature(f.signer.PublicKey().Type()), nil
 }
 
+// SignWithAlgorithm signs the data with the wrapped signer using the requested
+// algorithm. On failure it logs the error and returns an invalid placeholder
+// signature whose Format matches the requested algorithm, allowing the client
+// to try the next identity.
 func (f failoverSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*ssh.Signature, error) {
 	if as, ok := f.signer.(ssh.AlgorithmSigner); ok {
 		sig, err := as.SignWithAlgorithm(rand, data, algorithm)
@@ -38,14 +50,17 @@ func (f failoverSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm
 		}
 		blocklogger.Infof(f.connCtx, "[conndebug] agent signing failed for key %s %s (%v); continuing with next identity\n",
 			f.signer.PublicKey().Type(), ssh.FingerprintSHA256(f.signer.PublicKey()), err)
-		return f.invalidSignature(), nil
+		return f.invalidSignature(algorithm), nil
 	}
 	return f.Sign(rand, data)
 }
 
-func (f failoverSigner) invalidSignature() *ssh.Signature {
+// invalidSignature constructs a placeholder ssh.Signature with the given
+// format and a clearly-invalid blob. Returning this (rather than an error)
+// lets the SSH client move on to the next offered identity.
+func (f failoverSigner) invalidSignature(format string) *ssh.Signature {
 	return &ssh.Signature{
-		Format: f.signer.PublicKey().Type(),
+		Format: format,
 		Blob:   []byte("invalid-signature-identity-skipped"),
 	}
 }

--- a/pkg/remote/sshsigners.go
+++ b/pkg/remote/sshsigners.go
@@ -11,23 +11,29 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// failoverSigner wraps an ssh.Signer so that a signing failure from one
-// agent identity does not abort authentication; instead it returns a
-// synthesized invalid signature, allowing the SSH client to try the next
-// identity (matching OpenSSH's failover behavior).
+// failoverSigner wraps an ssh.Signer to implement SSH agent identity failover.
+// When signing with one agent identity fails, instead of aborting the entire
+// authentication attempt, it produces a synthesized invalid signature that
+// causes the SSH client to try the next available identity, matching OpenSSH's
+// default multi-identity authentication behavior. It implements both
+// ssh.Signer and ssh.AlgorithmSigner.
 type failoverSigner struct {
 	signer  ssh.Signer
 	connCtx context.Context
 }
 
-// PublicKey returns the public key of the wrapped signer.
+// PublicKey returns the public key associated with the wrapped signer.
+// It implements ssh.Signer.
 func (f failoverSigner) PublicKey() ssh.PublicKey {
 	return f.signer.PublicKey()
 }
 
-// Sign signs the data with the wrapped signer. On failure it logs the error
-// and returns an invalid placeholder signature so the client can continue to
-// the next identity.
+// Sign signs the given data using the wrapped signer. If signing succeeds, the
+// valid signature is returned. If signing fails (e.g. because the agent cannot
+// authenticate with this particular identity), the error is logged via
+// blocklogger and an invalid placeholder signature is returned instead of an
+// error, allowing the SSH client to proceed to the next offered identity.
+// It implements ssh.Signer.
 func (f failoverSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
 	sig, err := f.signer.Sign(rand, data)
 	if err == nil {
@@ -38,10 +44,12 @@ func (f failoverSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error
 	return f.invalidSignature(f.signer.PublicKey().Type()), nil
 }
 
-// SignWithAlgorithm signs the data with the wrapped signer using the requested
-// algorithm. On failure it logs the error and returns an invalid placeholder
-// signature whose Format matches the requested algorithm, allowing the client
-// to try the next identity.
+// SignWithAlgorithm signs the given data using the wrapped signer with the
+// requested signature algorithm. If the wrapped signer supports
+// ssh.AlgorithmSigner, the algorithm is forwarded; if signing fails in that
+// case an invalid signature with the requested algorithm format is returned.
+// If the wrapped signer does not implement ssh.AlgorithmSigner, it falls back
+// to Sign. It implements ssh.AlgorithmSigner.
 func (f failoverSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*ssh.Signature, error) {
 	if as, ok := f.signer.(ssh.AlgorithmSigner); ok {
 		sig, err := as.SignWithAlgorithm(rand, data, algorithm)
@@ -56,8 +64,9 @@ func (f failoverSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm
 }
 
 // invalidSignature constructs a placeholder ssh.Signature with the given
-// format and a clearly-invalid blob. Returning this (rather than an error)
-// lets the SSH client move on to the next offered identity.
+// format and an obviously-invalid blob. Returning this sentinel signature
+// instead of propagating the signing error causes the SSH client to skip
+// this identity and move on to the next one offered by the agent.
 func (f failoverSigner) invalidSignature(format string) *ssh.Signature {
 	return &ssh.Signature{
 		Format: format,


### PR DESCRIPTION
Fixes #3365

## Problem

When an SSH agent-backed key fails to sign (e.g. user cancels a FIDO2 / security-key user-presence prompt), the `crypto/ssh` publickey callback returns an error. The SSH library treats any callback error as fatal and aborts the entire authentication flow — it does **not** try any remaining agent identities or keyfiles. This differs from OpenSSH, which moves on to the next key when a signing request is declined.

For users with multiple identities in their agent (e.g. a YubiKey/FIDO2 key first, then a regular ed25519 key), tapping "decline" on the hardware key prompt prevents any subsequent key from being attempted, even when the server would accept it.

## Root cause

`agentClient.Signers()` returns `[]ssh.Signer` that call through to the agent. If `Sign()` returns an error (e.g. `agent.errNoMoreKeys`/user cancellation), `ssh.PublicKeysCallback` propagates that error and `RetryableAuthMethod` stops retrying because the method itself failed, not because authentication was rejected.

## Fix

Wrap each agent-backed signer in a new `failoverSigner` ([sshsigners.go](pkg/remote/sshsigners.go)) that:

- Implements both `ssh.Signer` and `ssh.AlgorithmSigner`.
- On `Sign` / `SignWithAlgorithm` failure, logs a `[conndebug]` message and returns a deliberately **invalid signature** (a blob that cannot verify) instead of an error.
- The server will reject the auth attempt (wrong signature for that key) which `ssh` treats as a normal per-key failure, allowing `RetryableAuthMethod` to continue with the next identity — exactly matching OpenSSH's behavior.

Also adds [conndebug] logging to aid troubleshooting:

- Agent socket dial failures
- Agent key listing errors
- Number of identities provided by the agent
- Each agent identity being tried (type + SHA256 fingerprint)
- Per-key signing failures with the key fingerprint and error

## Testing

- `go build ./...` passes
- `go vet ./pkg/remote/` passes
- `go test ./pkg/remote/` passes (includes `TestDialIdentityAgentUnix`)

No behavioral change when signers succeed; only the error path changes so that a rejected hardware-key prompt no longer blocks fallback to other identities.