### PR TITLE
fix(wsh): prevent deleteblock from silently ignoring positional arguments

### DIFF
--- a/cmd/wsh/cmd/wshcmd-deleteblock.go
+++ b/cmd/wsh/cmd/wshcmd-deleteblock.go
@@ -12,8 +12,10 @@ import (
 )
 
 var deleteBlockCmd = &cobra.Command{
-	Use:     "deleteblock",
+	Use:     "deleteblock [-b {blockid|blocknum|this}]",
 	Short:   "delete a block",
+	Long:    "Delete a block. If no block is specified with -b, deletes the current block (this).",
+	Args:    cobra.NoArgs,
 	RunE:    deleteBlockRun,
 	PreRunE: preRunSetupRpcClient,
 }


### PR DESCRIPTION
## Summary

Fixes #3417

The `wsh deleteblock` command had two issues:
1. The `Use` string didn't document the `-b` flag, making it unclear how to specify which block to delete
2. Without `Args` validation, positional arguments were silently ignored. When users passed a block ID as a positional argument (e.g. `wsh deleteblock BLOCKID` instead of `wsh deleteblock -b BLOCKID`), the argument was ignored and the command defaulted to deleting the current block ("this"), causing it to "close itself."

## Changes

- Updated `Use` string to `deleteblock [-b {blockid|blocknum|this}]` to document the `-b` flag (matching the `focusblock` command pattern)
- Added `Long` description clarifying default behavior
- Added `Args: cobra.NoArgs` to reject accidental positional arguments with a clear error instead of silently ignoring them

## Testing

- `go build ./cmd/wsh/` compiles successfully
- `go vet ./cmd/wsh/...` passes
- Verified `wsh deleteblock --help` shows correct usage with `-b` flag documented
- Verified `wsh deleteblock BLOCKID` (positional) now returns an error instead of silently deleting the current block