### PR TITLE
fix(term): emit distinct CSI-u sequence for Ctrl+Enter in terminal blocks

### DIFF
--- a/cmd/generateschema/main-generateschema.go
+++ b/cmd/generateschema/main-generateschema.go
@@ -99,6 +99,7 @@ type WidgetsMetaSchemaHints struct {
 	TermTransparency        *float64 `json:"term:transparency,omitempty"`
 	TermAllowBracketedPaste *bool    `json:"term:allowbracketedpaste,omitempty"`
 	TermShiftEnterNewline   *bool    `json:"term:shiftenternewline,omitempty"`
+	TermCtrlEnter           *bool    `json:"term:ctrlenter,omitempty"`
 	TermMacOptionIsMeta     *bool    `json:"term:macoptionismeta,omitempty"`
 	TermBellSound           *bool    `json:"term:bellsound,omitempty"`
 	TermBellIndicator       *bool    `json:"term:bellindicator,omitempty"`

--- a/frontend/app/view/term/term-model.ts
+++ b/frontend/app/view/term/term-model.ts
@@ -733,10 +733,14 @@ export class TermViewModel implements ViewModel {
             }
         }
         if (keyutil.checkKeyPressed(waveEvent, "Ctrl:Enter")) {
-            this.sendDataToController("\x1b[13;5u");
-            event.preventDefault();
-            event.stopPropagation();
-            return false;
+            const ctrlEnterAtom = getOverrideConfigAtom(this.blockId, "term:ctrlenter");
+            const ctrlEnterEnabled = globalStore.get(ctrlEnterAtom) ?? true;
+            if (ctrlEnterEnabled) {
+                this.sendDataToController("\x1b[13;5u");
+                event.preventDefault();
+                event.stopPropagation();
+                return false;
+            }
         }
 
         // Check for Ctrl-V paste (platform-dependent)

--- a/frontend/app/view/term/term-model.ts
+++ b/frontend/app/view/term/term-model.ts
@@ -732,6 +732,12 @@ export class TermViewModel implements ViewModel {
                 return false;
             }
         }
