### PR TITLE
fix(wsh): accept block reference as positional arg for deleteblock

### DIFF
--- a/cmd/wsh/cmd/wshcmd-deleteblock.go
+++ b/cmd/wsh/cmd/wshcmd-deleteblock.go
@@ -12,8 +12,10 @@ import (
 )
 
 var deleteBlockCmd = &cobra.Command{
-	Use:     "deleteblock",
+	Use:     "deleteblock [block-ref]",
 	Short:   "delete a block",
+	Long:    "Delete a block. Optionally specify a block reference (block:oid, uuid, block number, or keyword like 'this'). If no block is specified, deletes the current block. Can also use --block/-b flag.",
+	Args:    cobra.MaximumNArgs(1),
 	RunE:    deleteBlockRun,
 	PreRunE: preRunSetupRpcClient,
 }
@@ -26,7 +28,11 @@ func deleteBlockRun(cmd *cobra.Command, args []string) (rtnErr error) {
 	defer func() {
 		sendActivity("deleteblock", rtnErr == nil)
 	}()
-	fullORef, err := resolveBlockArg()
+	var blockRef string
+	if len(args) > 0 {
+		blockRef = args[0]
+	}
+	fullORef, err := resolveBlockArgWithOverride(blockRef)
 	if err != nil {
 		return err
 	}

--- a/cmd/wsh/cmd/wshcmd-root.go
+++ b/cmd/wsh/cmd/wshcmd-root.go
@@ -124,6 +124,21 @@ func resolveBlockArg() (*waveobj.ORef, error) {
 	return fullORef, nil
 }
 
+func resolveBlockArgWithOverride(override string) (*waveobj.ORef, error) {
+	oref := override
+	if oref == "" {
+		oref = blockArg
+	}
+	if oref == "" {
+		oref = "this"
+	}
+	fullORef, err := resolveSimpleId(oref)
+	if err != nil {
+		return nil, fmt.Errorf("resolving blockid: %w", err)
+	}
+	return fullORef, nil
+}
+
 func setupRpcClientWithToken(swapTokenStr string) (wshrpc.CommandAuthenticateRtnData, error) {
 	var rtn wshrpc.CommandAuthenticateRtnData
 	token, err := shellutil.UnpackSwapToken(swapTokenStr)


### PR DESCRIPTION
## Summary

The `wsh deleteblock` command previously only accepted a block reference via the `--block/-b` flag, with no Args validation, causing user confusion when positional arguments were silently ignored and the current block was deleted instead.

## Changes

- Accept an optional positional block-ref argument (e.g. `wsh deleteblock 2`)
- Add `Args: cobra.MaximumNArgs(1)` to validate argument count
- Add Long description documenting accepted reference formats (block:oid, uuid, block number, keywords like 'this')
- Add `resolveBlockArgWithOverride()` helper that prefers positional arg over `--block/-b` flag, defaulting to 'this' when neither is specified
- Update Use string to show the optional `[block-ref]` argument

## Usage

```bash
# Delete current block (default)
wsh deleteblock

# Delete block by number (1-indexed in current tab)
wsh deleteblock 2

# Delete block by full ORef
wsh deleteblock block:abc123-def456

# Delete block using -b flag (still supported)
wsh deleteblock -b 2
```

Fixes #3417