### PR TITLE
fix(webview): respect system color scheme for prefers-color-scheme in web blocks

### DIFF
--- a/emain/emain.ts
+++ b/emain/emain.ts
@@ -65,7 +65,7 @@ let confirmQuit = true;
 const waveDataDir = getWaveDataDir();
 const waveConfigDir = getWaveConfigDir();
 
-electron.nativeTheme.themeSource = "dark";
+electron.nativeTheme.themeSource = "system";
 
 console.log = log;
 console.log(


### PR DESCRIPTION
Fixes #3318

Changes `nativeTheme.themeSource` from 'dark' to 'system' so that embedded web content (web blocks) correctly respects the OS color scheme preference. Wave's own UI remains dark-themed via CSS `color-scheme: dark` and custom scrollbar styling, so this only affects webview/iframe content.