+        if (keyutil.checkKeyPressed(waveEvent, "Ctrl:Enter")) {
+            this.sendDataToController("\x1b[13;5u");
+            event.preventDefault();
+            event.stopPropagation();
+            return false;
+        }
 
         // Check for Ctrl-V paste (platform-dependent)
         if (this.shouldHandleCtrlVPaste() && keyutil.checkKeyPressed(waveEvent, "Ctrl:v")) {

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1182,6 +1182,7 @@ declare global {
         "term:transparency"?: number;
         "term:allowbracketedpaste"?: boolean;
         "term:shiftenternewline"?: boolean;
+        "term:ctrlenter"?: boolean;
         "term:macoptionismeta"?: boolean;
         "term:cursor"?: string;
         "term:cursorblink"?: boolean;
@@ -1417,6 +1418,7 @@ declare global {
         "term:transparency"?: number;
         "term:allowbracketedpaste"?: boolean;
         "term:shiftenternewline"?: boolean;
+        "term:ctrlenter"?: boolean;
         "term:macoptionismeta"?: boolean;
         "term:cursor"?: string;
         "term:cursorblink"?: boolean;

--- a/pkg/waveobj/metaconsts.go
+++ b/pkg/waveobj/metaconsts.go
@@ -121,6 +121,7 @@ const (
 	MetaKey_TermTransparency                 = "term:transparency"
 	MetaKey_TermAllowBracketedPaste          = "term:allowbracketedpaste"
 	MetaKey_TermShiftEnterNewline            = "term:shiftenternewline"
+	MetaKey_TermCtrlEnter                    = "term:ctrlenter"
 	MetaKey_TermMacOptionIsMeta              = "term:macoptionismeta"
 	MetaKey_TermCursor                       = "term:cursor"
 	MetaKey_TermCursorBlink                  = "term:cursorblink"

--- a/pkg/waveobj/wtypemeta.go
+++ b/pkg/waveobj/wtypemeta.go
@@ -125,6 +125,7 @@ type MetaTSType struct {
 	TermTransparency        *float64 `json:"term:transparency,omitempty"` // default 0.5
 	TermAllowBracketedPaste *bool    `json:"term:allowbracketedpaste,omitempty"`
 	TermShiftEnterNewline   *bool    `json:"term:shiftenternewline,omitempty"`
+	TermCtrlEnter           *bool    `json:"term:ctrlenter,omitempty"`
 	TermMacOptionIsMeta     *bool    `json:"term:macoptionismeta,omitempty"`
 	TermCursor              string   `json:"term:cursor,omitempty"`
 	TermCursorBlink         *bool    `json:"term:cursorblink,omitempty"`

--- a/pkg/wconfig/metaconsts.go
+++ b/pkg/wconfig/metaconsts.go
@@ -52,6 +52,7 @@ const (
 	ConfigKey_TermTransparency               = "term:transparency"
 	ConfigKey_TermAllowBracketedPaste        = "term:allowbracketedpaste"
 	ConfigKey_TermShiftEnterNewline          = "term:shiftenternewline"
+	ConfigKey_TermCtrlEnter                  = "term:ctrlenter"
 	ConfigKey_TermMacOptionIsMeta            = "term:macoptionismeta"
 	ConfigKey_TermCursor                     = "term:cursor"
 	ConfigKey_TermCursorBlink                = "term:cursorblink"

--- a/pkg/wconfig/settingsconfig.go
+++ b/pkg/wconfig/settingsconfig.go
@@ -103,6 +103,7 @@ type SettingsType struct {
 	TermTransparency        *float64 `json:"term:transparency,omitempty"`
 	TermAllowBracketedPaste *bool    `json:"term:allowbracketedpaste,omitempty"`
 	TermShiftEnterNewline   *bool    `json:"term:shiftenternewline,omitempty"`
+	TermCtrlEnter           *bool    `json:"term:ctrlenter,omitempty"`
 	TermMacOptionIsMeta     *bool    `json:"term:macoptionismeta,omitempty"`
 	TermCursor              string   `json:"term:cursor,omitempty"`
 	TermCursorBlink         *bool    `json:"term:cursorblink,omitempty"`

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -143,6 +143,9 @@
         "term:shiftenternewline": {
           "type": "boolean"
         },
+        "term:ctrlenter": {
+          "type": "boolean"
+        },
         "term:macoptionismeta": {
           "type": "boolean"
         },

--- a/schema/widgets.json
+++ b/schema/widgets.json
@@ -151,6 +151,9 @@
             "term:shiftenternewline": {
               "type": "boolean"
             },
+            "term:ctrlenter": {
+              "type": "boolean"
+            },
             "term:macoptionismeta": {
               "type": "boolean"
             },


### PR DESCRIPTION
## Summary

This PR adds Ctrl+Enter key handling in terminal blocks to emit the CSI-u modified-key sequence `ESC [ 13 ; 5 u` (`\x1b[13;5u`), allowing terminal applications to distinguish Ctrl+Enter from plain Enter.

## Problem

Previously, Ctrl+Enter in a terminal block produced the same byte (0x0a / newline) as plain Enter and Shift+Enter, making it impossible for terminal applications (like AI chat CLIs, multi-line editors, etc.) to bind Ctrl+Enter separately from Enter. Alt+Enter was already distinguishable via the ESC prefix, but Ctrl+Enter was collapsed.

## Fix

Added a `Ctrl:Enter` branch in `handleTerminalKeydown()` that sends the standard CSI-u sequence `\x1b[13;5u`, following the same pattern as the existing `Shift:Enter` handling.

- **Enter** → 0x0a (unchanged)
- **Shift+Enter** → 0x0a when `term:shiftenternewline` is enabled (unchanged)
- **Ctrl+Enter** → `\x1b[13;5u` (new)
- **Alt+Enter** → `\x1b[0a` (unchanged, ESC prefix)

Terminal applications that understand CSI-u (such as Pi, as mentioned in the issue) can now bind Ctrl+Enter to submit/send while using Enter/Shift+Enter for newline insertion in multi-line prompts.

## Testing

- TypeScript compiles without new errors.
- Enter and Shift+Enter behavior remains unchanged.

Fixes #3355