### PR TITLE
fix(shellexec): avoid false Snap detection and empty XDG_* vars

### DIFF
--- a/pkg/shellexec/shellexec.go
+++ b/pkg/shellexec/shellexec.go
@@ -648,8 +648,12 @@ func StartLocalShellProc(logCtx context.Context, termSize waveobj.TermSize, cmdS
 	  overrides them to point to snap directories. We will get the correct values, if
 	  set, from the PAM environment. If the XDG variables are set in profile or in an
 	  RC file, it will be overridden when the shell initializes.
+
+	  Only apply this correction when Wave itself is running as a Snap (SNAP_NAME == "waveterm"),
+	  not when $SNAP is merely inherited from a parent Snap process (e.g. a CLI tool
+	  installed via Snap).
 	*/
-	if os.Getenv("SNAP") != "" {
+	if os.Getenv("SNAP_NAME") == "waveterm" {
 		log.Printf("Detected Snap installation, correcting XDG environment variables")
 		varsToReplace := map[string]string{"XDG_CONFIG_HOME": "", "XDG_DATA_HOME": "", "XDG_CACHE_HOME": "", "XDG_RUNTIME_DIR": "", "XDG_CONFIG_DIRS": "", "XDG_DATA_DIRS": ""}
 		pamEnvs := tryGetPamEnvVars()
@@ -659,6 +663,15 @@ func StartLocalShellProc(logCtx context.Context, termSize waveobj.TermSize, cmdS
 				if _, ok := varsToReplace[k]; ok {
 					varsToReplace[k] = pamEnvs[k]
 				}
+			}
+		}
+		// Remove keys that still have empty values so they are not explicitly set to
+		// empty strings in the child environment (which breaks tools that fall back to
+		// XDG spec defaults).  When a key is absent from varsToReplace the child will
+		// either inherit the parent value or rely on shell rc files / spec defaults.
+		for k, v := range varsToReplace {
+			if v == "" {
+				delete(varsToReplace, k)
 			}
 		}
 		log.Printf("Setting XDG environment variables to: %v", varsToReplace)

--- a/pkg/shellexec/shellexec.go
+++ b/pkg/shellexec/shellexec.go
@@ -580,6 +580,10 @@ func StartRemoteShellJob(ctx context.Context, logCtx context.Context, termSize w
 	return jobId, nil
 }
 
+// StartLocalShellProc starts a local shell process with the given command string,
+// terminal size, command options, and connection name. It configures the shell
+// environment (including correcting XDG directory variables when running as a Snap),
+// sets up a PTY, and returns a ShellProc instance managing the running process.
 func StartLocalShellProc(logCtx context.Context, termSize waveobj.TermSize, cmdStr string, cmdOpts CommandOptsType, connName string) (*ShellProc, error) {
 	if cmdOpts.SwapToken == nil {
 		return nil, fmt.Errorf("SwapToken is required in CommandOptsType")


### PR DESCRIPTION
## Summary

This fixes #3336 with two tightly-scoped changes in `pkg/shellexec/shellexec.go`:

### 1. Narrow the Snap detection guard
The previous check `os.Getenv("SNAP") != ""` fires for **any** process that inherits $SNAP from a parent — including when Wave is launched from inside a Snap-installed terminal/CLI (e.g. the user snaps Alacritty or nvim and launches Wave from there). In that case Wave itself is not running as a Snap, but the code still wipes the XDG variables and tries to repopulate them from PAM.

Changed the guard to:

```go
if os.Getenv("SNAP_NAME") == "waveterm" {
```

`SNAP_NAME` is set by Snapd to the declared snap name for the **running** snap only; inherited $SNAP from a parent process does not carry the parent's `SNAP_NAME` across exec when the child is not a snap. This matches the documented Snap environment-variable conventions and ensures the correction only runs when Wave itself is the Snap.

### 2. Do not explicitly set XDG vars to empty strings
After fetching PAM env vars, any XDG key not present in PAM was left as `""` in `varsToReplace`, and was then passed to `shellutil.UpdateCmdEnv`. Depending on whether the key already existed in the command env, this either **unset** the variable or **set it to the empty string**, both of which break applications that rely on XDG Base Directory spec defaults (e.g. `XDG_RUNTIME_DIR` being empty caused the reported zsh-autosuggestions panic in uv/pipx-installed tools).

Added a filter that drops keys still holding empty values before calling `UpdateCmdEnv`. When a key is absent from the map, the child inherits the parent value (or uses spec defaults / shell rc files), which is the correct behavior on non-Snap systems and on Snaps where PAM didn't export that particular variable.

## Verification
- `go vet ./pkg/shellexec/` passes.
- Manually verified that with `SNAP` set but `SNAP_NAME != waveterm`, the Snap-correction block is no longer entered.
- Manually verified that with `SNAP_NAME=waveterm` and a partial PAM env, missing keys are omitted from `varsToReplace` rather than set to `""`.

Fixes #3336