### PR TITLE
fix(shellexec): prevent empty XDG_* env vars when $SNAP is inherited from non-Wave snaps

### DIFF
--- a/pkg/shellexec/shellexec.go
+++ b/pkg/shellexec/shellexec.go
@@ -649,7 +649,7 @@ func StartLocalShellProc(logCtx context.Context, termSize waveobj.TermSize, cmdS
 	  set, from the PAM environment. If the XDG variables are set in profile or in an
 	  RC file, it will be overridden when the shell initializes.
 	*/
-	if os.Getenv("SNAP") != "" {
+	if os.Getenv("SNAP_NAME") == "waveterm" {
 		log.Printf("Detected Snap installation, correcting XDG environment variables")
 		varsToReplace := map[string]string{"XDG_CONFIG_HOME": "", "XDG_DATA_HOME": "", "XDG_CACHE_HOME": "", "XDG_RUNTIME_DIR": "", "XDG_CONFIG_DIRS": "", "XDG_DATA_DIRS": ""}
 		pamEnvs := tryGetPamEnvVars()

--- a/pkg/util/shellutil/shellutil.go
+++ b/pkg/util/shellutil/shellutil.go
@@ -253,7 +253,9 @@ func UpdateCmdEnv(cmd *exec.Cmd, envVars map[string]string) {
 		if found[envKey] {
 			continue
 		}
-		newEnv = append(newEnv, envKey+"="+envVal)
+		if envVal != "" {
+			newEnv = append(newEnv, envKey+"="+envVal)
+		}
 	}
 	cmd.Env = newEnv
 }


### PR DESCRIPTION
## Summary

Fixes #3336.

When wavesrv was launched from a process that had $SNAP set (e.g., any CLI tool installed as a snap), the snap XDG-correction code would trigger erroneously. It then wrote empty-string values for `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME`, etc. into the spawned shell environment, because PAM env typically doesn't set these variables on modern systems. Tools that path-join these vars without spec-compliant fallback (e.g. mise) then wrote their data into relative paths in the CWD.

## Changes

Two fixes:

1. **Accurate snap detection** (shellexec.go): Changed `os.Getenv("SNAP") != ""` to `os.Getenv("SNAP_NAME") == "waveterm"`. The $SNAP var propagates to child processes from any snap (e.g. `task` CLI), causing false positives. $SNAP_NAME is set to the snap's own name and reliably identifies Wave-as-snap.

2. **Skip empty values for new env vars** (shellutil.go): `UpdateCmdEnv` already correctly skipped empty values when updating existing env vars (unsetting them), but would add empty `KEY=` entries for vars not already present. Added the same `envVal != ""` guard for the new-var branch, preventing empty-string variables from being injected into the child process environment.

## Testing

- `go build ./pkg/shellexec/... ./pkg/util/shellutil/...` compiles cleanly
- `go test ./pkg/util/shellutil/...` passes