### PR TITLE
fix: stop a de-focusing block from re-grabbing focus

### DIFF
--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -120,10 +120,14 @@ const BlockFull = memo(({ nodeModel, viewModel }: FullBlockProps) => {
         }
         setBlockClicked(false);
         const focusWithin = focusedBlockId() == nodeModel.blockId;
-        if (!focusWithin) {
+        // blockClicked is state and lags one commit, so this effect also runs when the block is
+        // losing focus. In that case DOM focus already moved to another block (focusWithin is false)
+        // and isFocused is false. Without these guards the de-focusing block re-grabs both DOM and
+        // logical focus, which makes two web blocks fight over focus indefinitely (webview-focus flap).
+        if (!focusWithin && isFocused) {
             setFocusTarget();
         }
-        if (!isFocused) {
+        if (!isFocused && focusWithin) {
             nodeModel.focusNode();
         }
     }, [blockClicked, isFocused]);


### PR DESCRIPTION
Fixes #3428

## Problem

With two `web` blocks open, clicking from one into the other makes both webviews unresponsive — buttons/links don't click, the URL bar can't be edited, typing does nothing. Only the block header icons still respond.

`webview-focus` flaps continuously between the two webview ids and `null`; focus is granted then revoked within a few ms, so no input lands. Terminal→web is fine; only web→web breaks.

In `BlockFull`, `blockClicked` is state and lags one commit, so the focus effect also runs while a block is *losing* focus (`blockClicked` still true, `isFocused` false). The effect could not distinguish a real click from a focus loss, so the de-focusing block re-grabbed both DOM focus (`setFocusTarget`) and logical focus (`focusNode`). With two web blocks each doing this, they fight indefinitely. A single webview settles because there is no competitor.

## Fix

Use `focusWithin` (does DOM focus currently sit inside this block) to tell the two cases apart:

- Pull DOM focus in (`setFocusTarget`) only when this block is the focused node.
- Claim logical focus (`focusNode`) only when the click actually landed inside this block.

A block that is losing focus now satisfies neither condition, so it no longer re-grabs focus, and the two web blocks stop fighting.

## Test Plan

- Open two web blocks, click A → B → A — verify links/buttons click, URL bar edits, and typing works in both (previously dead)
- Verify `webview-focus` no longer flaps in the logs while idling on a web block
- Terminal → web focus still works
- Clicking an unfocused block still focuses it (click-to-focus)
- Single web block behaves as before