### PR TITLE
Fix DeepSeek multi-turn chat breaking with reasoning_content error

### DIFF
--- a/pkg/aiusechat/openaichat/openaichat-backend.go
+++ b/pkg/aiusechat/openaichat/openaichat-backend.go
@@ -129,7 +129,7 @@ func processChatStream(
 				break
 			}
 			if sseHandler.Err() != nil {
-				partialMsg := extractPartialTextMessage(msgID, textBuilder.String())
+				partialMsg := extractPartialTextMessage(msgID, textBuilder.String(), reasoningBuilder.String())
 				return &uctypes.WaveStopReason{
 					Kind:      uctypes.StopKindCanceled,
 					ErrorType: "client_disconnect",
@@ -265,16 +265,17 @@ func processChatStream(
 	return stopReason, assistantMsg, nil
 }
 
-func extractPartialTextMessage(msgID string, text string) *StoredChatMessage {
-	if text == "" {
+func extractPartialTextMessage(msgID string, text string, reasoning string) *StoredChatMessage {
+	if text == "" && reasoning == "" {
 		return nil
 	}
 
 	return &StoredChatMessage{
 		MessageId: msgID,
 		Message: ChatRequestMessage{
-			Role:    "assistant",
-			Content: text,
+			Role:             "assistant",
+			Content:          text,
+			ReasoningContent: reasoning,
 		},
 	}
 }

--- a/pkg/aiusechat/openaichat/openaichat-backend.go
+++ b/pkg/aiusechat/openaichat/openaichat-backend.go
@@ -101,6 +101,7 @@ func processChatStream(
 ) (*uctypes.WaveStopReason, *StoredChatMessage, error) {
 	decoder := eventsource.NewDecoder(body)
 	var textBuilder strings.Builder
+	var reasoningBuilder strings.Builder
 	msgID := uuid.New().String()
 	textID := uuid.New().String()
 	var finishReason string
@@ -159,6 +160,9 @@ func processChatStream(
 		}
 
 		choice := chunk.Choices[0]
+		if choice.Delta.ReasoningContent != "" {
+			reasoningBuilder.WriteString(choice.Delta.ReasoningContent)
+		}
 		if choice.Delta.Content != "" {
 			if !textStarted {
 				_ = sseHandler.AiMsgTextStart(textID)
@@ -239,7 +243,8 @@ func processChatStream(
 	assistantMsg := &StoredChatMessage{
 		MessageId: msgID,
 		Message: ChatRequestMessage{
-			Role: "assistant",
+			Role:             "assistant",
+			ReasoningContent: reasoningBuilder.String(),
 		},
 	}
 

--- a/pkg/aiusechat/openaichat/openaichat-types.go
+++ b/pkg/aiusechat/openaichat/openaichat-types.go
@@ -50,29 +50,32 @@ type ChatImageUrl struct {
 }
 
 type ChatRequestMessage struct {
-	Role         string            `json:"role"`                   // "system","user","assistant","tool"
-	Content      string            `json:"-"`                      // plain text (used when ContentParts is nil)
-	ContentParts []ChatContentPart `json:"-"`                      // multimodal parts (used when images present)
-	ToolCalls    []ToolCall        `json:"tool_calls,omitempty"`   // assistant tool-call message
-	ToolCallID   string            `json:"tool_call_id,omitempty"` // for role:"tool"
-	Name         string            `json:"name,omitempty"`         // tool name on role:"tool"
+	Role             string            `json:"role"`                   // "system","user","assistant","tool"
+	Content          string            `json:"-"`                      // plain text (used when ContentParts is nil)
+	ContentParts     []ChatContentPart `json:"-"`                      // multimodal parts (used when images present)
+	ReasoningContent string            `json:"-"`                      // preserved for DeepSeek multi-turn (reasoning_content)
+	ToolCalls        []ToolCall        `json:"tool_calls,omitempty"`   // assistant tool-call message
+	ToolCallID       string            `json:"tool_call_id,omitempty"` // for role:"tool"
+	Name             string            `json:"name,omitempty"`         // tool name on role:"tool"
 }
 
 // chatRequestMessageJSON is the wire format for ChatRequestMessage
 type chatRequestMessageJSON struct {
-	Role       string          `json:"role"`
-	Content    json.RawMessage `json:"content"`
-	ToolCalls  []ToolCall      `json:"tool_calls,omitempty"`
-	ToolCallID string          `json:"tool_call_id,omitempty"`
-	Name       string          `json:"name,omitempty"`
+	Role             string          `json:"role"`
+	Content          json.RawMessage `json:"content"`
+	ReasoningContent string          `json:"reasoning_content,omitempty"`
+	ToolCalls        []ToolCall      `json:"tool_calls,omitempty"`
+	ToolCallID       string          `json:"tool_call_id,omitempty"`
+	Name             string          `json:"name,omitempty"`
 }
 
 func (cm ChatRequestMessage) MarshalJSON() ([]byte, error) {
 	raw := chatRequestMessageJSON{
-		Role:       cm.Role,
-		ToolCalls:  cm.ToolCalls,
-		ToolCallID: cm.ToolCallID,
-		Name:       cm.Name,
+		Role:             cm.Role,
+		ReasoningContent: cm.ReasoningContent,
+		ToolCalls:        cm.ToolCalls,
+		ToolCallID:       cm.ToolCallID,
+		Name:             cm.Name,
 	}
 	if len(cm.ContentParts) > 0 {
 		b, err := json.Marshal(cm.ContentParts)
@@ -96,6 +99,7 @@ func (cm *ChatRequestMessage) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	cm.Role = raw.Role
+	cm.ReasoningContent = raw.ReasoningContent
 	cm.ToolCalls = raw.ToolCalls
 	cm.ToolCallID = raw.ToolCallID
 	cm.Name = raw.Name
@@ -193,9 +197,10 @@ type StreamChoice struct {
 
 // This is the important part:
 type ContentDelta struct {
-	Role      string          `json:"role,omitempty"`
-	Content   string          `json:"content,omitempty"`
-	ToolCalls []ToolCallDelta `json:"tool_calls,omitempty"`
+	Role             string          `json:"role,omitempty"`
+	Content          string          `json:"content,omitempty"`
+	ReasoningContent string          `json:"reasoning_content,omitempty"`
+	ToolCalls        []ToolCallDelta `json:"tool_calls,omitempty"`
 }
 
 type ToolCallDelta struct {


### PR DESCRIPTION
Multi-turn conversations with DeepSeek V4 were completely broken — the second message always failed with "reasoning_content must be passed back to the API". The first message goes through fine, but as soon as you reply it errors out.

The issue is that `ContentDelta` had no field for `reasoning_content`, so it got dropped during stream deserialization. The stored assistant message had no `reasoning_content`, and when that message got included in the next request, DeepSeek rejected it because the field it originally sent was missing. Classic round-trip fidelity bug.

Fixed by adding `ReasoningContent` to `ContentDelta`, threading it through `ChatRequestMessage` and the `chatRequestMessageJSON` wire struct with proper marshal/unmarshal, and setting it on the stored assistant message after stream completion. Field is `omitempty` so it has zero effect on providers that don't use it.

Verified by running a multi-turn DeepSeek V4 conversation — follow-up messages go through cleanly now.

Fixes #3266