### PR TITLE
fix(web): add missing returns after http.Error in handlers

### DIFF
--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -119,12 +119,14 @@ func handleService(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(bodyData, &webCall)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+		return
 	}
 
 	rtn := service.CallService(r.Context(), webCall)
 	jsonRtn, err := json.Marshal(rtn)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("error serializing response: %v", err), http.StatusInternalServerError)
+		return
 	}
 	w.Header().Set(ContentTypeHeaderKey, ContentTypeJson)
 	w.Header().Set(ContentLengthHeaderKey, fmt.Sprintf("%d", len(jsonRtn)))
@@ -157,6 +159,7 @@ func handleWaveFile(w http.ResponseWriter, r *http.Request) {
 		offset, err = strconv.ParseInt(offsetStr, 10, 64)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("invalid offset: %v", err), http.StatusBadRequest)
+			return
 		}
 	}
 	if _, err := uuid.Parse(zoneId); err != nil {
@@ -180,6 +183,7 @@ func handleWaveFile(w http.ResponseWriter, r *http.Request) {
 	jsonFileBArr, err := json.Marshal(file)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("error serializing file info: %v", err), http.StatusInternalServerError)
+		return
 	}
 	// can make more efficient by checking modtime + If-Modified-Since headers to allow caching
 	dataStartIdx := file.DataStartIdx()
@@ -239,6 +243,7 @@ func handleLocalStreamFile(w http.ResponseWriter, r *http.Request, path string, 
 		path, err := wavebase.ExpandHomeDir(path)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 		http.ServeFile(w, r, path)
 	}


### PR DESCRIPTION
## Summary

Five HTTP handlers in `pkg/web/web.go` write an error response with `http.Error(...)` but are missing the `return` afterwards, so the handler keeps executing on the error path:

| Handler | Error path | What happened after the error |
|---|---|---|
| `handleService` | invalid JSON body (400) | still invoked `service.CallService` with a zero-value `WebCallType` |
| `handleService` | response marshal failure (500) | still wrote 200 headers + body on top of the error |
| `handleWaveFile` | invalid `offset` param (400) | kept serving the file with `offset=0` |
| `handleWaveFile` | fileinfo marshal failure (500) | still streamed the file data |
| `handleStreamFile` | `ExpandHomeDir` error (400) | still called `http.ServeFile` with the unexpanded path |

The `handleService` case is the most relevant one: a malformed request body is rejected with 400 but the service call is executed anyway with empty data.

The fix is the same one-liner in each spot: `return` after `http.Error`. No behavior change on success paths.

Found while triaging CodeQL alerts on a fork; these were flagged around the `go/stack-trace-exposure` / `go/path-injection` sites but the underlying real bug is the missing early return.

## Test plan

- `go vet ./pkg/web/` and `go build ./pkg/web/` pass.
- Error paths now terminate at the first `http.Error` (single response per request); success paths untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NctL6NKspWCzRxHJDwBGMk