### PR TITLE
feat(wsh): add 'tab list' and 'tab move' commands for scriptable tab management

### DIFF
--- a/cmd/wsh/cmd/wshcmd-tab.go
+++ b/cmd/wsh/cmd/wshcmd-tab.go
@@ -1,0 +1,226 @@
+// Copyright 2026, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/wavetermdev/waveterm/pkg/waveobj"
+	"github.com/wavetermdev/waveterm/pkg/wshrpc"
+	"github.com/wavetermdev/waveterm/pkg/wshrpc/wshclient"
+)
+
+var tabCommand = &cobra.Command{
+	Use:   "tab",
+	Short: "Manage tabs",
+	Long:  "Commands for listing and reordering tabs.",
+}
+
+var tabListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List tabs in a workspace",
+	Long: `List tabs with their ids and names, in their current order.
+Defaults to the current workspace (from WAVETERM_WORKSPACEID).`,
+	RunE:    tabListRun,
+	PreRunE: preRunSetupRpcClient,
+}
+
+var tabMoveCmd = &cobra.Command{
+	Use:   "move <tabid> --index <n>",
+	Short: "Move a tab to a new position in the tab bar",
+	Long: `Move the specified tab to the given 0-based index within its workspace.
+The tab ordering is updated atomically; the set of tab ids must remain exactly
+the same (no adding or dropping tabs).`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    tabMoveRun,
+	PreRunE: preRunSetupRpcClient,
+}
+
+var (
+	tabWorkspaceId string
+	tabListJSON    bool
+	tabMoveIndex   int
+)
+
+func init() {
+	tabListCmd.Flags().StringVar(&tabWorkspaceId, "workspace", "", "workspace id (defaults to WAVETERM_WORKSPACEID)")
+	tabListCmd.Flags().BoolVar(&tabListJSON, "json", false, "output as JSON")
+	tabCommand.AddCommand(tabListCmd)
+
+	tabMoveCmd.Flags().StringVar(&tabWorkspaceId, "workspace", "", "workspace id (defaults to WAVETERM_WORKSPACEID)")
+	tabMoveCmd.Flags().IntVar(&tabMoveIndex, "index", -1, "0-based target position (required)")
+	tabCommand.AddCommand(tabMoveCmd)
+
+	rootCmd.AddCommand(tabCommand)
+}
+
+type tabListEntry struct {
+	TabId       string `json:"tabid"`
+	Name        string `json:"name"`
+	WorkspaceId string `json:"workspaceid"`
+	Index       int    `json:"index"`
+}
+
+func resolveWorkspaceId() (string, error) {
+	wsId := tabWorkspaceId
+	if wsId != "" {
+		return wsId, nil
+	}
+	wsId = os.Getenv("WAVETERM_WORKSPACEID")
+	if wsId != "" {
+		return wsId, nil
+	}
+	return "", fmt.Errorf("no workspace id specified (use --workspace or set WAVETERM_WORKSPACEID)")
+}
+
+func getWorkspaceForId(wsId string, workspaces []wshrpc.WorkspaceInfoData) (*waveobj.Workspace, error) {
+	for _, w := range workspaces {
+		if w.WorkspaceData.OID == wsId {
+			return w.WorkspaceData, nil
+		}
+	}
+	return nil, fmt.Errorf("workspace %q not found", wsId)
+}
+
+func tabListRun(cmd *cobra.Command, args []string) (rtnErr error) {
+	defer func() {
+		sendActivity("tab-list", rtnErr == nil)
+	}()
+
+	wsId, err := resolveWorkspaceId()
+	if err != nil {
+		return err
+	}
+
+	workspaces, err := wshclient.WorkspaceListCommand(RpcClient, &wshrpc.RpcOpts{Timeout: 5000})
+	if err != nil {
+		return fmt.Errorf("failed to list workspaces: %v", err)
+	}
+
+	ws, err := getWorkspaceForId(wsId, workspaces)
+	if err != nil {
+		return err
+	}
+
+	var entries []tabListEntry
+	for i, tabId := range ws.TabIds {
+		tabData, err := wshclient.GetTabCommand(RpcClient, tabId, &wshrpc.RpcOpts{Timeout: 2000})
+		if err != nil {
+			WriteStderr("warning: could not fetch tab %s: %v\n", tabId, err)
+			entries = append(entries, tabListEntry{
+				TabId:       tabId,
+				Name:        "<error>",
+				WorkspaceId: ws.OID,
+				Index:       i,
+			})
+			continue
+		}
+		entries = append(entries, tabListEntry{
+			TabId:       tabId,
+			Name:        tabData.Name,
+			WorkspaceId: ws.OID,
+			Index:       i,
+		})
+	}
+
+	if tabListJSON {
+		bytes, mErr := json.MarshalIndent(entries, "", "  ")
+		if mErr != nil {
+			return fmt.Errorf("failed to marshal JSON: %v", mErr)
+		}
+		WriteStdout("%s\n", string(bytes))
+		return nil
+	}
+
+	w := tabwriter.NewWriter(WrappedStdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintf(w, "INDEX\tTAB ID\tNAME\n")
+	for _, e := range entries {
+		tabId := e.TabId
+		if len(tabId) > 36 {
+			tabId = tabId[:34] + ".."
+		}
+		fmt.Fprintf(w, "%d\t%s\t%s\n", e.Index, tabId, e.Name)
+	}
+	return nil
+}
+
+func tabMoveRun(cmd *cobra.Command, args []string) (rtnErr error) {
+	defer func() {
+		sendActivity("tab-move", rtnErr == nil)
+	}()
+
+	if !cmd.Flags().Changed("index") {
+		return fmt.Errorf("--index is required (0-based target position)")
+	}
+
+	tabId := args[0]
+	wsId, err := resolveWorkspaceId()
+	if err != nil {
+		return err
+	}
+
+	workspaces, err := wshclient.WorkspaceListCommand(RpcClient, &wshrpc.RpcOpts{Timeout: 5000})
+	if err != nil {
+		return fmt.Errorf("failed to list workspaces: %v", err)
+	}
+
+	ws, err := getWorkspaceForId(wsId, workspaces)
+	if err != nil {
+		return err
+	}
+
+	oldIdx := -1
+	for i, id := range ws.TabIds {
+		if id == tabId {
+			oldIdx = i
+			break
+		}
+	}
+	if oldIdx == -1 {
+		return fmt.Errorf("tab %q not found in workspace %q", tabId, ws.OID)
+	}
+
+	targetIdx := tabMoveIndex
+	if targetIdx < 0 || targetIdx >= len(ws.TabIds) {
+		return fmt.Errorf("index %d out of range [0, %d]", targetIdx, len(ws.TabIds)-1)
+	}
+	if targetIdx == oldIdx {
+		WriteStdout("tab %s is already at index %d\n", tabId, targetIdx)
+		return nil
+	}
+
+	newTabIds := reorderTabIds(ws.TabIds, oldIdx, targetIdx, tabId)
+
+	err = wshclient.UpdateWorkspaceTabIdsCommand(RpcClient, ws.OID, newTabIds, &wshrpc.RpcOpts{Timeout: 2000})
+	if err != nil {
+		return fmt.Errorf("failed to update tab order: %v", err)
+	}
+
+	WriteStdout("moved tab %s from index %d to %d\n", tabId, oldIdx, targetIdx)
+	return nil
+}
+
+// reorderTabIds returns a new slice with the element at oldIdx moved to targetIdx.
+// It preserves the relative order of all other elements. Both oldIdx and targetIdx
+// must be valid indices into tabIds, and oldIdx != targetIdx.
+func reorderTabIds(tabIds []string, oldIdx, targetIdx int, tabId string) []string {
+	newTabIds := make([]string, 0, len(tabIds))
+	for i, id := range tabIds {
+		if i == oldIdx {
+			continue
+		}
+		newTabIds = append(newTabIds, id)
+	}
+	result := make([]string, 0, len(tabIds))
+	result = append(result, newTabIds[:targetIdx]...)
+	result = append(result, tabId)
+	result = append(result, newTabIds[targetIdx:]...)
+	return result
+}

--- a/cmd/wsh/cmd/wshcmd-tab.go
+++ b/cmd/wsh/cmd/wshcmd-tab.go
@@ -109,7 +109,7 @@ func tabListRun(cmd *cobra.Command, args []string) (rtnErr error) {
 		return err
 	}
 
-	var entries []tabListEntry = make([]tabListEntry, 0)
+	entries := make([]tabListEntry, 0)
 	for i, tabId := range ws.TabIds {
 		tabData, err := wshclient.GetTabCommand(RpcClient, tabId, &wshrpc.RpcOpts{Timeout: 2000})
 		if err != nil {

--- a/cmd/wsh/cmd/wshcmd-tab.go
+++ b/cmd/wsh/cmd/wshcmd-tab.go
@@ -55,6 +55,7 @@ func init() {
 
 	tabMoveCmd.Flags().StringVar(&tabWorkspaceId, "workspace", "", "workspace id (defaults to WAVETERM_WORKSPACEID)")
 	tabMoveCmd.Flags().IntVar(&tabMoveIndex, "index", -1, "0-based target position (required)")
+	tabMoveCmd.MarkFlagRequired("index")
 	tabCommand.AddCommand(tabMoveCmd)
 
 	rootCmd.AddCommand(tabCommand)
@@ -108,7 +109,7 @@ func tabListRun(cmd *cobra.Command, args []string) (rtnErr error) {
 		return err
 	}
 
-	var entries []tabListEntry
+	var entries []tabListEntry = make([]tabListEntry, 0)
 	for i, tabId := range ws.TabIds {
 		tabData, err := wshclient.GetTabCommand(RpcClient, tabId, &wshrpc.RpcOpts{Timeout: 2000})
 		if err != nil {
@@ -155,10 +156,6 @@ func tabMoveRun(cmd *cobra.Command, args []string) (rtnErr error) {
 	defer func() {
 		sendActivity("tab-move", rtnErr == nil)
 	}()
-
-	if !cmd.Flags().Changed("index") {
-		return fmt.Errorf("--index is required (0-based target position)")
-	}
 
 	tabId := args[0]
 	wsId, err := resolveWorkspaceId()

--- a/cmd/wsh/cmd/wshcmd-tab.go
+++ b/cmd/wsh/cmd/wshcmd-tab.go
@@ -109,7 +109,7 @@ func tabListRun(cmd *cobra.Command, args []string) (rtnErr error) {
 		return err
 	}
 
-	entries := make([]tabListEntry, 0)
+	entries := make([]tabListEntry, 0, len(ws.TabIds))
 	for i, tabId := range ws.TabIds {
 		tabData, err := wshclient.GetTabCommand(RpcClient, tabId, &wshrpc.RpcOpts{Timeout: 2000})
 		if err != nil {

--- a/cmd/wsh/cmd/wshcmd-tab_test.go
+++ b/cmd/wsh/cmd/wshcmd-tab_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReorderTabIds(t *testing.T) {
+	tests := []struct {
+		name      string
+		tabIds    []string
+		oldIdx    int
+		targetIdx int
+		tabId     string
+		expected  []string
+	}{
+		{
+			name:      "move first to last",
+			tabIds:    []string{"a", "b", "c", "d", "e"},
+			oldIdx:    0,
+			targetIdx: 4,
+			tabId:     "a",
+			expected:  []string{"b", "c", "d", "e", "a"},
+		},
+		{
+			name:      "move last to first",
+			tabIds:    []string{"a", "b", "c", "d", "e"},
+			oldIdx:    4,
+			targetIdx: 0,
+			tabId:     "e",
+			expected:  []string{"e", "a", "b", "c", "d"},
+		},
+		{
+			name:      "move second to fourth (right)",
+			tabIds:    []string{"a", "b", "c", "d", "e"},
+			oldIdx:    1,
+			targetIdx: 3,
+			tabId:     "b",
+			expected:  []string{"a", "c", "d", "b", "e"},
+		},
+		{
+			name:      "move fourth to second (left)",
+			tabIds:    []string{"a", "b", "c", "d", "e"},
+			oldIdx:    3,
+			targetIdx: 1,
+			tabId:     "d",
+			expected:  []string{"a", "d", "b", "c", "e"},
+		},
+		{
+			name:      "move second to third (right by one)",
+			tabIds:    []string{"a", "b", "c", "d", "e"},
+			oldIdx:    1,
+			targetIdx: 2,
+			tabId:     "b",
+			expected:  []string{"a", "c", "b", "d", "e"},
+		},
+		{
+			name:      "move third to second (left by one)",
+			tabIds:    []string{"a", "b", "c", "d", "e"},
+			oldIdx:    2,
+			targetIdx: 1,
+			tabId:     "c",
+			expected:  []string{"a", "c", "b", "d", "e"},
+		},
+		{
+			name:      "two elements swap",
+			tabIds:    []string{"x", "y"},
+			oldIdx:    0,
+			targetIdx: 1,
+			tabId:     "x",
+			expected:  []string{"y", "x"},
+		},
+		{
+			name:      "move middle to end",
+			tabIds:    []string{"a", "b", "c", "d", "e"},
+			oldIdx:    2,
+			targetIdx: 4,
+			tabId:     "c",
+			expected:  []string{"a", "b", "d", "e", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy to avoid mutating the test input
+			input := make([]string, len(tt.tabIds))
+			copy(input, tt.tabIds)
+			result := reorderTabIds(input, tt.oldIdx, tt.targetIdx, tt.tabId)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("reorderTabIds(%v, %d, %d, %q) = %v, want %v",
+					tt.tabIds, tt.oldIdx, tt.targetIdx, tt.tabId, result, tt.expected)
+			}
+			if len(result) != len(tt.tabIds) {
+				t.Errorf("length changed: got %d, want %d", len(result), len(tt.tabIds))
+			}
+		})
+	}
+}

--- a/cmd/wsh/cmd/wshcmd-workspace.go
+++ b/cmd/wsh/cmd/wshcmd-workspace.go
@@ -37,7 +37,7 @@ func workspaceListRun(cmd *cobra.Command, args []string) {
 	WriteStdout("[\n")
 	for i, w := range workspaces {
 		WriteStdout("  {\n    \"windowId\": \"%s\",\n", w.WindowId)
-		WriteStderr("    \"workspaceId\": \"%s\",\n", w.WorkspaceData.OID)
+		WriteStdout("    \"workspaceId\": \"%s\",\n", w.WorkspaceData.OID)
 		WriteStdout("    \"name\": \"%s\",\n", w.WorkspaceData.Name)
 		WriteStdout("    \"icon\": \"%s\",\n", w.WorkspaceData.Icon)
 		WriteStdout("    \"color\": \"%s\"\n", w.WorkspaceData.Color)


### PR DESCRIPTION
## Summary

This PR adds two new wsh subcommands under `wsh tab` to make tabs scriptable from the command line, addressing #3425.

### New commands

**`wsh tab list`** (alias: `ls`) — lists tabs in the current workspace with their ids, names, and indices.
- Defaults to the current workspace from `WAVETERM_WORKSPACEID`, overridable with `--workspace <id>`
- Supports `--json` flag for machine-readable output
- Example:
  ```
  $ wsh tab list
  INDEX  TAB ID                                NAME
  0      550e8400-e29b-41d4-a716-446655440000  Terminal
  1      650e8400-e29b-41d4-a716-446655440001  google.com
  ```

**`wsh tab move <tabid> --index <n>`** — moves a tab to the specified 0-based position within its workspace.
- Validates that the tab exists in the workspace and that the index is in range
- Guards against dropping/adding tabs (the set of tab ids is preserved exactly)
- No-op when the tab is already at the target index
- Example:
  ```
  $ wsh tab move 650e8400-e29b-41d4-a716-446655440001 --index 0
  moved tab 650e8400-... from index 1 to 0
  ```

### Bug fix
- Fixed a small bug in `wsh workspace list` where the `workspaceId` field was being printed to stderr instead of stdout due to a `WriteStderr`/`WriteStdout` typo.

### Testing
- Added unit tests for the tab reordering logic (`reorderTabIds`) covering 8 scenarios: first↔last, left/right moves, adjacent swaps, and two-element arrays
- All existing tests in `cmd/wsh/cmd/` continue to pass
- `go build ./cmd/wsh/...` and `go vet ./cmd/wsh/...` clean
- `gofmt` verified

Closes #3425