### PR TITLE
Fix bookmark typeahead not rendering suggestions

### DIFF
--- a/frontend/app/view/webview/webview.tsx
+++ b/frontend/app/view/webview/webview.tsx
@@ -285,10 +285,10 @@ export class WebViewModel implements ViewModel {
         globalStore.set(this.typeaheadOpen, open);
     }
 
-    async fetchBookmarkSuggestions(
+    fetchBookmarkSuggestions = async (
         query: string,
         reqContext: SuggestionRequestContext
-    ): Promise<FetchSuggestionsResponse> {
+    ): Promise<FetchSuggestionsResponse> => {
         const result = await this.env.rpc.FetchSuggestionsCommand(TabRpcClient, {
             suggestiontype: "bookmark",
             query,
@@ -296,7 +296,7 @@ export class WebViewModel implements ViewModel {
             reqnum: reqContext.reqnum,
         });
         return result;
-    }
+    };
 
     handleUrlWrapperMouseOver(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {
         const urlInputFocused = globalStore.get(this.urlInputFocused);
@@ -755,7 +755,7 @@ const BookmarkTypeahead = memo(
         const env = useWaveEnv<WebViewEnv>();
         const openBookmarksJson = () => {
             fireAndForget(async () => {
-                const path = `${env.electron.getConfigDir()}/presets/bookmarks.json`;
+                const path = `${env.electron.getConfigDir()}/bookmarks.json`;
                 const blockDef: BlockDef = {
                     meta: {
                         view: "preview",


### PR DESCRIPTION
## Summary
- `fetchBookmarkSuggestions` was a plain class method passed by reference to
  `BlockHeaderSuggestionControl` (`fetchSuggestions={model.fetchBookmarkSuggestions}`).
  Calling it as a bare function lost its `this` binding, so `this.env` threw a
  `TypeError` inside the method. The rejection had no `.catch`, so `fetched`
  never flipped to `true` and neither the bookmark list nor the empty state
  ever rendered — pressing `Cmd+O` just showed an empty input with nothing
  below it.
- The "Open bookmarks.json" button in the empty state pointed at
  `presets/bookmarks.json`, a path nothing else reads from or writes to.
  Bookmarks are actually loaded from `<configDir>/bookmarks.json`. Clicking
  the button created a dead file that had no effect on the app.

## Fix
- Converted `fetchBookmarkSuggestions` to an arrow function class field so
  `this` stays bound to the `WebViewModel` instance regardless of how it's
  invoked.
- Fixed the "Open bookmarks.json" button to point at `<configDir>/bookmarks.json`.