### PR TITLE
wavebase: symlink ~/.config/waveterm for snap users

### DIFF
--- a/pkg/wavebase/wavebase.go
+++ b/pkg/wavebase/wavebase.go
@@ -198,6 +198,15 @@ func EnsureWaveDBDir() error {
 }
 
 func EnsureWaveConfigDir() error {
+	// Symlink ~/.config/waveterm → snap config dir so external edits are visible.
+	if ClientPackageType() == "snap" {
+		stdDir := filepath.Join(GetHomeDir(), ".config", "waveterm")
+		if _, err := os.Lstat(stdDir); os.IsNotExist(err) {
+			if err := os.Symlink(GetWaveConfigDir(), stdDir); err != nil {
+				log.Printf("wavebase: symlink %s: %v\n", stdDir, err)
+			}
+		}
+	}
 	return CacheEnsureDir(GetWaveConfigDir(), "waveconfig", 0700, "wave config directory")
 }
 


### PR DESCRIPTION
When Wave runs as a classic snap, $WAVETERM_CONFIG_HOME points to
$SNAP_USER_DATA/.config/waveterm and not ~/.config/waveterm. Users
who follow the docs and edit ~/.config/waveterm/waveai.json directly
see no effect.

Fix: on startup, if ~/.config/waveterm doesn't exist, symlink it to
the snap config dir.  Existing paths are left alone.